### PR TITLE
Improve error messages

### DIFF
--- a/adldap/active_directory.c
+++ b/adldap/active_directory.c
@@ -623,7 +623,6 @@ int ad_user_lock(LDAP *ld, const char *dn) {
     
     const int result_get_flags = ad_get_attribute(ld, dn, "userAccountControl", &flags);
     if (result_get_flags != AD_SUCCESS || flags[0] == NULL) {
-        save_error("Failed to get flags");
         result = result_get_flags;
 
         goto end;

--- a/adldap/active_directory.c
+++ b/adldap/active_directory.c
@@ -855,7 +855,7 @@ int ad_rename_user(LDAP *ld, const char *dn, const char *new_name) {
     // Construct userPrincipalName
     const int result_dn2domain = dn2domain(dn, &domain);
     if (result_dn2domain != AD_SUCCESS) {
-        result = AD_ERROR;
+        result = result_dn2domain;
 
         goto end;
     }
@@ -935,7 +935,7 @@ int ad_move_user(LDAP *ld, const char *current_dn, const char *new_container) {
     // Construct userPrincipalName
     const int result_dn2domain = dn2domain(new_container, &domain);
     if (AD_SUCCESS != result_dn2domain) {
-        result = AD_ERROR;
+        result = result_dn2domain;
 
         goto end;
     }
@@ -974,7 +974,7 @@ int ad_move(LDAP *ld, const char *current_dn, const char *new_container) {
     char *comma_ptr = strchr(rdn, ',');
     if (comma_ptr == NULL) {
         // Failed to extract RDN from DN
-        result = AD_ERROR;
+        result = AD_INVALID_DN;
 
         goto end;
     }
@@ -1016,7 +1016,7 @@ int dn2domain(const char *dn, char **domain_out) {
     // Explode dn
     const int result_str2dn = ldap_str2dn(dn, &exp_dn, LDAP_DN_FORMAT_LDAPV3);
     if (result_str2dn != LDAP_SUCCESS) {
-        result = AD_ERROR;
+        result = AD_INVALID_DN;
 
         goto end;
     }
@@ -1029,7 +1029,7 @@ int dn2domain(const char *dn, char **domain_out) {
         LDAPAVA *rdn = rdns[0];
 
         if (rdn == NULL) {
-            result = AD_ERROR;
+            result = AD_INVALID_DN;
 
             goto end;
         }
@@ -1037,7 +1037,7 @@ int dn2domain(const char *dn, char **domain_out) {
         // NOTE: BER/DER encoded attributes are unsupported
         const bool string_encoding = (rdn->la_flags & LDAP_AVA_STRING);
         if (!string_encoding) {
-            result = AD_ERROR;
+            result = AD_INVALID_DN;
 
             goto end;
         }

--- a/adldap/active_directory.c
+++ b/adldap/active_directory.c
@@ -1006,7 +1006,6 @@ int ad_group_remove_user(LDAP *ld, const char *group_dn, const char *user_dn) {
  * dns domain, eg: "ou=users,dc=example,dc=com" returns
  * "example.com".
  * domain should be freed using free()
- * Returns AD_SUCCESS or error code
  */
 int dn2domain(const char *dn, char **domain_out) {
     int result = AD_SUCCESS;
@@ -1249,7 +1248,6 @@ int query_server_for_hosts(const char *dname, char ***hosts_out) {
  * Perform an attribute search on object
  * Outputs LDAPMessage res which contains results of the search
  * res should bbe freed by the caller using ldap_msgfree()
- * Returns AD_SUCCESS or error code
  */
 int ad_get_all_attributes_internal(LDAP *ld, const char *dn, const char *attribute, LDAPMessage **res_out) {
     int result = AD_SUCCESS;

--- a/adldap/active_directory.c
+++ b/adldap/active_directory.c
@@ -344,7 +344,7 @@ int ad_get_attribute(LDAP *ld, const char *dn, const char *attribute, char ***va
 
     values_ldap = ldap_get_values_len(ld, entry, attribute);
     if (values_ldap == NULL) {
-        result = AD_ERROR;
+        result = AD_LDAP_ERROR;
 
         goto end;
     }
@@ -408,7 +408,7 @@ int ad_get_all_attributes(LDAP *ld, const char *dn, char ****attributes_out) {
     for (char *attr = ldap_first_attribute(ld, entry, &berptr); attr != NULL; attr = ldap_next_attribute(ld, entry, berptr)) {
         struct berval **values_ldap = ldap_get_values_len(ld, entry, attr);
         if (values_ldap == NULL) {
-            result = AD_ERROR;
+            result = AD_LDAP_ERROR;
 
             ldap_value_free_len(values_ldap);
 
@@ -616,8 +616,7 @@ int ad_user_lock(LDAP *ld, const char *dn) {
     
     const int result_get_flags = ad_get_attribute(ld, dn, "userAccountControl", &flags);
     if (result_get_flags != AD_SUCCESS) {
-        // Failed to get flags
-        result = AD_ERROR;
+        result = result_get_flags;
 
         goto end;
     }
@@ -629,7 +628,6 @@ int ad_user_lock(LDAP *ld, const char *dn) {
 
     const int result_replace = ad_attribute_replace(ld, dn, "userAccountControl", newflags);
     if (result_replace != AD_SUCCESS) {
-        // Failed to replace userAccountControl
         result = result_replace;
 
         goto end;

--- a/adldap/ad_connection.cpp
+++ b/adldap/ad_connection.cpp
@@ -55,8 +55,9 @@ bool AdConnection::is_connected() {
     return false;
 }
 
-const char *AdConnection::get_error() {
-    return ad_get_error();
+int AdConnection::get_ldap_result() const {
+    const int result = ad_get_ldap_result(ldap_connection);
+    return result;
 }
 
 std::string AdConnection::get_search_base() const {

--- a/adldap/include/active_directory.h
+++ b/adldap/include/active_directory.h
@@ -44,7 +44,6 @@ int ad_get_domain_hosts(const char *domain, const char *site, char ***hosts_out)
 /**
  * Connect and authenticate to Active Directory server
  * If connected succesfully saves connection handle into ds
- * Returns AD_SUCCESS or error code
  */
 int ad_login(const char* uri, LDAP **ld_out);
 
@@ -80,14 +79,12 @@ int ad_search(LDAP *ld, const char *filter, const char* search_base, char ***lis
  * If none are found, list is allocated and is empty
  * list is NULL terminated
  * list should be freed by the caller using ad_array_free()
- * Returns AD_SUCCESS or error code
  */
 int ad_list(LDAP *ld, const char *dn, char ***list_out);
 
 /**
  * Output a NULL terminated array of values for the given attribute
  * Array should be freed by the caller using ad_array_free()
- * Returns AD_SUCCESS or error code
  */
 int ad_get_attribute(LDAP *ld, const char *dn, const char *attribute, char ***values_out);
 
@@ -96,134 +93,113 @@ int ad_get_attribute(LDAP *ld, const char *dn, const char *attribute, char ***va
  * object
  * Each sub-array contains an attribute name followed by it's values
  * Output should be freed by the caller using ad_2d_array_free()
- * Returns AD_SUCCESS or error code
  */
 int ad_get_all_attributes(LDAP *ld, const char *dn, char ****attributes_out);
 
 /**
  * Create user object below given DN
  * New user object is locked by default
- * Returns AD_SUCCESS or error code
  */
 int ad_create_user(LDAP *ld, const char *username, const char *dn);
 
 /**
  * Create computer object below given DN
- * Returns AD_SUCCESS or error code
  */
 int ad_create_computer(LDAP *ld, const char *name, const char *dn);
 
 /**
  * Create an organizational unit
- * Returns AD_SUCCESS or error code
  */
 int ad_create_ou(LDAP *ld, const char *ou_name, const char *dn);
 
 /**
  * Create a group with given name below given DN
- * Returns AD_SUCCESS or error code
  */
 int ad_create_group(LDAP *ld, const char *group_name, const char *dn);
 
 /**
  * Delete object
- * Returns AD_SUCCESS or error code
  */
 int ad_delete(LDAP *ld, const char *dn);
 
 /**
  * Lock a user account
- * Returns AD_SUCCESS or error code
  */
 int ad_user_lock(LDAP *ld, const char *dn);
 
 /**
  * Unlock a disabled user account
- * Returns AD_SUCCESS or error code
  */
 int ad_user_unlock(LDAP *ld, const char *dn);
 
 /**
  * Set the user's password to the given password string
  * SSL connection is required
- * Returns AD_SUCCESS or error code
  */
 int ad_user_set_pass(LDAP *ld, const char *dn, const char *password);
 
 /**
  * Adds a value to given attribute
  * This function works only on multi-valued attributes
- * Returns AD_SUCCESS or error code
  */
 int ad_attribute_add(LDAP *ld, const char *dn, const char *attribute, const char *value);
 
 /**
  * Same as ad_attribute_add() but for binary data
- * Returns AD_SUCCESS or error code
  */
 int ad_attribute_add_binary(LDAP *ld, const char *dn, const char *attribute, const char *data, int data_length);
 
 /**
  * Replaces the value of given attribute with new value
  * If attributes has multiple values, all of them are replaced
- * Returns AD_SUCCESS or error code
  */
 int ad_attribute_replace(LDAP *ld, const char *dn, const char *attribute, const char *value);
 
 /**
  * Same as ad_mode_replace() but for binary data
- * Returns AD_SUCCESS or error code
  */
 int ad_attribute_replace_binary(LDAP *ld, const char *dn, const char *attribute, const char *data, int data_length);
 
 /**
  * Remove (attribute, value) mapping from object
  * If given value is NULL, remove all values of this attributes
- * Returns AD_SUCCESS or error code
  */
 int ad_attribute_delete(LDAP *ld, const char *dn, const char *attribute, const char *value);
 
 /**
  * Rename object
  * Use specialized functions to rename users and groups
- * Returns AD_SUCCESS or error code
  */
 int ad_rename(LDAP *ld, const char *dn, const char *new_rdn);
 
 /**
  * Rename user and update related attributes
- * Returns AD_SUCCESS or error code
  */
 int ad_rename_user(LDAP *ld, const char *dn, const char *new_name);
 
 /**
  * Rename group and update related attributes
- * Returns AD_SUCCESS or error code
  */
 int ad_rename_group(LDAP *ld, const char *dn, const char *new_name);
 
 /**
  * Move object
  * Use ad_move_user() for user objects
- * Returns AD_SUCCESS or error code
  */
 int ad_move(LDAP *ld, const char *current_dn, const char *new_container);
 
 /**
  * Move user and update attributes affected by move
- * Returns AD_SUCCESS or error code
  */
 int ad_move_user(LDAP *ld, const char *current_dn, const char *new_container);
 
 /**
  * Add user to a group
- * Returns AD_SUCCESS or error code
  */
 int ad_group_add_user(LDAP *ld, const char *group_dn, const char *user_dn);
 
 /**
  * Remove user from a group
- * Returns AD_SUCCESS or error code
  */
 int ad_group_remove_user(LDAP *ld, const char *group_dn, const char *user_dn);
 

--- a/adldap/include/active_directory.h
+++ b/adldap/include/active_directory.h
@@ -21,6 +21,7 @@
 #define AD_SUCCESS 0
 #define AD_ERROR 1
 #define AD_LDAP_ERROR 2
+#define AD_INVALID_DN 3
 
 #if defined(__cplusplus)
 extern "C" {

--- a/adldap/include/active_directory.h
+++ b/adldap/include/active_directory.h
@@ -12,38 +12,32 @@
 **/
 
 #include <ldap.h>
+#include <stdbool.h>
 
 #ifndef ACTIVE_DIRECTORY_H
 #define ACTIVE_DIRECTORY_H 1
 
-/* Error codes */
-#define AD_SUCCESS 1
-#define AD_COULDNT_OPEN_CONFIG_FILE 2
-#define AD_MISSING_CONFIG_PARAMETER 3
-#define AD_SERVER_CONNECT_FAILURE 4
-#define AD_LDAP_OPERATION_FAILURE 5
-#define AD_OBJECT_NOT_FOUND 6
-#define AD_ATTRIBUTE_ENTRY_NOT_FOUND 7
-#define AD_INVALID_DN 8
-#define AD_RESOLV_ERROR 9
+// Result codes
+#define AD_SUCCESS 0
+#define AD_ERROR 1
+#define AD_LDAP_ERROR 2
 
 #if defined(__cplusplus)
 extern "C" {
 #endif /* __cplusplus */
 
 /**
- * Output a pointer to a string containing an explanation
- * of the last error that occured. If no error has previously occured
- * the string the contents are undefined. Subsequent active directory
- * library calls may over-write this string.
+ * Return a result code from last LDAP operation
+ * When a library function returns AD_LDAP_ERROR, use this to get
+ * the ldap error code
  */
-const char *ad_get_error();
+int ad_get_ldap_result(LDAP *ld);
 
 /**
  * Output a list of hosts that exist for given domain and site
  * list is NULL terminated
  * list should be freed by the caller using ad_array_free()
- * Returns AD_SUCCESS or error code
+ * Returns a result code
  */
 int ad_get_domain_hosts(const char *domain, const char *site, char ***hosts_out);
 

--- a/adldap/include/ad_connection.h
+++ b/adldap/include/ad_connection.h
@@ -35,9 +35,9 @@ public:
     AdConnection();
     int connect(std::string uri_arg, std::string domain);
     bool is_connected();
-    const char *get_error();
     std::string get_search_base() const;
     std::string get_uri() const;
+    int get_ldap_result() const;
 
     int create_user(const char *username, const char *dn);
     int create_computer(const char *name, const char *dn);

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -482,7 +482,7 @@ AdResult AdInterface::set_pass(const QString &dn, const QString &password) {
             error_string = tr("Password doesn't match rules");
         }
 
-        error_message(QString(tr("Failed to set pass of \"%1\". Error: \"%2\"")).arg(name, error_string));
+        error_message(QString(tr("Failed to set pass of \"%1\"")).arg(name), error_string);
 
         return make_result(false, error_string);
     }
@@ -684,16 +684,30 @@ void AdInterface::success_message(const QString &msg) {
     emit message(msg, AdInterfaceMessageType_Success);
 }
 
-void AdInterface::error_message(const QString &msg) {
-    emit message(msg, AdInterfaceMessageType_Error);
-}
-
-void AdInterface::default_error_message(const QString &context, int result) {
-    // TODO: convert result code to string using ldap lib
-    const QString error = "";
+void AdInterface::error_message(const QString &context, const QString &error) {
     const QString msg = QString(tr("%1. Error: \"%2\"")).arg(context, error);
 
     emit message(msg, AdInterfaceMessageType_Error);
+}
+
+void AdInterface::default_error_message(const QString &context, int ad_result) {
+    auto get_error =
+    [this, ad_result]() {
+        if (ad_result == AD_LDAP_ERROR) {
+            // NOTE: hardcode ldap errors here so that they can be translated
+            const int ldap_result = connection->get_ldap_result();
+            switch (ldap_result) {
+                default: return tr("Unknown LDAP error");
+            }
+        } else {
+            switch (ad_result) {
+                default: return tr("Unknown AD error");
+            }
+        }
+    };
+    const QString error = get_error();
+
+    error_message(context, error);
 }
 
 QString filter_EQUALS(const QString &attribute, const QString &value) {

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -694,7 +694,6 @@ void AdInterface::default_error_message(const QString &context, int ad_result) {
     auto get_error =
     [this, ad_result]() {
         if (ad_result == AD_LDAP_ERROR) {
-            // NOTE: hardcode ldap errors here so that they can be translated
             const int ldap_result = connection->get_ldap_result();
             switch (ldap_result) {
                 case LDAP_NO_SUCH_OBJECT: return tr("No such object");

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -698,6 +698,8 @@ void AdInterface::default_error_message(const QString &context, int ad_result) {
             switch (ldap_result) {
                 case LDAP_NO_SUCH_OBJECT: return tr("No such object");
                 case LDAP_CONSTRAINT_VIOLATION: return tr("Constraint violation");
+                case LDAP_UNWILLING_TO_PERFORM: return tr("Server is unwilling to perform");
+                case LDAP_ALREADY_EXISTS: return tr("Already exists");
                 default: return tr("Unknown LDAP error");
             }
         } else {

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -701,6 +701,7 @@ void AdInterface::default_error_message(const QString &context, int ad_result) {
             }
         } else {
             switch (ad_result) {
+                case AD_INVALID_DN: return tr("Invalid DN");
                 default: return tr("Unknown AD error");
             }
         }

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -697,10 +697,14 @@ void AdInterface::default_error_message(const QString &context, int ad_result) {
             // NOTE: hardcode ldap errors here so that they can be translated
             const int ldap_result = connection->get_ldap_result();
             switch (ldap_result) {
+                case LDAP_NO_SUCH_OBJECT: return tr("No such object");
+                case LDAP_CONSTRAINT_VIOLATION: return tr("Constraint violation");
                 default: return tr("Unknown LDAP error");
             }
         } else {
             switch (ad_result) {
+                case AD_SUCCESS: return tr("AD success");
+                case AD_ERROR: return tr("Generic AD error");
                 case AD_INVALID_DN: return tr("Invalid DN");
                 default: return tr("Unknown AD error");
             }

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -74,7 +74,7 @@ public:
 
     bool login(const QString &host, const QString &domain);
 
-    QString get_error_str();
+    QString get_last_error_string() const;
     QString get_search_base();
     QString get_uri();
 
@@ -117,6 +117,7 @@ private:
     adldap::AdConnection *connection = nullptr;
     QHash<QString, Attributes> attributes_cache;
     bool suppress_not_found_error = false;
+    QString last_error_string = "";
 
     AdInterface();
 
@@ -124,7 +125,7 @@ private:
     void update_cache(const QList<QString> &changed_dns);
     bool should_emit_message(int result);
     void success_message(const QString &msg);
-    void error_message(const QString &msg);
+    void error_message(const QString &msg, int result);
 }; 
 
 QString filter_EQUALS(const QString &attribute, const QString &value);

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -52,6 +52,11 @@ enum AdInterfaceMessageType {
     AdInterfaceMessageType_Error
 };
 
+struct AdResult {
+    bool success;
+    QString msg;
+};
+
 QString extract_name_from_dn(const QString &dn);
 QString extract_parent_dn_from_dn(const QString &dn);
 
@@ -76,7 +81,6 @@ public:
 
     QString get_search_base();
     QString get_uri();
-    QString get_last_error_string() const;
 
     QList<QString> list(const QString &dn);
     QList<QString> search(const QString &filter);
@@ -91,7 +95,7 @@ public:
     void object_delete(const QString &dn);
     void object_move(const QString &dn, const QString &new_container);
     void object_rename(const QString &dn, const QString &new_name);
-    bool set_pass(const QString &dn, const QString &password);
+    AdResult set_pass(const QString &dn, const QString &password);
     
     void group_add_user(const QString &group_dn, const QString &user_dn);
     void group_remove_user(const QString &group_dn, const QString &user_dn);
@@ -117,17 +121,15 @@ private:
     adldap::AdConnection *connection = nullptr;
     QHash<QString, Attributes> attributes_cache;
     bool suppress_not_found_error = false;
-    int last_error;
-    
-    static QString get_ldap_error_string(int error);
-    
+        
     AdInterface();
 
     QMap<QString, QList<QString>> load_attributes(const QString &dn);
     void update_cache(const QList<QString> &changed_dns);
     bool should_emit_message(int result);
     void success_message(const QString &msg);
-    void error_message(const QString &msg, int result);
+    void error_message(const QString &msg);
+    void default_error_message(const QString &context, int result);
 }; 
 
 QString filter_EQUALS(const QString &attribute, const QString &value);

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -74,9 +74,9 @@ public:
 
     bool login(const QString &host, const QString &domain);
 
-    QString get_last_error_string() const;
     QString get_search_base();
     QString get_uri();
+    QString get_last_error_string() const;
 
     QList<QString> list(const QString &dn);
     QList<QString> search(const QString &filter);
@@ -117,8 +117,10 @@ private:
     adldap::AdConnection *connection = nullptr;
     QHash<QString, Attributes> attributes_cache;
     bool suppress_not_found_error = false;
-    QString last_error_string = "";
-
+    int last_error;
+    
+    static QString get_ldap_error_string(int error);
+    
     AdInterface();
 
     QMap<QString, QList<QString>> load_attributes(const QString &dn);

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -128,8 +128,8 @@ private:
     void update_cache(const QList<QString> &changed_dns);
     bool should_emit_message(int result);
     void success_message(const QString &msg);
-    void error_message(const QString &msg);
-    void default_error_message(const QString &context, int result);
+    void error_message(const QString &context, const QString &error);
+    void default_error_message(const QString &context, int ad_result);
 }; 
 
 QString filter_EQUALS(const QString &attribute, const QString &value);

--- a/src/password_dialog.cpp
+++ b/src/password_dialog.cpp
@@ -81,7 +81,7 @@ void PasswordDialog::on_ok_button(bool) {
     if (success) {
         done(QDialog::Accepted);
     } else {
-        const QString error = AdInterface::instance()->get_error_str();
+        const QString error = AdInterface::instance()->get_last_error_string();
         QMessageBox::warning(this, "Warning", QString(tr("Failed to set password! %1")).arg(error));
     }
 }

--- a/src/password_dialog.cpp
+++ b/src/password_dialog.cpp
@@ -76,13 +76,12 @@ void PasswordDialog::on_ok_button(bool) {
         return;
     }
 
-    const bool success = AdInterface::instance()->set_pass(target, new_password);
+    const AdResult result = AdInterface::instance()->set_pass(target, new_password);
 
-    if (success) {
+    if (result.success) {
         done(QDialog::Accepted);
     } else {
-        const QString error = AdInterface::instance()->get_last_error_string();
-        QMessageBox::warning(this, "Warning", QString(tr("Failed to set password! %1")).arg(error));
+        QMessageBox::warning(this, "Warning", QString(tr("Failed to set password! %1")).arg(result.msg));
     }
 }
 

--- a/translations/en.ts
+++ b/translations/en.ts
@@ -114,37 +114,48 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="700"/>
+        <location filename="../src/ad_interface.cpp" line="699"/>
         <source>No such object</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="701"/>
+        <location filename="../src/ad_interface.cpp" line="700"/>
         <source>Constraint violation</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="../src/ad_interface.cpp" line="701"/>
+        <source>Server is unwilling to perform</source>
+        <translation>Server is unwilling to perform</translation>
+    </message>
+    <message>
         <location filename="../src/ad_interface.cpp" line="702"/>
+        <source>Already exists</source>
+        <translatorcomment>add &quot;object&quot; to avoid gendering verb in russian</translatorcomment>
+        <translation>Object already exists</translation>
+    </message>
+    <message>
+        <location filename="../src/ad_interface.cpp" line="703"/>
         <source>Unknown LDAP error</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="706"/>
+        <location filename="../src/ad_interface.cpp" line="707"/>
         <source>AD success</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="707"/>
+        <location filename="../src/ad_interface.cpp" line="708"/>
         <source>Generic AD error</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="708"/>
+        <location filename="../src/ad_interface.cpp" line="709"/>
         <source>Invalid DN</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="709"/>
+        <location filename="../src/ad_interface.cpp" line="710"/>
         <source>Unknown AD error</source>
         <translation></translation>
     </message>

--- a/translations/en.ts
+++ b/translations/en.ts
@@ -4,108 +4,153 @@
 <context>
     <name>AdInterface</name>
     <message>
-        <location filename="../src/ad_interface.cpp" line="99"/>
+        <location filename="../src/ad_interface.cpp" line="102"/>
         <source>Logged in to &quot;%1&quot; at &quot;%2&quot;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="105"/>
+        <location filename="../src/ad_interface.cpp" line="108"/>
         <source>Failed to login to &quot;%1&quot; at &quot;%2&quot;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="143"/>
+        <location filename="../src/ad_interface.cpp" line="144"/>
         <source>Failed to load children of &quot;%1&quot;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="169"/>
+        <location filename="../src/ad_interface.cpp" line="170"/>
         <source>Failed to search for &quot;%1&quot;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="217"/>
+        <location filename="../src/ad_interface.cpp" line="220"/>
         <source>Failed to get attributes of &quot;%1&quot;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="273"/>
+        <location filename="../src/ad_interface.cpp" line="276"/>
         <source>Changed attribute &quot;%1&quot; of &quot;%2&quot; from &quot;%3&quot; to &quot;%4&quot;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="279"/>
+        <location filename="../src/ad_interface.cpp" line="282"/>
         <source>Failed to change attribute &quot;%1&quot; of object &quot;%2&quot; from &quot;%3&quot; to &quot;%4&quot;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="316"/>
+        <location filename="../src/ad_interface.cpp" line="319"/>
         <source>Created &quot;%1&quot;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="322"/>
+        <location filename="../src/ad_interface.cpp" line="325"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="337"/>
+        <location filename="../src/ad_interface.cpp" line="340"/>
         <source>Deleted object &quot;%1&quot;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="341"/>
+        <location filename="../src/ad_interface.cpp" line="344"/>
         <source>Failed to delete object &quot;%1&quot;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="368"/>
+        <location filename="../src/ad_interface.cpp" line="374"/>
         <source>Moved &quot;%1&quot; to &quot;%2&quot;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="372"/>
+        <location filename="../src/ad_interface.cpp" line="378"/>
         <source>Failed to move &quot;%1&quot; to &quot;%2&quot;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="388"/>
+        <location filename="../src/ad_interface.cpp" line="395"/>
         <source>Added user &quot;%1&quot; to group &quot;%2&quot;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="392"/>
+        <location filename="../src/ad_interface.cpp" line="399"/>
         <source>Failed to add user &quot;%1&quot; to group &quot;%2&quot;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="408"/>
+        <location filename="../src/ad_interface.cpp" line="416"/>
         <source>Removed user &quot;%1&quot; from group &quot;%2&quot;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="412"/>
+        <location filename="../src/ad_interface.cpp" line="420"/>
         <source>Failed to remove user &quot;%1&quot; from group &quot;%2&quot;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="444"/>
+        <location filename="../src/ad_interface.cpp" line="454"/>
         <source>Renamed &quot;%1&quot; to &quot;%2&quot;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="448"/>
-        <source>Failed to rename &quot;%1&quot; to &quot;%2&quot;. Error: &quot;%3&quot;</source>
+        <location filename="../src/ad_interface.cpp" line="458"/>
+        <source>Failed to rename &quot;%1&quot; to &quot;%2&quot;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="461"/>
+        <location filename="../src/ad_interface.cpp" line="482"/>
+        <source>Password doesn&apos;t match rules</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/ad_interface.cpp" line="485"/>
+        <source>Failed to set pass of &quot;%1&quot;</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/ad_interface.cpp" line="688"/>
+        <source>%1. Error: &quot;%2&quot;</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/ad_interface.cpp" line="700"/>
+        <source>No such object</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/ad_interface.cpp" line="701"/>
+        <source>Constraint violation</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/ad_interface.cpp" line="702"/>
+        <source>Unknown LDAP error</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/ad_interface.cpp" line="706"/>
+        <source>AD success</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/ad_interface.cpp" line="707"/>
+        <source>Generic AD error</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/ad_interface.cpp" line="708"/>
+        <source>Invalid DN</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/ad_interface.cpp" line="709"/>
+        <source>Unknown AD error</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/ad_interface.cpp" line="473"/>
         <source>Set pass of &quot;%1&quot;</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../src/ad_interface.cpp" line="467"/>
-        <source>Failed to set pass of &quot;%1&quot;. Error: &quot;%2&quot;</source>
         <translation></translation>
     </message>
 </context>
@@ -520,7 +565,7 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/password_dialog.cpp" line="85"/>
+        <location filename="../src/password_dialog.cpp" line="84"/>
         <source>Failed to set password! %1</source>
         <translation></translation>
     </message>
@@ -553,89 +598,89 @@
     <message>
         <location filename="../gpgui/gui/MainWindow.cpp" line="65"/>
         <source>Open PReg file for editing</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../gpgui/gui/MainWindow.cpp" line="67"/>
         <source>&amp;Save PReg file</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../gpgui/gui/MainWindow.cpp" line="68"/>
         <source>Save active PReg file</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../gpgui/gui/MainWindow.cpp" line="70"/>
         <source>&amp;Save REG file</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../gpgui/gui/MainWindow.cpp" line="71"/>
         <source>Save active PReg file as REG</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../gpgui/gui/MainWindow.cpp" line="73"/>
         <source>&amp;Exit</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../gpgui/gui/MainWindow.cpp" line="74"/>
         <source>Exit GPGUI</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../gpgui/gui/MainWindow.cpp" line="77"/>
         <source>&amp;About</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../gpgui/gui/MainWindow.cpp" line="78"/>
         <location filename="../gpgui/gui/MainWindow.cpp" line="134"/>
         <source>About GPGUI</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../gpgui/gui/MainWindow.cpp" line="82"/>
         <source>Ready</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../gpgui/gui/MainWindow.cpp" line="89"/>
         <source>Select PReg file to edit</source>
         <extracomment>QMainWindow(parent)</extracomment>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../gpgui/gui/MainWindow.cpp" line="94"/>
         <source>Select PReg file to save</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../gpgui/gui/MainWindow.cpp" line="102"/>
         <source>PReg editor</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../gpgui/gui/MainWindow.cpp" line="103"/>
         <source>GPO editor</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../gpgui/gui/MainWindow.cpp" line="104"/>
         <source>Domain Control</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../gpgui/gui/MainWindow.cpp" line="134"/>
         <source>GPGUI about</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../gpgui/gui/MainWindow.cpp" line="182"/>
         <source>Loaded PReg file</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 </TS>

--- a/translations/ru.ts
+++ b/translations/ru.ts
@@ -4,109 +4,154 @@
 <context>
     <name>AdInterface</name>
     <message>
-        <location filename="../src/ad_interface.cpp" line="99"/>
+        <location filename="../src/ad_interface.cpp" line="102"/>
         <source>Logged in to &quot;%1&quot; at &quot;%2&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Логин в &quot;%1&quot; на &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="105"/>
+        <location filename="../src/ad_interface.cpp" line="108"/>
         <source>Failed to login to &quot;%1&quot; at &quot;%2&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Логин не удался в &quot;%1&quot; на &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="143"/>
+        <location filename="../src/ad_interface.cpp" line="144"/>
         <source>Failed to load children of &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось загрузить детей &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="169"/>
+        <location filename="../src/ad_interface.cpp" line="170"/>
         <source>Failed to search for &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось выполнить поиск &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="279"/>
+        <location filename="../src/ad_interface.cpp" line="282"/>
         <source>Failed to change attribute &quot;%1&quot; of object &quot;%2&quot; from &quot;%3&quot; to &quot;%4&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось изменить атрибут &quot;%1&quot; объекта &quot;%2&quot; с &quot;%3&quot; на &quot;%4&quot;</translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="341"/>
+        <location filename="../src/ad_interface.cpp" line="344"/>
         <source>Failed to delete object &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось удалить &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="372"/>
+        <location filename="../src/ad_interface.cpp" line="378"/>
         <source>Failed to move &quot;%1&quot; to &quot;%2&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось переместить &quot;%1&quot; в &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="392"/>
+        <location filename="../src/ad_interface.cpp" line="399"/>
         <source>Failed to add user &quot;%1&quot; to group &quot;%2&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось добавить &quot;%1&quot; в группу &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="412"/>
+        <location filename="../src/ad_interface.cpp" line="420"/>
         <source>Failed to remove user &quot;%1&quot; from group &quot;%2&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось удалить пользователя &quot;%1&quot; из группы &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="217"/>
+        <location filename="../src/ad_interface.cpp" line="458"/>
+        <source>Failed to rename &quot;%1&quot; to &quot;%2&quot;</source>
+        <translation>Не удалось переименовать &quot;%1&quot; в &quot;%2&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/ad_interface.cpp" line="482"/>
+        <source>Password doesn&apos;t match rules</source>
+        <translation>Пароль не соответствует правилам</translation>
+    </message>
+    <message>
+        <location filename="../src/ad_interface.cpp" line="485"/>
+        <source>Failed to set pass of &quot;%1&quot;</source>
+        <translation>Не удалось установить пароль для %1</translation>
+    </message>
+    <message>
+        <location filename="../src/ad_interface.cpp" line="688"/>
+        <source>%1. Error: &quot;%2&quot;</source>
+        <translation>%1. Ошибка: &quot;%2&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/ad_interface.cpp" line="700"/>
+        <source>No such object</source>
+        <translation>Нет такого объекта</translation>
+    </message>
+    <message>
+        <location filename="../src/ad_interface.cpp" line="701"/>
+        <source>Constraint violation</source>
+        <translation>Нарушение ограничений</translation>
+    </message>
+    <message>
+        <location filename="../src/ad_interface.cpp" line="702"/>
+        <source>Unknown LDAP error</source>
+        <translation>Неизвестная LDAP ошибка</translation>
+    </message>
+    <message>
+        <location filename="../src/ad_interface.cpp" line="706"/>
+        <source>AD success</source>
+        <translation>AD успех</translation>
+    </message>
+    <message>
+        <location filename="../src/ad_interface.cpp" line="707"/>
+        <source>Generic AD error</source>
+        <translation>AD ошибка</translation>
+    </message>
+    <message>
+        <location filename="../src/ad_interface.cpp" line="708"/>
+        <source>Invalid DN</source>
+        <translation>Недействительный DN</translation>
+    </message>
+    <message>
+        <location filename="../src/ad_interface.cpp" line="709"/>
+        <source>Unknown AD error</source>
+        <translation>Неизвестная AD ошибка</translation>
+    </message>
+    <message>
+        <location filename="../src/ad_interface.cpp" line="220"/>
         <source>Failed to get attributes of &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось получить атрибуты для &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="273"/>
+        <location filename="../src/ad_interface.cpp" line="276"/>
         <source>Changed attribute &quot;%1&quot; of &quot;%2&quot; from &quot;%3&quot; to &quot;%4&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Изменен атрибут &quot;%1&quot; из &quot;%2&quot; с &quot;%3&quot; на &quot;%4&quot;</translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="316"/>
+        <location filename="../src/ad_interface.cpp" line="319"/>
         <source>Created &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Создан объект - &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="322"/>
+        <location filename="../src/ad_interface.cpp" line="325"/>
         <source>Failed to create &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось создать объект &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="337"/>
+        <location filename="../src/ad_interface.cpp" line="340"/>
         <source>Deleted object &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Удален объект - &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="368"/>
+        <location filename="../src/ad_interface.cpp" line="374"/>
         <source>Moved &quot;%1&quot; to &quot;%2&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Перемещен объект - &quot;%1&quot; в &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="388"/>
+        <location filename="../src/ad_interface.cpp" line="395"/>
         <source>Added user &quot;%1&quot; to group &quot;%2&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавлен пользователь &quot;%1&quot; в группу &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="408"/>
+        <location filename="../src/ad_interface.cpp" line="416"/>
         <source>Removed user &quot;%1&quot; from group &quot;%2&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Удален пользователь &quot;%1&quot; из группы &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="444"/>
+        <location filename="../src/ad_interface.cpp" line="454"/>
         <source>Renamed &quot;%1&quot; to &quot;%2&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Переименован объект &quot;%1&quot; в &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="448"/>
-        <source>Failed to rename &quot;%1&quot; to &quot;%2&quot;. Error: &quot;%3&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/ad_interface.cpp" line="461"/>
+        <location filename="../src/ad_interface.cpp" line="473"/>
         <source>Set pass of &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/ad_interface.cpp" line="467"/>
-        <source>Failed to set pass of &quot;%1&quot;. Error: &quot;%2&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Установлен пароль для %1</translation>
     </message>
 </context>
 <context>
@@ -525,7 +570,7 @@
         <translation>Пароли не совпадают!</translation>
     </message>
     <message>
-        <location filename="../src/password_dialog.cpp" line="85"/>
+        <location filename="../src/password_dialog.cpp" line="84"/>
         <source>Failed to set password! %1</source>
         <translation>Не удалось установить пароль! %1</translation>
     </message>

--- a/translations/ru.ts
+++ b/translations/ru.ts
@@ -69,37 +69,47 @@
         <translation>%1. Ошибка: &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="700"/>
+        <location filename="../src/ad_interface.cpp" line="699"/>
         <source>No such object</source>
         <translation>Нет такого объекта</translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="701"/>
+        <location filename="../src/ad_interface.cpp" line="700"/>
         <source>Constraint violation</source>
         <translation>Нарушение ограничений</translation>
     </message>
     <message>
+        <location filename="../src/ad_interface.cpp" line="701"/>
+        <source>Server is unwilling to perform</source>
+        <translation>Сервер не хочет выполнять</translation>
+    </message>
+    <message>
         <location filename="../src/ad_interface.cpp" line="702"/>
+        <source>Already exists</source>
+        <translation type="unfinished">Объект уже существует</translation>
+    </message>
+    <message>
+        <location filename="../src/ad_interface.cpp" line="703"/>
         <source>Unknown LDAP error</source>
         <translation>Неизвестная LDAP ошибка</translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="706"/>
+        <location filename="../src/ad_interface.cpp" line="707"/>
         <source>AD success</source>
         <translation>AD успех</translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="707"/>
+        <location filename="../src/ad_interface.cpp" line="708"/>
         <source>Generic AD error</source>
         <translation>AD ошибка</translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="708"/>
+        <location filename="../src/ad_interface.cpp" line="709"/>
         <source>Invalid DN</source>
         <translation>Недействительный DN</translation>
     </message>
     <message>
-        <location filename="../src/ad_interface.cpp" line="709"/>
+        <location filename="../src/ad_interface.cpp" line="710"/>
         <source>Unknown AD error</source>
         <translation>Неизвестная AD ошибка</translation>
     </message>


### PR DESCRIPTION
Error messages can now be reworded and translated. Also error messages can be further customized depending on context. For example LDAP_CONSTRAINT_VIOLATION applies to passwords, names, attributes, etc. and in each case it's now possible to clarify the error.

For example:
_"Failed to set password for X. Error: "Constraint violation." => "Failed to set password for X. Error: "Password doesn't match rules."_

Added new AdResult struct to bundle error message with success bool.
Also remove old unused error codes.
Update translations.