### PR TITLE
do kerberos auth in login dialog

### DIFF
--- a/.gear/admc.spec
+++ b/.gear/admc.spec
@@ -26,6 +26,7 @@ BuildRequires: doxygen
 BuildRequires: libuuid-devel
 BuildRequires: glib2-devel
 BuildRequires: libpcre-devel
+BuildRequires: libkrb5-devel
 
 Requires: libldap
 Requires: libsasl2
@@ -33,6 +34,7 @@ Requires: libsmbclient
 Requires: libuuid
 Requires: qt5-base-common
 Requires: glib2
+Requires: libkrb5
 
 Source0: %name-%version.tar
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,7 @@
 ## ADMC
 Join your machine to the domain. See this [guide](https://www.altlinux.org/%D0%A3%D1%87%D0%B0%D1%81%D1%82%D0%BD%D0%B8%D0%BA:Toga/ADJoin).
 
-Do `$ kinit administrator@DOMAIN.ALT` and enter the admin password.
-
-Launch admc.
-
-Menubar -> File -> Login -> enter domain name (DOMAIN.ALT) -> press enter -> select host (dc0 is fine) -> Login.
+Launch admc. Enter username and password. Press login.
 
 ## GPGUI
 

--- a/cmake/FindKrb5.cmake
+++ b/cmake/FindKrb5.cmake
@@ -1,0 +1,40 @@
+find_package(PkgConfig)
+if(PKG_CONFIG_FOUND)
+    pkg_check_modules(PC_KRB5 krb5)
+endif()
+
+find_path(KRB5_INCLUDE_DIR
+    NAMES krb5.h
+    HINTS ${PC_KRB5_INCLUDEDIR}
+)
+
+find_library(KRB5_LIBRARY
+    NAMES krb5
+    HINTS ${PC_KRB5_LIBDIR}
+)
+
+mark_as_advanced(
+    KRB5_INCLUDE_DIR
+    KRB5_LIBRARY
+)
+
+find_package_handle_standard_args(Krb5
+    FOUND_VAR KRB5_FOUND
+    REQUIRED_VARS
+        KRB5_INCLUDE_DIR
+        KRB5_LIBRARY
+)
+
+if(KRB5_FOUND AND NOT TARGET Krb5::Krb5)
+    add_library(Krb5::Krb5 INTERFACE IMPORTED)
+
+    target_link_libraries(Krb5::Krb5
+        INTERFACE
+            krb5
+    )
+
+    target_include_directories(Krb5::Krb5
+        INTERFACE
+            ${KRB5_INCLUDE_DIR}
+    )
+endif()

--- a/src/admc/CMakeLists.txt
+++ b/src/admc/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(Qt5 REQUIRED
 
 find_package(Uuid REQUIRED)
 find_package(Smbclient REQUIRED)
+find_package(Krb5 REQUIRED)
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
@@ -91,6 +92,7 @@ target_link_libraries(admc
     adldap
     Uuid::Uuid
     Smbclient::Smbclient
+    Krb5::Krb5
 )
 
 install(TARGETS admc)

--- a/src/admc/ad_interface.cpp
+++ b/src/admc/ad_interface.cpp
@@ -54,27 +54,31 @@ void get_auth_data_fn(const char * pServer, const char * pShare, char * pWorkgro
 }
 
 bool AdInterface::login() {
-    // Get default krb5 domain (realm)
+    // Get default domain (realm)
     const QString domain =
     []() {
+        krb5_error_code result;
         krb5_context context;
-        const krb5_error_code result = krb5_init_context(&context);
+
+        result = krb5_init_context(&context);
         if (result) {
-            printf("krb5_init_context failed\n");
+            qDebug() << "Failed to init krb5 context";
             return QString();
         }
 
         char *realm_cstr = NULL;
-        krb5_get_default_realm(context, &realm_cstr);
-        // TODO: error
+        result = krb5_get_default_realm(context, &realm_cstr);
+        if (result) {
+            qDebug() << "Failed to get default realm";
 
-        QString out;
-        if (realm_cstr != NULL) {
-            out = QString(realm_cstr);
+            krb5_free_context(context);
+
+            return QString();
         }
 
+        const QString out = QString(realm_cstr);
+
         krb5_free_default_realm(context, realm_cstr);
-        krb5_free_context(context);
 
         return out;
     }();

--- a/src/admc/ad_interface.h
+++ b/src/admc/ad_interface.h
@@ -166,7 +166,7 @@ private:
 public:
     static AdInterface *instance();
 
-    bool login(const QString &domain, const QString &site);
+    bool login();
 
     // Use this if you are doing a series of AD modifications.
     // During the batch, modified() signals won't be emitted

--- a/src/admc/login_dialog.cpp
+++ b/src/admc/login_dialog.cpp
@@ -71,13 +71,16 @@ LoginDialog::LoginDialog(QWidget *parent)
 
     connect(
         login_button, &QAbstractButton::clicked,
-        this, &LoginDialog::on_login_button);
+        this, &LoginDialog::login);
+    connect(
+        password_edit, &QLineEdit::returnPressed,
+        this, &LoginDialog::login);
     connect(
         this, &QDialog::rejected,
         this, &LoginDialog::on_rejected);
 }
 
-void LoginDialog::on_login_button() {
+void LoginDialog::login() {
     // Authenticate using krb5
     krb5_context context;
     krb5_ccache ccache = NULL;

--- a/src/admc/login_dialog.h
+++ b/src/admc/login_dialog.h
@@ -30,8 +30,8 @@ private slots:
     void on_rejected();
 
 private:
-    QLineEdit *domain_edit = nullptr;
-    QLineEdit *site_edit = nullptr;
+    QLineEdit *principal_edit = nullptr;
+    QLineEdit *password_edit = nullptr;
     QCheckBox *autologin_check;
 };
 

--- a/src/admc/login_dialog.h
+++ b/src/admc/login_dialog.h
@@ -14,6 +14,13 @@
 #ifndef LOGIN_DIALOG_H
 #define LOGIN_DIALOG_H
 
+/**
+ * Opened when app launches. Asks for username and password
+ * and then authenticates through kerberos. Toggling "auto
+ * login" option will skip this dialog on subsequent
+ * launches unless authentication is required.
+ */
+
 #include <QDialog>
 
 class QLineEdit;

--- a/src/admc/login_dialog.h
+++ b/src/admc/login_dialog.h
@@ -26,13 +26,14 @@ public:
     LoginDialog(QWidget *parent);
 
 private slots:
-    void on_login_button();
     void on_rejected();
+    void login();
 
 private:
     QLineEdit *principal_edit = nullptr;
     QLineEdit *password_edit = nullptr;
     QCheckBox *autologin_check;
+
 };
 
 #endif /* LOGIN_DIALOG_H */

--- a/src/admc/main.cpp
+++ b/src/admc/main.cpp
@@ -21,9 +21,9 @@
 #include "main_window.h"
 #include "ad_interface.h"
 #include "settings.h"
+#include "login_dialog.h"
 
 #include <QApplication>
-#include <QCommandLineParser>
 #include <QStringList>
 #include <QTranslator>
 
@@ -35,47 +35,14 @@ int main(int argc, char **argv) {
     app.setOrganizationName(ADMC_ORGANIZATION);
     app.setOrganizationDomain(ADMC_ORGANIZATION_DOMAIN);
 
-    const QLocale saved_locale = SETTINGS()->get_variant(VariantSetting_Locale).toLocale();
-
     QTranslator translator;
+    const QLocale saved_locale = SETTINGS()->get_variant(VariantSetting_Locale).toLocale();
     translator.load(saved_locale, QString(), QString(), ":/translations");
     app.installTranslator(&translator);
 
-    QCommandLineParser cli_parser;
-    cli_parser.setApplicationDescription(QCoreApplication::applicationName());
-    cli_parser.addHelpOption();
-    cli_parser.addVersionOption();
+    MainWindow main_window;
 
-    cli_parser.addOption({{"H", "host"}, "Host to use for login", "host"});
-    cli_parser.addOption({{"D", "domain"}, "Domain to use for login", "domain"});
+    const int retval = app.exec();
 
-    const QStringList arg_list = qApp->arguments();
-    cli_parser.process(arg_list);
-
-    QStringList positional_args = cli_parser.positionalArguments();
-    if (positional_args.size() > 0) {
-        // CLI
-        const bool defined_login_values = cli_parser.isSet("host") && cli_parser.isSet("domain");
-        if (!defined_login_values) {
-            printf("Error: must define host and domain options, see help for options.");
-
-            return 1;
-        }
-
-        const QString host = cli_parser.value("host");
-        const QString domain = cli_parser.value("domain");
-        
-        AD()->login(host, domain);
-        AD()->command(positional_args);
-
-        return 0;
-    } else {
-        // GUI
-        MainWindow main_window;
-        main_window.show();
-
-        const int retval = app.exec();
-
-        return retval;
-    }
+    return retval;
 }

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -136,10 +136,9 @@ QString bool_to_string(BoolSetting type) {
 
 QString variant_to_string(VariantSetting type) {
     switch (type) {
-        CASE_ENUM_TO_STRING(VariantSetting_Domain);
-        CASE_ENUM_TO_STRING(VariantSetting_Site);
         CASE_ENUM_TO_STRING(VariantSetting_MainWindowGeometry);
         CASE_ENUM_TO_STRING(VariantSetting_Locale);
+        CASE_ENUM_TO_STRING(VariantSetting_Principal);
         CASE_ENUM_TO_STRING(VariantSetting_COUNT);
     }
     return "";

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -42,8 +42,7 @@ class QWidget;
 
 enum VariantSetting {
     // ADMC
-    VariantSetting_Domain,    
-    VariantSetting_Site,    
+    VariantSetting_Principal,    
     VariantSetting_Locale,
 
     // GPGUI


### PR DESCRIPTION
Login dialog now has these inputs: username(principal), password and auto-login checkbox.
Domain name is obtained from krb5 library instead of from user. Site is left blank.
While auto-login is turned on, the login dialog is skipped. If user hasn't authenticated through kerberos, login dialog will popup to ask for password.

Couldn't figure out how to check if authentication is needed or not via krb5 library, so for now just attempting AD login and if it fails bring up the login dialog. Would be better if was able to check if pass is needed via krb5, because that way would know for sure whether AD login failed due to no kerberos auth or not being connected to domain.

Hide main window until login dialog suceeds.