### PR TITLE
Ad config rework

### DIFF
--- a/src/admc/ad_config.cpp
+++ b/src/admc/ad_config.cpp
@@ -129,25 +129,13 @@ AdConfig::AdConfig(QObject *parent)
         QHash<QString, QHash<QString, QString>> out;
 
         const QString locale_dir = get_locale_dir();
-        const QList<QString> search_attributes = {ATTRIBUTE_ATTRIBUTE_DISPLAY_NAMES, ATTRIBUTE_EXTRA_COLUMNS};
+        const QList<QString> search_attributes = {ATTRIBUTE_ATTRIBUTE_DISPLAY_NAMES};
         const QHash<QString, AdObject> search_results = AD()->search("", search_attributes, SearchScope_Children, locale_dir);
 
         for (const QString &dn : search_results.keys()) {
-            const AdObject object  = search_results[dn];
+            const AdObject object = search_results[dn];
 
-            const QList<QString> display_names =
-            [dn, object]() {
-                QList<QString> display_names_out = object.get_strings(ATTRIBUTE_ATTRIBUTE_DISPLAY_NAMES);
-
-                // NOTE: default display specifier contains some extra display names that are used for contents columns
-                if (dn.contains("default-Display")) {
-                    const QList<QString> extra_display_names = object.get_strings(ATTRIBUTE_EXTRA_COLUMNS);
-
-                    display_names_out.append(extra_display_names);
-                }
-
-                return display_names_out;
-            }();
+            const QList<QString> display_names = object.get_strings(ATTRIBUTE_ATTRIBUTE_DISPLAY_NAMES);
 
             const QString specifier_class = get_display_specifier_class(dn);
 

--- a/src/admc/ad_config.cpp
+++ b/src/admc/ad_config.cpp
@@ -358,7 +358,7 @@ AttributeType AdConfig::get_attribute_type(const QString &attribute) const {
     }
 }
 
-LargeIntegerSubtype AdConfig::get_large_integer_subtype(const QString &attribute) const {
+LargeIntegerSubtype AdConfig::get_attribute_large_integer_subtype(const QString &attribute) const {
     // Manually remap large integer types to subtypes
     // TODO: figure out where to get this data
     // externally. So far haven't found anything.
@@ -385,7 +385,7 @@ LargeIntegerSubtype AdConfig::get_large_integer_subtype(const QString &attribute
     }
 }
 
-bool AdConfig::attribute_is_number(const QString &attribute) const {
+bool AdConfig::get_attribute_is_number(const QString &attribute) const {
     static const QList<AttributeType> number_types = {
         AttributeType_Integer,
         AttributeType_LargeInteger,

--- a/src/admc/ad_config.cpp
+++ b/src/admc/ad_config.cpp
@@ -385,13 +385,6 @@ LargeIntegerSubtype AdConfig::get_large_integer_subtype(const QString &attribute
     }
 }
 
-void AdConfig::limit_edit(QLineEdit *edit, const QString &attribute) {
-    const int range_upper = get_attribute_range_upper(attribute);
-    if (range_upper > 0) {
-        edit->setMaxLength(range_upper);
-    }
-}
-
 bool AdConfig::attribute_is_number(const QString &attribute) const {
     static const QList<AttributeType> number_types = {
         AttributeType_Integer,
@@ -414,6 +407,13 @@ bool AdConfig::get_attribute_is_system_only(const QString &attribute) const {
 
 int AdConfig::get_attribute_range_upper(const QString &attribute) const {
     return attribute_schemas[attribute].get_int(ATTRIBUTE_RANGE_UPPER);
+}
+
+void AdConfig::limit_edit(QLineEdit *edit, const QString &attribute) {
+    const int range_upper = get_attribute_range_upper(attribute);
+    if (range_upper > 0) {
+        edit->setMaxLength(range_upper);
+    }
 }
 
 QString get_locale_dir() {

--- a/src/admc/ad_config.cpp
+++ b/src/admc/ad_config.cpp
@@ -537,33 +537,15 @@ bool AdConfig::attribute_is_number(const QString &attribute) const {
 }
 
 bool AdConfig::get_attribute_is_single_valued(const QString &attribute) const {
-    const AdObject schema = attribute_schemas[attribute];
-
-    if (schema.contains(ATTRIBUTE_IS_SINGLE_VALUED)) {
-        return schema.get_bool(ATTRIBUTE_IS_SINGLE_VALUED);
-    } else {
-        return false;
-    }
+    return attribute_schemas[attribute].get_bool(ATTRIBUTE_IS_SINGLE_VALUED);
 }
 
 bool AdConfig::get_attribute_is_system_only(const QString &attribute) const {
-    const AdObject schema = attribute_schemas[attribute];
-
-    if (schema.contains(ATTRIBUTE_SYSTEM_ONLY)) {
-        return schema.get_bool(ATTRIBUTE_SYSTEM_ONLY);
-    } else {
-        return false;
-    }
+    return attribute_schemas[attribute].get_bool(ATTRIBUTE_SYSTEM_ONLY);
 }
 
 int AdConfig::get_attribute_range_upper(const QString &attribute) const {
-    const AdObject schema = attribute_schemas[attribute];
-
-    if (schema.contains(ATTRIBUTE_RANGE_UPPER)) {
-        return schema.get_int(ATTRIBUTE_RANGE_UPPER);
-    } else {
-        return 0;
-    }
+    return attribute_schemas[attribute].get_int(ATTRIBUTE_RANGE_UPPER);
 }
 
 // Display specifier DN is "CN=object-class-Display,CN=..."

--- a/src/admc/ad_config.h
+++ b/src/admc/ad_config.h
@@ -89,8 +89,8 @@ public:
     QList<Attribute> get_find_attributes(const ObjectClass &object_class) const;
 
     AttributeType get_attribute_type(const Attribute &attribute) const;
-    LargeIntegerSubtype get_large_integer_subtype(const Attribute &attribute) const;
-    bool attribute_is_number(const Attribute &attribute) const;
+    LargeIntegerSubtype get_attribute_large_integer_subtype(const Attribute &attribute) const;
+    bool get_attribute_is_number(const Attribute &attribute) const;
     bool get_attribute_is_single_valued(const Attribute &attribute) const;
     bool get_attribute_is_system_only(const Attribute &attribute) const;
     int get_attribute_range_upper(const Attribute &attribute) const;

--- a/src/admc/ad_config.h
+++ b/src/admc/ad_config.h
@@ -107,9 +107,6 @@ private:
 
     QHash<Attribute, AdObject> attribute_schemas;
     QHash<ObjectClass, AdObject> class_schemas;
-
-    QString get_ldap_to_ad_name(const QString &ldap_name) const;
-    QString get_ad_to_ldap_name(const QString &ad_name) const;
 };
 
 AdConfig *ADCONFIG();

--- a/src/admc/ad_config.h
+++ b/src/admc/ad_config.h
@@ -74,24 +74,26 @@ Q_OBJECT
 public:
     AdConfig(QObject *parent);
 
-    QList<ObjectClass> get_filter_containers() const;
+    QString get_attribute_display_name(const Attribute &attribute, const ObjectClass &objectClass) const;
+
+    QString get_class_display_name(const ObjectClass &objectClass) const;
 
     QList<Attribute> get_columns() const;
     QString get_column_display_name(const Attribute &attribute) const;
 
+    QList<ObjectClass> get_filter_containers() const;
+
     QList<ObjectClass> get_possible_superiors(const QList<ObjectClass> &object_classes) const;
 
-    QString get_class_display_name(const ObjectClass &objectClass) const;
     QList<Attribute> get_possible_attributes(const QList<ObjectClass> &object_classes) const;
     QList<Attribute> get_find_attributes(const ObjectClass &object_class) const;
-    QString get_attribute_display_name(const Attribute &attribute, const ObjectClass &objectClass) const;
 
     AttributeType get_attribute_type(const Attribute &attribute) const;
+    LargeIntegerSubtype get_large_integer_subtype(const Attribute &attribute) const;
+    bool attribute_is_number(const Attribute &attribute) const;
     bool get_attribute_is_single_valued(const Attribute &attribute) const;
     bool get_attribute_is_system_only(const Attribute &attribute) const;
     int get_attribute_range_upper(const Attribute &attribute) const;
-    bool attribute_is_number(const Attribute &attribute) const;
-    LargeIntegerSubtype get_large_integer_subtype(const Attribute &attribute) const;
 
     void limit_edit(QLineEdit *edit, const QString &attribute);
 

--- a/src/admc/ad_config.h
+++ b/src/admc/ad_config.h
@@ -102,13 +102,11 @@ private:
     QHash<Attribute, QString> column_display_names;
 
     QHash<ObjectClass, QString> class_display_names;
-    QHash<ObjectClass, QList<ObjectClass>> possible_superiors;
-    QHash<ObjectClass, QList<Attribute>> possible_attributes;
     QHash<ObjectClass, QList<Attribute>> find_attributes;
     QHash<ObjectClass, QHash<Attribute, QString>> attribute_display_names;
-    QHash<ObjectClass, QList<QString>> auxiliary_classes;
 
     QHash<Attribute, AdObject> attribute_schemas;
+    QHash<ObjectClass, AdObject> class_schemas;
 
     QHash<QString, QString> ldap_to_ad_names;
     QHash<QString, QString> ad_to_ldap_names;

--- a/src/admc/ad_config.h
+++ b/src/admc/ad_config.h
@@ -108,9 +108,6 @@ private:
     QHash<Attribute, AdObject> attribute_schemas;
     QHash<ObjectClass, AdObject> class_schemas;
 
-    QHash<QString, QString> ldap_to_ad_names;
-    QHash<QString, QString> ad_to_ldap_names;
-
     QString get_ldap_to_ad_name(const QString &ldap_name) const;
     QString get_ad_to_ldap_name(const QString &ad_name) const;
 };

--- a/src/admc/ad_config.h
+++ b/src/admc/ad_config.h
@@ -66,6 +66,7 @@ typedef QString ObjectClass;
 typedef QString Attribute;
 
 class QLineEdit;
+class AdObject;
 
 class AdConfig final : public QObject {
 Q_OBJECT
@@ -107,10 +108,7 @@ private:
     QHash<ObjectClass, QHash<Attribute, QString>> attribute_display_names;
     QHash<ObjectClass, QList<QString>> auxiliary_classes;
 
-    QHash<Attribute, AttributeType> attribute_types;
-    QHash<Attribute, bool> attribute_is_single_valued;
-    QHash<Attribute, bool> attribute_is_system_only;
-    QHash<Attribute, int> attribute_range_upper;
+    QHash<Attribute, AdObject> attribute_schemas;
 
     QHash<QString, QString> ldap_to_ad_names;
     QHash<QString, QString> ad_to_ldap_names;

--- a/src/admc/ad_utils.cpp
+++ b/src/admc/ad_utils.cpp
@@ -40,7 +40,7 @@ QString datetime_qdatetime_to_string(const QString &attribute, const QDateTime &
 
     switch (type) {
         case AttributeType_LargeInteger: {
-            const LargeIntegerSubtype subtype = ADCONFIG()->get_large_integer_subtype(attribute);
+            const LargeIntegerSubtype subtype = ADCONFIG()->get_attribute_large_integer_subtype(attribute);
             if (subtype == LargeIntegerSubtype_Datetime) {
                 const qint64 millis = QDateTime(ntfs_epoch).msecsTo(datetime);
                 const qint64 hundred_nanos = millis * MILLIS_TO_100_NANOS;
@@ -74,7 +74,7 @@ QDateTime datetime_string_to_qdatetime(const QString &attribute, const QString &
     [=]() {
         switch (type) {
             case AttributeType_LargeInteger: {
-                const LargeIntegerSubtype subtype = ADCONFIG()->get_large_integer_subtype(attribute);
+                const LargeIntegerSubtype subtype = ADCONFIG()->get_attribute_large_integer_subtype(attribute);
                 
                 if (subtype == LargeIntegerSubtype_Datetime) {
                     QDateTime out = QDateTime(ntfs_epoch);

--- a/src/admc/attribute_display.cpp
+++ b/src/admc/attribute_display.cpp
@@ -33,7 +33,7 @@ QString attribute_display_value(const QString &attribute, const QByteArray &valu
 
     switch (type) {
         case AttributeType_LargeInteger: {
-            const LargeIntegerSubtype subtype = ADCONFIG()->get_large_integer_subtype(attribute);
+            const LargeIntegerSubtype subtype = ADCONFIG()->get_attribute_large_integer_subtype(attribute);
 
             switch (subtype) {
                 case LargeIntegerSubtype_Datetime: return large_integer_datetime_to_display_value(attribute, value);

--- a/src/admc/editors/string_editor.cpp
+++ b/src/admc/editors/string_editor.cpp
@@ -49,7 +49,7 @@ StringEditor::StringEditor(const QString attribute, const QList<QByteArray> valu
 
     edit = new QLineEdit();
 
-    if (ADCONFIG()->attribute_is_number(attribute)) {
+    if (ADCONFIG()->get_attribute_is_number(attribute)) {
         set_line_edit_to_numbers_only(edit);
     }
 

--- a/src/admc/edits/string_edit.cpp
+++ b/src/admc/edits/string_edit.cpp
@@ -42,7 +42,7 @@ StringEdit::StringEdit(const QString &attribute_arg, const QString &objectClass_
     
     edit = new QLineEdit();
     
-    if (ADCONFIG()->attribute_is_number(attribute)) {
+    if (ADCONFIG()->get_attribute_is_number(attribute)) {
         set_line_edit_to_numbers_only(edit);
     }
     


### PR DESCRIPTION
Store class and attribute schema as objects instead of splitting fields into separate hashmaps.
Combine preprocessing of data.