### PR TITLE
Shared object model

### DIFF
--- a/src/admc/CMakeLists.txt
+++ b/src/admc/CMakeLists.txt
@@ -38,7 +38,7 @@ add_executable(admc
     attribute_display.cpp
     object_list_widget.cpp
     toggle_widgets_dialog.cpp
-    contents_filter_dialog.cpp
+    filter_dialog.cpp
     advanced_view_proxy.cpp
     
     rename_dialog.cpp

--- a/src/admc/CMakeLists.txt
+++ b/src/admc/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(admc
     object_list_widget.cpp
     toggle_widgets_dialog.cpp
     contents_filter_dialog.cpp
+    advanced_view_proxy.cpp
     
     rename_dialog.cpp
     rename_policy_dialog.cpp

--- a/src/admc/CMakeLists.txt
+++ b/src/admc/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(admc
     ad_object.cpp
     details_dialog.cpp
     containers_widget.cpp
+    containers_proxy.cpp
     contents_widget.cpp
     main_window.cpp
     status.cpp

--- a/src/admc/CMakeLists.txt
+++ b/src/admc/CMakeLists.txt
@@ -36,7 +36,7 @@ add_executable(admc
     password_dialog.cpp
     menubar.cpp
     attribute_display.cpp
-    object_list_widget.cpp
+    find_results.cpp
     toggle_widgets_dialog.cpp
     filter_dialog.cpp
     advanced_view_proxy.cpp

--- a/src/admc/ad_config.cpp
+++ b/src/admc/ad_config.cpp
@@ -293,6 +293,14 @@ QString AdConfig::get_column_display_name(const Attribute &attribute) const {
     return column_display_names.value(attribute, attribute);
 }
 
+int AdConfig::get_column_index(const QString &attribute) const {
+    if (!columns.contains(attribute)) {
+        qWarning() << "ADCONFIG columns missing attribute:" << attribute;
+    }
+
+    return columns.indexOf(attribute);
+}
+
 QList<QString> AdConfig::get_filter_containers() const {
     return filter_containers;
 }

--- a/src/admc/ad_config.cpp
+++ b/src/admc/ad_config.cpp
@@ -248,6 +248,12 @@ AdConfig::AdConfig(QObject *parent)
             out.append(object_class);
         }
 
+        // NOTE: domain not included for some reason, so add it manually
+        out.append(CLASS_DOMAIN);
+
+        // Make configuration and schema pass filter in dev mode so they are visible and can be fetched
+        out.append({CLASS_CONFIGURATION, CLASS_dMD});
+
         return out;
     }();
 }

--- a/src/admc/ad_config.h
+++ b/src/admc/ad_config.h
@@ -82,6 +82,7 @@ public:
 
     QList<Attribute> get_columns() const;
     QString get_column_display_name(const Attribute &attribute) const;
+    int get_column_index(const QString &attribute) const;
 
     QList<ObjectClass> get_filter_containers() const;
 

--- a/src/admc/ad_interface.cpp
+++ b/src/admc/ad_interface.cpp
@@ -388,6 +388,8 @@ bool AdInterface::attribute_replace_values(const QString &dn, const QString &att
     if (result == AD_SUCCESS) {
         success_status_message(QString(tr("Changed attribute \"%1\" of object \"%2\" from \"%3\" to \"%4\"")).arg(attribute, name, old_values_display, values_display), do_msg);
 
+        emit object_changed(dn);
+
         return true;
     } else {
         const QString context = QString(tr("Failed to change attribute \"%1\" of object \"%2\" from \"%3\" to \"%4\"")).arg(attribute, name, old_values_display, values_display);
@@ -425,6 +427,8 @@ bool AdInterface::attribute_add_value(const QString &dn, const QString &attribut
 
         success_status_message(context, do_msg);
 
+        emit object_changed(dn);
+
         return true;
     } else {
         const QString context = QString(tr("Failed to add value \"%1\" for attribute \"%2\" of object \"%3\"")).arg(new_display_value, attribute, name);
@@ -447,6 +451,8 @@ bool AdInterface::attribute_delete_value(const QString &dn, const QString &attri
         const QString context = QString(tr("Deleted value \"%1\" for attribute \"%2\" of object \"%3\"")).arg(value_display, attribute, name);
 
         success_status_message(context, do_msg);
+
+        emit object_changed(dn);
 
         return true;
     } else {
@@ -561,7 +567,7 @@ bool AdInterface::object_rename(const QString &dn, const QString &new_name) {
     if (result == AD_SUCCESS) {
         success_status_message(QString(tr("Renamed object \"%1\" to \"%2\"")).arg(old_name, new_name));
 
-        emit object_changed(dn);
+        emit object_deleted(dn);
         emit object_added(new_dn);
 
         return true;

--- a/src/admc/ad_interface.cpp
+++ b/src/admc/ad_interface.cpp
@@ -132,29 +132,6 @@ bool AdInterface::connect() {
     }
 }
 
-void AdInterface::refresh() {
-    // TODO: remove? rework!
-    // emit modified();
-}
-
-void AdInterface::start_batch() {
-    if (batch_in_progress) {
-        printf("Called start_batch() while batch is in progress!\n");
-        return;
-    }
-
-    batch_in_progress = true;
-}
-
-void AdInterface::end_batch() {
-    if (!batch_in_progress) {
-        printf("Called end_batch() before start_batch()!\n");
-        return;
-    }
-
-    batch_in_progress = false;
-}
-
 AdConfig *AdInterface::config() const {
     return m_config;
 }
@@ -584,7 +561,7 @@ bool AdInterface::object_rename(const QString &dn, const QString &new_name) {
     if (result == AD_SUCCESS) {
         success_status_message(QString(tr("Renamed object \"%1\" to \"%2\"")).arg(old_name, new_name));
 
-        emit object_deleted(dn);
+        emit object_changed(dn);
         emit object_added(new_dn);
 
         return true;
@@ -1097,10 +1074,6 @@ QString AdInterface::sysvol_path_to_smb(const QString &sysvol_path) const {
     out = QString("smb://%1/%2").arg(m_host, out);
 
     return out;
-}
-
-void AdInterface::emit_object_changed(const QString &dn) {
-    emit object_changed(dn);
 }
 
 AdInterface::AdInterface()

--- a/src/admc/ad_interface.cpp
+++ b/src/admc/ad_interface.cpp
@@ -1099,6 +1099,10 @@ QString AdInterface::sysvol_path_to_smb(const QString &sysvol_path) const {
     return out;
 }
 
+void AdInterface::emit_object_changed(const QString &dn) {
+    emit object_changed(dn);
+}
+
 AdInterface::AdInterface()
 : QObject()
 {

--- a/src/admc/ad_interface.h
+++ b/src/admc/ad_interface.h
@@ -62,15 +62,6 @@ public:
 
     bool connect();
 
-    void refresh();
-
-    // Use this if you are doing a series of AD modifications.
-    // During the batch, modified() signals won't be emitted
-    // and once the batch is complete one modified() signal
-    // is emitted, so that GUI is reloaded only once.
-    void start_batch();
-    void end_batch();
-
     AdConfig *config() const;
     QString domain() const;
     QString domain_head() const;
@@ -115,16 +106,9 @@ public:
 
     QString sysvol_path_to_smb(const QString &sysvol_path) const;
 
-    void emit_object_changed(const QString &dn);
-
 signals:
     // Emitted when connected successfully to a server
     void connected();
-
-    // Emitted when a f-n that modifies server state is
-    // used. Widgets should connect to this signal and
-    // reload updated server state in the slot.
-    void modified();
 
     void search_has_multiple_pages();
 
@@ -143,8 +127,6 @@ private:
     QString m_schema_dn;
     QString m_host;
 
-    bool batch_in_progress = false;
-        
     AdInterface();
 
     void success_status_message(const QString &msg, const DoStatusMsg do_msg = DoStatusMsg_Yes);

--- a/src/admc/ad_interface.h
+++ b/src/admc/ad_interface.h
@@ -115,7 +115,7 @@ public:
 
     QString sysvol_path_to_smb(const QString &sysvol_path) const;
 
-    void emit_object_added(const QString &dn);
+    void emit_object_changed(const QString &dn);
 
 signals:
     // Emitted when connected successfully to a server

--- a/src/admc/ad_interface.h
+++ b/src/admc/ad_interface.h
@@ -115,6 +115,8 @@ public:
 
     QString sysvol_path_to_smb(const QString &sysvol_path) const;
 
+    void emit_object_added(const QString &dn);
+
 signals:
     // Emitted when connected successfully to a server
     void connected();
@@ -125,6 +127,11 @@ signals:
     void modified();
 
     void search_has_multiple_pages();
+
+    // These signals are for ObjectModel
+    void object_added(const QString &dn);
+    void object_deleted(const QString &dn);
+    void object_changed(const QString &dn);
 
 private:
     LDAP *ld;
@@ -140,7 +147,6 @@ private:
         
     AdInterface();
 
-    void emit_modified();
     void success_status_message(const QString &msg, const DoStatusMsg do_msg = DoStatusMsg_Yes);
     void error_status_message(const QString &context, const QString &error, const DoStatusMsg do_msg = DoStatusMsg_Yes);
     QString default_error() const;
@@ -152,6 +158,5 @@ private:
 };
 
 AdInterface *AD();
-
 
 #endif /* AD_INTERFACE_H */

--- a/src/admc/ad_utils.cpp
+++ b/src/admc/ad_utils.cpp
@@ -198,9 +198,15 @@ QString dn_get_name(const QString &dn) {
     return name;
 }
 
-QString dn_get_parent_canonical(const QString &dn) {
+QString dn_get_parent(const QString &dn) {
     const int comma_i = dn.indexOf(',');
     const QString parent_dn = dn.mid(comma_i + 1);
+
+    return parent_dn;
+}
+
+QString dn_get_parent_canonical(const QString &dn) {
+    const QString parent_dn = dn_get_parent(dn);
 
     return dn_canonical(parent_dn);
 }

--- a/src/admc/ad_utils.h
+++ b/src/admc/ad_utils.h
@@ -50,6 +50,7 @@ QString extract_rid_from_sid(const QByteArray &sid);
 bool ad_string_to_bool(const QString &string);
 
 QString dn_get_name(const QString &dn);
+QString dn_get_parent(const QString &dn);
 QString dn_get_parent_canonical(const QString &dn);
 QString dn_rename(const QString &dn, const QString &new_name);
 QString dn_canonical(const QString &dn);

--- a/src/admc/advanced_view_proxy.cpp
+++ b/src/admc/advanced_view_proxy.cpp
@@ -1,0 +1,56 @@
+/*
+ * ADMC - AD Management Center
+ *
+ * Copyright (C) 2020 BaseALT Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "advanced_view_proxy.h"
+
+#include "object_model.h"
+#include "settings.h"
+
+AdvancedViewProxy::AdvancedViewProxy(QObject *parent)
+: QSortFilterProxyModel(parent) {
+    const BoolSettingSignal *signal = SETTINGS()->get_bool_signal(BoolSetting_AdvancedView);
+
+    connect(
+        signal, &BoolSettingSignal::changed,
+        this, &AdvancedViewProxy::on_setting_changed);
+    on_setting_changed();
+}
+
+void AdvancedViewProxy::on_setting_changed() {
+    advanced_view = SETTINGS()->get_bool(BoolSetting_AdvancedView);
+    invalidateFilter();
+}
+
+bool AdvancedViewProxy::filterAcceptsRow(int source_row, const QModelIndex &source_parent) const {
+    if (advanced_view) {
+        // When advanced view is ON, accept all objects
+        return true;
+    } else {
+        // When advanced view is OFF, filter out "advanced
+        // view only" objects
+        const QModelIndex index = sourceModel()->index(source_row, 0, source_parent);
+        const bool advanced_view_only = index.data(ObjectModel::Roles::AdvancedViewOnly).toBool();
+
+        if (advanced_view_only) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+}

--- a/src/admc/advanced_view_proxy.h
+++ b/src/admc/advanced_view_proxy.h
@@ -20,6 +20,12 @@
 #ifndef ADVANCED_VIEW_PROXY_H
 #define ADVANCED_VIEW_PROXY_H
 
+/**
+ * Proxy model for object model. Filters out objects that
+ * are advanced view only if advanced view is turned off. If
+ * advanced view is ON, shows all objects.
+ */
+
 #include <QSortFilterProxyModel>
 
 class AdvancedViewProxy final : public QSortFilterProxyModel {

--- a/src/admc/advanced_view_proxy.h
+++ b/src/admc/advanced_view_proxy.h
@@ -17,52 +17,24 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONTAINERS_WIDGET_H
-#define CONTAINERS_WIDGET_H
+#ifndef ADVANCED_VIEW_PROXY_H
+#define ADVANCED_VIEW_PROXY_H
 
-#include <QWidget>
 #include <QSortFilterProxyModel>
 
-class QItemSelection;
-class AdvancedViewProxy;
-class QTreeView;
-class ObjectModel;
-class ContainersFilterProxy;
-
-class ContainersWidget final : public QWidget {
+class AdvancedViewProxy final : public QSortFilterProxyModel {
 Q_OBJECT
 
 public:
-    ContainersWidget(ObjectModel *model, QWidget *parent);
-
-signals:
-    void selected_changed(const QModelIndex &source_index);
+    AdvancedViewProxy(QObject *parent);
 
 private slots:
-    void on_selection_changed(const QItemSelection &selected, const QItemSelection &);
-    void on_context_menu(const QPoint pos);
-
-private:
-    QTreeView *view;
-    AdvancedViewProxy *advanced_view_proxy;
-    ContainersFilterProxy *containers_proxy;
-
-    void showEvent(QShowEvent *event);
-};
-
-class ContainersFilterProxy final : public QSortFilterProxyModel {
-Q_OBJECT
-
-public:
-    ContainersFilterProxy(QObject *parent);
-
-private slots:
-    void on_show_non_containers();
+    void on_setting_changed();
     
 private:
-    bool show_non_containers;
-
+    bool advanced_view;
+    
     bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const override;
 };
 
-#endif /* CONTAINERS_WIDGET_H */
+#endif /* ADVANCED_VIEW_PROXY_H */

--- a/src/admc/containers_proxy.cpp
+++ b/src/admc/containers_proxy.cpp
@@ -1,0 +1,48 @@
+/*
+ * ADMC - AD Management Center
+ *
+ * Copyright (C) 2020 BaseALT Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "containers_proxy.h"
+
+#include "settings.h"
+#include "object_model.h"
+
+ContainersProxy::ContainersProxy(QObject *parent)
+: QSortFilterProxyModel(parent) {
+    const BoolSettingSignal *show_non_containers_signal = SETTINGS()->get_bool_signal(BoolSetting_ShowNonContainersInContainersTree);
+    connect(
+        show_non_containers_signal, &BoolSettingSignal::changed,
+        this, &ContainersProxy::on_show_non_containers);
+    on_show_non_containers();
+}
+
+void ContainersProxy::on_show_non_containers() {
+    show_non_containers = SETTINGS()->get_bool(BoolSetting_ShowNonContainersInContainersTree);
+    invalidateFilter();
+}
+
+bool ContainersProxy::filterAcceptsRow(int source_row, const QModelIndex &source_parent) const {
+    if (show_non_containers) {
+        return true;
+    } else {
+        const QModelIndex index = sourceModel()->index(source_row, 0, source_parent);
+        const bool is_container = index.data(ObjectModel::Roles::IsContainer).toBool();
+
+        return is_container;
+    }
+}

--- a/src/admc/containers_proxy.h
+++ b/src/admc/containers_proxy.h
@@ -17,36 +17,31 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONTAINERS_WIDGET_H
-#define CONTAINERS_WIDGET_H
+#ifndef CONTAINERS_PROXY_H
+#define CONTAINERS_PROXY_H
 
-#include <QWidget>
+#include <QSortFilterProxyModel>
 
-class QItemSelection;
-class AdvancedViewProxy;
-class QTreeView;
-class ObjectModel;
 class ContainersProxy;
 
-class ContainersWidget final : public QWidget {
+/**
+ * Filters out objects that aren't containers. If "Show
+ * non-containers" setting is turned on, shows all objects.
+ */
+
+class ContainersProxy final : public QSortFilterProxyModel {
 Q_OBJECT
 
 public:
-    ContainersWidget(ObjectModel *model, QWidget *parent);
-
-signals:
-    void selected_changed(const QModelIndex &source_index);
+    ContainersProxy(QObject *parent);
 
 private slots:
-    void on_selection_changed(const QItemSelection &selected, const QItemSelection &);
-    void on_context_menu(const QPoint pos);
-
+    void on_show_non_containers();
+    
 private:
-    QTreeView *view;
-    AdvancedViewProxy *advanced_view_proxy;
-    ContainersProxy *containers_proxy;
+    bool show_non_containers;
 
-    void showEvent(QShowEvent *event);
+    bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const override;
 };
 
-#endif /* CONTAINERS_WIDGET_H */
+#endif /* CONTAINERS_PROXY_H */

--- a/src/admc/containers_proxy.h
+++ b/src/admc/containers_proxy.h
@@ -25,8 +25,9 @@
 class ContainersProxy;
 
 /**
- * Filters out objects that aren't containers. If "Show
- * non-containers" setting is turned on, shows all objects.
+ * Proxy model for object model. Filters out objects that
+ * aren't containers. If "Show non-containers" setting is
+ * turned on, shows all objects.
  */
 
 class ContainersProxy final : public QSortFilterProxyModel {

--- a/src/admc/containers_widget.cpp
+++ b/src/admc/containers_widget.cpp
@@ -26,6 +26,7 @@
 #include "ad_interface.h"
 #include "ad_object.h"
 #include "filter.h"
+#include "object_model.h"
 
 #include <QTreeView>
 #include <QIcon>
@@ -35,18 +36,12 @@
 #include <QVBoxLayout>
 #include <QDebug>
 
-enum ContainersColumn {
-    ContainersColumn_Name,
-    ContainersColumn_DN,
-    ContainersColumn_COUNT,
-};
-
 QStandardItem *make_row(QStandardItem *parent, const AdObject &object);
 
 ContainersWidget::ContainersWidget(QWidget *parent)
 : QWidget(parent)
 {
-    model = new ContainersModel(this);
+    model = new ObjectModel(ObjectModel::Column::COUNT, ObjectModel::Column::DN, this);
 
     proxy = new ContainersFilterProxy(this);
 
@@ -60,12 +55,12 @@ ContainersWidget::ContainersWidget(QWidget *parent)
     view->setDragDropMode(QAbstractItemView::DragDrop);
     view->setAllColumnsShowFocus(true);
     view->setSortingEnabled(true);
-    view->sortByColumn(ContainersColumn_Name, Qt::AscendingOrder);
+    view->sortByColumn(ObjectModel::Column::Name, Qt::AscendingOrder);
 
     proxy->setSourceModel(model);
     view->setModel(proxy);
 
-    setup_column_toggle_menu(view, model, {ContainersColumn_Name});
+    setup_column_toggle_menu(view, model, {ObjectModel::Column::Name});
 
     // Insert label into layout
     const auto layout = new QVBoxLayout();
@@ -81,13 +76,6 @@ ContainersWidget::ContainersWidget(QWidget *parent)
     QObject::connect(
         view, &QWidget::customContextMenuRequested,
         this, &ContainersWidget::on_context_menu);
-
-    // Make row for head object
-    QStandardItem *invis_root = model->invisibleRootItem();
-    const QString head_dn = AD()->domain_head();
-    const AdObject head_object = AD()->search_object(head_dn);
-
-    make_row(invis_root, head_object);
 };
 
 // Transform selected index into source index and pass it on
@@ -103,13 +91,13 @@ void ContainersWidget::on_selection_changed(const QItemSelection &selected, cons
     const QModelIndex index = proxy->mapToSource(index_proxy);
     model->fetchMore(index);
 
-    const QString dn = get_dn_from_index(index, ContainersColumn_DN);
+    const QString dn = get_dn_from_index(index, ObjectModel::Column::DN);
 
     emit selected_changed(dn);
 }
 
 void ContainersWidget::on_context_menu(const QPoint pos) {
-    const QString dn = get_dn_from_pos(pos, view, ContainersColumn_DN);
+    const QString dn = get_dn_from_pos(pos, view, ObjectModel::Column::DN);
     if (dn.isEmpty()) {
         return;
     }
@@ -121,131 +109,9 @@ void ContainersWidget::on_context_menu(const QPoint pos) {
 void ContainersWidget::showEvent(QShowEvent *event) {
     resize_columns(view,
     {
-        {ContainersColumn_Name, 0.5},
-        {ContainersColumn_DN, 0.5},
+        {ObjectModel::Column::Name, 0.5},
+        {ObjectModel::Column::DN, 0.5},
     });
-}
-
-ContainersModel::ContainersModel(QObject *parent)
-: ObjectModel(ContainersColumn_COUNT, ContainersColumn_DN, parent)
-{
-    set_horizontal_header_labels_from_map(this, {
-        {ContainersColumn_Name, tr("Name")},
-        {ContainersColumn_DN, tr("DN")}
-    });
-}
-
-bool ContainersModel::canFetchMore(const QModelIndex &parent) const {
-    if (!parent.isValid()) {
-        return false;
-    }
-
-    bool can_fetch = parent.data(ContainersModel::Roles::CanFetch).toBool();
-
-    return can_fetch;
-}
-
-void ContainersModel::fetchMore(const QModelIndex &parent) {
-    if (!parent.isValid() || !canFetchMore(parent)) {
-        return;
-    }
-
-    const QString parent_dn = get_dn_from_index(parent, ContainersColumn_DN);
-
-    QStandardItem *parent_item = itemFromIndex(parent);
-
-    // Add children
-    const QList<QString> search_attributes = {ATTRIBUTE_NAME, ATTRIBUTE_DISTINGUISHED_NAME, ATTRIBUTE_OBJECT_CLASS};
-    const QString filter = current_advanced_view_filter();
-    const QHash<QString, AdObject> search_results = AD()->search(filter, search_attributes, SearchScope_Children, parent_dn);
-
-    for (const AdObject object : search_results.values()) {
-        make_row(parent_item, object);
-    }
-
-    // Unset CanFetch flag
-    parent_item->setData(false, ContainersModel::Roles::CanFetch);
-
-    // In dev mode, load configuration and schema objects
-    // NOTE: have to manually add configuration and schema objects because they aren't searchable
-    const bool dev_mode = SETTINGS()->get_bool(BoolSetting_DevMode);
-    if (dev_mode) {
-        const QString search_base = AD()->domain_head();
-        const QString configuration_dn = AD()->configuration_dn();
-        const QString schema_dn = AD()->schema_dn();
-
-        const auto load_manually =
-        [parent_item](const QString &child) {
-            const AdObject object = AD()->search_object(child);
-            make_row(parent_item, object);
-        };
-
-        if (parent_dn == search_base) {
-            load_manually(configuration_dn);
-        } else if (parent_dn == configuration_dn) {
-            load_manually(schema_dn);
-        }
-    }
-}
-
-// Override this so that unexpanded and unfetched items show the expander even though they technically don't have any children loaded
-// NOTE: expander is show if hasChildren returns true
-bool ContainersModel::hasChildren(const QModelIndex &parent = QModelIndex()) const {
-    if (canFetchMore(parent)) {
-        return true;
-    } else {
-        return QStandardItemModel::hasChildren(parent);
-    }
-}
-
-// Make row in model at given parent based on object with given dn
-QStandardItem *make_row(QStandardItem *parent, const AdObject &object) {
-    const bool is_container =
-    [object]() {
-        static const QList<QString> accepted_classes =
-        []() {
-            QList<QString> out = ADCONFIG()->get_filter_containers();
-
-            // Make configuration and schema pass filter in dev mode so they are visible and can be fetched
-            const bool dev_mode = SETTINGS()->get_bool(BoolSetting_DevMode);
-            if (dev_mode) {
-                out.append({CLASS_CONFIGURATION, CLASS_dMD});
-            }
-
-            // TODO: domain not included for some reason, so add it ourselves
-            out.append(CLASS_DOMAIN);
-            
-            return out;
-        }();
-
-        // NOTE: compare against all classes of object, not just the most derived one
-        const QList<QString> object_classes = object.get_strings(ATTRIBUTE_OBJECT_CLASS);
-        for (const auto acceptable_class : accepted_classes) {
-            if (object_classes.contains(acceptable_class)) {
-                return true;
-            }
-        }
-
-        return false;
-    }();
-
-    const QList<QStandardItem *> row = make_item_row(ContainersColumn_COUNT);
-    
-    const QString name = object.get_string(ATTRIBUTE_NAME);
-    const QString dn = object.get_dn();
-    row[ContainersColumn_Name]->setText(name);
-    row[ContainersColumn_DN]->setText(dn);
-
-    const QIcon icon = object.get_icon();
-    row[0]->setIcon(icon);
-
-    // Can fetch(expand) object if it's a container
-    row[0]->setData(is_container, ContainersModel::Roles::CanFetch);
-    row[0]->setData(is_container, ContainersModel::Roles::IsContainer);
-
-    parent->appendRow(row);
-
-    return row[0];
 }
 
 ContainersFilterProxy::ContainersFilterProxy(QObject *parent)
@@ -269,7 +135,7 @@ bool ContainersFilterProxy::filterAcceptsRow(int source_row, const QModelIndex &
         return true;
     } else {
         const QModelIndex index = sourceModel()->index(source_row, 0, source_parent);
-        const bool is_container = index.data(ContainersModel::Roles::IsContainer).toBool();
+        const bool is_container = index.data(ObjectModel::Roles::IsContainer).toBool();
 
         return is_container;
     }

--- a/src/admc/containers_widget.cpp
+++ b/src/admc/containers_widget.cpp
@@ -38,10 +38,10 @@
 
 QStandardItem *make_row(QStandardItem *parent, const AdObject &object);
 
-ContainersWidget::ContainersWidget(QWidget *parent)
+ContainersWidget::ContainersWidget(ObjectModel *model_arg, QWidget *parent)
 : QWidget(parent)
 {
-    model = new ObjectModel(ObjectModel::Column::COUNT, ObjectModel::Column::DN, this);
+    model = model_arg;
 
     proxy = new ContainersFilterProxy(this);
 
@@ -86,14 +86,10 @@ void ContainersWidget::on_selection_changed(const QItemSelection &selected, cons
         return;
     }
 
-    // Fetch selected object to remove expander if it has not children
-    const QModelIndex index_proxy = indexes[0];
-    const QModelIndex index = proxy->mapToSource(index_proxy);
-    model->fetchMore(index);
-
-    const QString dn = get_dn_from_index(index, ObjectModel::Column::DN);
-
-    emit selected_changed(dn);
+    const QModelIndex proxy_index = indexes[0];
+    const QModelIndex source_index = proxy->mapToSource(proxy_index);
+    
+    emit selected_changed(source_index);
 }
 
 void ContainersWidget::on_context_menu(const QPoint pos) {

--- a/src/admc/containers_widget.cpp
+++ b/src/admc/containers_widget.cpp
@@ -55,12 +55,12 @@ ContainersWidget::ContainersWidget(ObjectModel *model_arg, QWidget *parent)
     view->setDragDropMode(QAbstractItemView::DragDrop);
     view->setAllColumnsShowFocus(true);
     view->setSortingEnabled(true);
-    view->sortByColumn(ObjectModel::Column::Name, Qt::AscendingOrder);
+    view->sortByColumn(ADCONFIG()->get_column_index(ATTRIBUTE_NAME), Qt::AscendingOrder);
 
     proxy->setSourceModel(model);
     view->setModel(proxy);
 
-    setup_column_toggle_menu(view, model, {ObjectModel::Column::Name});
+    setup_column_toggle_menu(view, model, {ADCONFIG()->get_column_index(ATTRIBUTE_NAME)});
 
     // Insert label into layout
     const auto layout = new QVBoxLayout();
@@ -93,7 +93,7 @@ void ContainersWidget::on_selection_changed(const QItemSelection &selected, cons
 }
 
 void ContainersWidget::on_context_menu(const QPoint pos) {
-    const QString dn = get_dn_from_pos(pos, view, ObjectModel::Column::DN);
+    const QString dn = get_dn_from_pos(pos, view, ADCONFIG()->get_column_index(ATTRIBUTE_DISTINGUISHED_NAME));
     if (dn.isEmpty()) {
         return;
     }
@@ -105,8 +105,8 @@ void ContainersWidget::on_context_menu(const QPoint pos) {
 void ContainersWidget::showEvent(QShowEvent *event) {
     resize_columns(view,
     {
-        {ObjectModel::Column::Name, 0.5},
-        {ObjectModel::Column::DN, 0.5},
+        {ADCONFIG()->get_column_index(ATTRIBUTE_NAME), 0.5},
+        {ADCONFIG()->get_column_index(ATTRIBUTE_DISTINGUISHED_NAME), 0.5},
     });
 }
 

--- a/src/admc/containers_widget.h
+++ b/src/admc/containers_widget.h
@@ -20,15 +20,13 @@
 #ifndef CONTAINERS_WIDGET_H
 #define CONTAINERS_WIDGET_H
 
-#include "object_model.h"
-
 #include <QWidget>
 #include <QSortFilterProxyModel>
 
 class QItemSelection;
 class AdvancedViewProxy;
 class QTreeView;
-class ContainersModel;
+class ObjectModel;
 class ContainersFilterProxy;
 
 class ContainersWidget final : public QWidget {
@@ -36,7 +34,7 @@ Q_OBJECT
 
 public:
     ContainersWidget(QWidget *parent);
-    ContainersModel *model;
+    ObjectModel *model;
 
 signals:
     void selected_changed(const QString &dn);
@@ -50,24 +48,6 @@ private:
     ContainersFilterProxy *proxy;
 
     void showEvent(QShowEvent *event);
-};
-
-class ContainersModel final : public ObjectModel {
-Q_OBJECT
-
-public:
-    enum Roles {
-        CanFetch = Qt::UserRole + 1,
-        IsContainer = Qt::UserRole + 2,
-    };
-
-    ContainersModel(QObject *parent);
-
-    bool canFetchMore(const QModelIndex &parent) const;
-    void fetchMore(const QModelIndex &parent);
-    bool hasChildren(const QModelIndex &parent) const override;
-
-private slots:
 };
 
 class ContainersFilterProxy final : public QSortFilterProxyModel {

--- a/src/admc/containers_widget.h
+++ b/src/admc/containers_widget.h
@@ -33,17 +33,17 @@ class ContainersWidget final : public QWidget {
 Q_OBJECT
 
 public:
-    ContainersWidget(QWidget *parent);
-    ObjectModel *model;
+    ContainersWidget(ObjectModel *model_arg, QWidget *parent);
 
 signals:
-    void selected_changed(const QString &dn);
+    void selected_changed(const QModelIndex &source_index);
 
 private slots:
     void on_selection_changed(const QItemSelection &selected, const QItemSelection &);
     void on_context_menu(const QPoint pos);
 
 private:
+    ObjectModel *model;
     QTreeView *view;
     ContainersFilterProxy *proxy;
 

--- a/src/admc/containers_widget.h
+++ b/src/admc/containers_widget.h
@@ -22,6 +22,7 @@
 
 #include <QWidget>
 #include <QSortFilterProxyModel>
+#include <QHeaderView>
 
 class QItemSelection;
 class AdvancedViewProxy;

--- a/src/admc/containers_widget.h
+++ b/src/admc/containers_widget.h
@@ -23,11 +23,13 @@
 #include "object_model.h"
 
 #include <QWidget>
+#include <QSortFilterProxyModel>
 
 class QItemSelection;
 class AdvancedViewProxy;
 class QTreeView;
 class ContainersModel;
+class ContainersFilterProxy;
 
 class ContainersWidget final : public QWidget {
 Q_OBJECT
@@ -45,8 +47,8 @@ private slots:
 
 private:
     QTreeView *view;
+    ContainersFilterProxy *proxy;
 
-    void reload();
     void showEvent(QShowEvent *event);
 };
 
@@ -56,6 +58,7 @@ Q_OBJECT
 public:
     enum Roles {
         CanFetch = Qt::UserRole + 1,
+        IsContainer = Qt::UserRole + 2,
     };
 
     ContainersModel(QObject *parent);
@@ -65,6 +68,21 @@ public:
     bool hasChildren(const QModelIndex &parent) const override;
 
 private slots:
+};
+
+class ContainersFilterProxy final : public QSortFilterProxyModel {
+Q_OBJECT
+
+public:
+    ContainersFilterProxy(QObject *parent);
+
+private slots:
+    void on_show_non_containers();
+    
+private:
+    bool show_non_containers;
+
+    bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const override;
 };
 
 #endif /* CONTAINERS_WIDGET_H */

--- a/src/admc/contents_widget.cpp
+++ b/src/admc/contents_widget.cpp
@@ -24,6 +24,7 @@
 #include "ad_config.h"
 #include "object_model.h"
 #include "advanced_view_proxy.h"
+#include "object_context_menu.h"
 #include "utils.h"
 
 #include <QVBoxLayout>
@@ -66,6 +67,20 @@ ContentsWidget::ContentsWidget(ObjectModel *model_arg, ContainersWidget *contain
     connect(
         containers_widget, &ContainersWidget::selected_changed,
         this, &ContentsWidget::on_containers_selected_changed);
+
+    QObject::connect(
+        view, &QWidget::customContextMenuRequested,
+        this, &ContentsWidget::on_context_menu);
+}
+
+void ContentsWidget::on_context_menu(const QPoint pos) {
+    const QString dn = get_dn_from_pos(pos, view, ADCONFIG()->get_column_index(ATTRIBUTE_DISTINGUISHED_NAME));
+    if (dn.isEmpty()) {
+        return;
+    }
+
+    ObjectContextMenu context_menu(dn, view);
+    exec_menu_from_view(&context_menu, view, pos);
 }
 
 void ContentsWidget::on_containers_selected_changed(const QModelIndex &source_index) {

--- a/src/admc/contents_widget.cpp
+++ b/src/admc/contents_widget.cpp
@@ -29,13 +29,12 @@
 #include "utils.h"
 
 #include <QVBoxLayout>
-#include <QAction>
 #include <QDebug>
 #include <QTreeView>
 #include <QHeaderView>
 #include <QLabel>
 
-ContentsWidget::ContentsWidget(ObjectModel *model_arg, ContainersWidget *containers_widget, const QAction *filter_contents_action)
+ContentsWidget::ContentsWidget(ObjectModel *model_arg, ContainersWidget *containers_widget)
 : QWidget()
 {   
     model = model_arg;

--- a/src/admc/contents_widget.cpp
+++ b/src/admc/contents_widget.cpp
@@ -22,8 +22,6 @@
 #include "settings.h"
 #include "ad_interface.h"
 #include "ad_config.h"
-#include "object_list_widget.h"
-#include "contents_filter_dialog.h"
 #include "object_model.h"
 #include "advanced_view_proxy.h"
 #include "utils.h"
@@ -37,7 +35,6 @@
 ContentsWidget::ContentsWidget(ObjectModel *model, ContainersWidget *containers_widget, const QAction *filter_contents_action)
 : QWidget()
 {   
-    // object_list = new ObjectListWidget(ObjectListWidgetType_Contents);
     view = new QTreeView(this);
     view->setAcceptDrops(true);
     view->setEditTriggers(QAbstractItemView::NoEditTriggers);
@@ -64,44 +61,14 @@ ContentsWidget::ContentsWidget(ObjectModel *model, ContainersWidget *containers_
     layout->setSpacing(0);
     layout->addWidget(view);
 
-    filter_dialog = new ContentsFilterDialog(this);
-
-    connect(
-        filter_dialog, &ContentsFilterDialog::filter_changed,
-        this, &ContentsWidget::load_filter);
-
     connect(
         containers_widget, &ContainersWidget::selected_changed,
         this, &ContentsWidget::on_containers_selected_changed);
-    connect(
-        AD(), &AdInterface::modified,
-        this, &ContentsWidget::on_ad_modified);
-
-    connect(
-        filter_contents_action, &QAction::triggered,
-        [this]() {
-            filter_dialog->open();
-        });
 }
 
 void ContentsWidget::on_containers_selected_changed(const QModelIndex &source_index) {
     const QModelIndex proxy_index = advanced_view_proxy->mapFromSource(source_index);
     view->setRootIndex(proxy_index);
-}
-
-void ContentsWidget::on_ad_modified() {
-    // change_target(target_dn);
-}
-
-void ContentsWidget::load_filter(const QString &filter) {
-    // qDebug() << "Contents filter:" << filter;
-    // object_list->load_children(target_dn, filter);
-}
-
-void ContentsWidget::change_target(const QString &dn) {
-    // target_dn = dn;
-
-    // object_list->load_children(target_dn);
 }
 
 void ContentsWidget::showEvent(QShowEvent *event) {

--- a/src/admc/contents_widget.cpp
+++ b/src/admc/contents_widget.cpp
@@ -25,6 +25,7 @@
 #include "object_model.h"
 #include "advanced_view_proxy.h"
 #include "object_context_menu.h"
+#include "details_dialog.h"
 #include "utils.h"
 
 #include <QVBoxLayout>
@@ -51,6 +52,8 @@ ContentsWidget::ContentsWidget(ObjectModel *model_arg, ContainersWidget *contain
     view->setAllColumnsShowFocus(true);
     view->setSortingEnabled(true);
     view->header()->setSectionsMovable(true);
+
+    DetailsDialog::connect_to_open_by_double_click(view, ADCONFIG()->get_column_index(ATTRIBUTE_DISTINGUISHED_NAME));
 
     advanced_view_proxy = new AdvancedViewProxy(this);
 

--- a/src/admc/contents_widget.cpp
+++ b/src/admc/contents_widget.cpp
@@ -130,7 +130,7 @@ void ContentsWidget::on_containers_selected_changed(const QModelIndex &source_in
 
     const QString label_text =
     [this, source_index]() {
-        const QString object_count_string = tr("%n object(s)", "", model->rowCount());
+        const QString object_count_string = tr("%n object(s)", "", model->rowCount(source_index));
 
         const QString parent_name = source_index.data().toString();
 

--- a/src/admc/contents_widget.cpp
+++ b/src/admc/contents_widget.cpp
@@ -23,21 +23,38 @@
 #include "ad_interface.h"
 #include "object_list_widget.h"
 #include "contents_filter_dialog.h"
+#include "object_model.h"
 
 #include <QVBoxLayout>
 #include <QAction>
 #include <QDebug>
+#include <QTreeView>
+#include <QHeaderView>
 
-ContentsWidget::ContentsWidget(ContainersWidget *containers_widget, const QAction *filter_contents_action)
+ContentsWidget::ContentsWidget(ObjectModel *model, ContainersWidget *containers_widget, const QAction *filter_contents_action)
 : QWidget()
 {   
-    object_list = new ObjectListWidget(ObjectListWidgetType_Contents);
+    // object_list = new ObjectListWidget(ObjectListWidgetType_Contents);
+    view = new QTreeView(this);
+    view->setAcceptDrops(true);
+    view->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    view->setSelectionMode(QAbstractItemView::SingleSelection);
+    view->setRootIsDecorated(false);
+    view->setItemsExpandable(false);
+    view->setExpandsOnDoubleClick(false);
+    view->setContextMenuPolicy(Qt::CustomContextMenu);
+    view->setDragDropMode(QAbstractItemView::DragDrop);
+    view->setAllColumnsShowFocus(true);
+    view->setSortingEnabled(true);
+    view->header()->setSectionsMovable(true);
+
+    view->setModel(model);
 
     const auto layout = new QVBoxLayout();
     setLayout(layout);
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(0);
-    layout->addWidget(object_list);
+    layout->addWidget(view);
 
     filter_dialog = new ContentsFilterDialog(this);
 
@@ -66,22 +83,23 @@ ContentsWidget::ContentsWidget(ContainersWidget *containers_widget, const QActio
         });
 }
 
-void ContentsWidget::on_containers_selected_changed(const QString &dn) {
-    object_list->reset_name_filter();
-    change_target(dn);
+void ContentsWidget::on_containers_selected_changed(const QModelIndex &source_index) {
+    // object_list->reset_name_filter();
+    // change_target(dn);
+    view->setRootIndex(source_index);
 }
 
 void ContentsWidget::on_ad_modified() {
-    change_target(target_dn);
+    // change_target(target_dn);
 }
 
 void ContentsWidget::load_filter(const QString &filter) {
-    qDebug() << "Contents filter:" << filter;
-    object_list->load_children(target_dn, filter);
+    // qDebug() << "Contents filter:" << filter;
+    // object_list->load_children(target_dn, filter);
 }
 
 void ContentsWidget::change_target(const QString &dn) {
-    target_dn = dn;
+    // target_dn = dn;
 
-    object_list->load_children(target_dn);
+    // object_list->load_children(target_dn);
 }

--- a/src/admc/contents_widget.cpp
+++ b/src/admc/contents_widget.cpp
@@ -21,9 +21,11 @@
 #include "containers_widget.h"
 #include "settings.h"
 #include "ad_interface.h"
+#include "ad_config.h"
 #include "object_list_widget.h"
 #include "contents_filter_dialog.h"
 #include "object_model.h"
+#include "utils.h"
 
 #include <QVBoxLayout>
 #include <QAction>
@@ -49,6 +51,8 @@ ContentsWidget::ContentsWidget(ObjectModel *model, ContainersWidget *containers_
     view->header()->setSectionsMovable(true);
 
     view->setModel(model);
+
+    setup_column_toggle_menu(view, model, {ADCONFIG()->get_column_index(ATTRIBUTE_NAME), ADCONFIG()->get_column_index(ATTRIBUTE_OBJECT_CLASS), ADCONFIG()->get_column_index(ATTRIBUTE_DESCRIPTION)});
 
     const auto layout = new QVBoxLayout();
     setLayout(layout);
@@ -102,4 +106,12 @@ void ContentsWidget::change_target(const QString &dn) {
     // target_dn = dn;
 
     // object_list->load_children(target_dn);
+}
+
+void ContentsWidget::showEvent(QShowEvent *event) {
+    resize_columns(view,
+    {
+        {ADCONFIG()->get_column_index(ATTRIBUTE_NAME), 0.4},
+        {ADCONFIG()->get_column_index(ATTRIBUTE_OBJECT_CLASS), 0.4},
+    });
 }

--- a/src/admc/contents_widget.h
+++ b/src/admc/contents_widget.h
@@ -24,9 +24,7 @@
 #include <QString>
 
 class ContainersWidget;
-class ObjectListWidget;
 class QAction;
-class ContentsFilterDialog;
 class ObjectModel;
 class QTreeView;
 class QModelIndex;
@@ -46,16 +44,12 @@ public:
 
 private slots:
     void on_containers_selected_changed(const QModelIndex &source_index);
-    void on_ad_modified();
-    void load_filter(const QString &filter);
 
 private:
     QString target_dn;
     QTreeView *view;
-    ContentsFilterDialog *filter_dialog;
     AdvancedViewProxy *advanced_view_proxy;
 
-    void change_target(const QString &dn);
     void showEvent(QShowEvent *event);
 };
 

--- a/src/admc/contents_widget.h
+++ b/src/admc/contents_widget.h
@@ -24,7 +24,6 @@
 #include <QString>
 
 class ContainersWidget;
-class QAction;
 class ObjectModel;
 class QTreeView;
 class QModelIndex;
@@ -41,7 +40,7 @@ class ContentsWidget final : public QWidget {
 Q_OBJECT
 
 public:
-    ContentsWidget(ObjectModel *model_arg, ContainersWidget *containers_widget, const QAction *filter_contents_action);
+    ContentsWidget(ObjectModel *model_arg, ContainersWidget *containers_widget);
 
 private slots:
     void on_containers_selected_changed(const QModelIndex &source_index);

--- a/src/admc/contents_widget.h
+++ b/src/admc/contents_widget.h
@@ -27,6 +27,9 @@ class ContainersWidget;
 class ObjectListWidget;
 class QAction;
 class ContentsFilterDialog;
+class ObjectModel;
+class QTreeView;
+class QModelIndex;
 
 /**
  * Shows a list of objects, which are children of a target
@@ -38,16 +41,16 @@ class ContentsWidget final : public QWidget {
 Q_OBJECT
 
 public:
-    ContentsWidget(ContainersWidget *containers_widget, const QAction *filter_contents_action);
+    ContentsWidget(ObjectModel *model, ContainersWidget *containers_widget, const QAction *filter_contents_action);
 
 private slots:
-    void on_containers_selected_changed(const QString &dn);
+    void on_containers_selected_changed(const QModelIndex &source_index);
     void on_ad_modified();
     void load_filter(const QString &filter);
 
 private:
     QString target_dn;
-    ObjectListWidget *object_list;
+    QTreeView *view;
     ContentsFilterDialog *filter_dialog;
 
     void change_target(const QString &dn);

--- a/src/admc/contents_widget.h
+++ b/src/admc/contents_widget.h
@@ -54,6 +54,7 @@ private:
     ContentsFilterDialog *filter_dialog;
 
     void change_target(const QString &dn);
+    void showEvent(QShowEvent *event);
 };
 
 #endif /* CONTENTS_WIDGET_H */

--- a/src/admc/contents_widget.h
+++ b/src/admc/contents_widget.h
@@ -29,6 +29,7 @@ class ObjectModel;
 class QTreeView;
 class QModelIndex;
 class AdvancedViewProxy;
+class QLabel;
 
 /**
  * Shows a list of objects, which are children of a target
@@ -45,12 +46,15 @@ public:
 private slots:
     void on_containers_selected_changed(const QModelIndex &source_index);
     void on_context_menu(const QPoint pos);
+    void on_header_toggled();
 
 private:
     QString target_dn;
     QTreeView *view;
     ObjectModel *model;
     AdvancedViewProxy *advanced_view_proxy;
+    QWidget *header;
+    QLabel *header_label;
 
     void showEvent(QShowEvent *event);
 };

--- a/src/admc/contents_widget.h
+++ b/src/admc/contents_widget.h
@@ -30,6 +30,7 @@ class ContentsFilterDialog;
 class ObjectModel;
 class QTreeView;
 class QModelIndex;
+class AdvancedViewProxy;
 
 /**
  * Shows a list of objects, which are children of a target
@@ -52,6 +53,7 @@ private:
     QString target_dn;
     QTreeView *view;
     ContentsFilterDialog *filter_dialog;
+    AdvancedViewProxy *advanced_view_proxy;
 
     void change_target(const QString &dn);
     void showEvent(QShowEvent *event);

--- a/src/admc/contents_widget.h
+++ b/src/admc/contents_widget.h
@@ -44,6 +44,7 @@ public:
 
 private slots:
     void on_containers_selected_changed(const QModelIndex &source_index);
+    void on_context_menu(const QPoint pos);
 
 private:
     QString target_dn;

--- a/src/admc/contents_widget.h
+++ b/src/admc/contents_widget.h
@@ -40,7 +40,7 @@ class ContentsWidget final : public QWidget {
 Q_OBJECT
 
 public:
-    ContentsWidget(ObjectModel *model, ContainersWidget *containers_widget, const QAction *filter_contents_action);
+    ContentsWidget(ObjectModel *model_arg, ContainersWidget *containers_widget, const QAction *filter_contents_action);
 
 private slots:
     void on_containers_selected_changed(const QModelIndex &source_index);
@@ -48,6 +48,7 @@ private slots:
 private:
     QString target_dn;
     QTreeView *view;
+    ObjectModel *model;
     AdvancedViewProxy *advanced_view_proxy;
 
     void showEvent(QShowEvent *event);

--- a/src/admc/create_dialog.cpp
+++ b/src/admc/create_dialog.cpp
@@ -216,35 +216,31 @@ void CreateDialog::accept() {
 
     STATUS()->start_error_log();
 
-    AD()->start_batch();
-    {   
-        auto fail_msg =
-        [this, class_name, name]() {
-            const QString message = QString(tr("Failed to create %1 \"%2\"")).arg(class_name, name);
-            STATUS()->message(message, StatusType_Error);
-        };
+    auto fail_msg =
+    [this, class_name, name]() {
+        const QString message = QString(tr("Failed to create %1 \"%2\"")).arg(class_name, name);
+        STATUS()->message(message, StatusType_Error);
+    };
 
-        const bool add_success = AD()->object_add(dn, object_class);
+    const bool add_success = AD()->object_add(dn, object_class);
 
-        if (add_success) {
-            const bool apply_if_unmodified = true;
-            const bool apply_success = edits_apply(all_edits, dn, apply_if_unmodified);
+    if (add_success) {
+        const bool apply_if_unmodified = true;
+        const bool apply_success = edits_apply(all_edits, dn, apply_if_unmodified);
 
-            if (apply_success) {
-                const QString message = QString(tr("Created %1 \"%2\"")).arg(class_name, name);
+        if (apply_success) {
+            const QString message = QString(tr("Created %1 \"%2\"")).arg(class_name, name);
 
-                STATUS()->message(message, StatusType_Success);
+            STATUS()->message(message, StatusType_Success);
 
-                QDialog::accept();
-            } else {
-                AD()->object_delete(dn);
-                fail_msg();
-            }
+            QDialog::accept();
         } else {
+            AD()->object_delete(dn);
             fail_msg();
         }
+    } else {
+        fail_msg();
     }
-    AD()->end_batch();
     
     STATUS()->end_error_log(this);
 }

--- a/src/admc/details_dialog.cpp
+++ b/src/admc/details_dialog.cpp
@@ -246,6 +246,8 @@ void DetailsDialog::apply() {
         }
     }
 
+    reset();
+
     STATUS()->end_error_log(this);
 }
 

--- a/src/admc/details_dialog.cpp
+++ b/src/admc/details_dialog.cpp
@@ -215,9 +215,6 @@ DetailsDialog::DetailsDialog(const QString &target_arg, const bool is_floating_i
     connect(
         cancel_button, &QPushButton::clicked,
         this, &DetailsDialog::reject);
-    connect(
-        AD(), &AdInterface::modified,
-        this, &DetailsDialog::reload_target);
 
     const BoolSettingSignal *docked_setting = SETTINGS()->get_bool_signal(BoolSetting_DetailsIsDocked);
     connect(
@@ -243,14 +240,11 @@ void DetailsDialog::on_docked_setting_changed() {
 void DetailsDialog::apply() {
     STATUS()->start_error_log();
 
-    AD()->start_batch();
     for (auto tab : tabs) {
         if (tab_widget->indexOf(tab) != -1) {
             tab->apply(target);
         }
     }
-    AD()->end_batch();
-    AD()->emit_object_changed(target);
 
     STATUS()->end_error_log(this);
 }
@@ -268,17 +262,4 @@ void DetailsDialog::reset() {
 void DetailsDialog::on_edited() {
     apply_button->setEnabled(true);
     reset_button->setEnabled(true);
-}
-
-void DetailsDialog::reload_target() {
-    const AdObject object = AD()->search_object(target);
-
-    if (object.is_empty()) {
-        close();
-        docked_instance = nullptr;
-    } else {
-        for (auto tab : tabs) {
-            tab->load(object);
-        }
-    }
 }

--- a/src/admc/details_dialog.cpp
+++ b/src/admc/details_dialog.cpp
@@ -250,6 +250,7 @@ void DetailsDialog::apply() {
         }
     }
     AD()->end_batch();
+    AD()->emit_object_changed(target);
 
     STATUS()->end_error_log(this);
 }

--- a/src/admc/details_dialog.h
+++ b/src/admc/details_dialog.h
@@ -55,7 +55,6 @@ private slots:
     void reset();
     void on_docked_setting_changed();
     void on_edited();
-    void reload_target();
 
 private:
     static DetailsDialog *docked_instance;

--- a/src/admc/filter_dialog.cpp
+++ b/src/admc/filter_dialog.cpp
@@ -17,14 +17,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "contents_filter_dialog.h"
+#include "filter_dialog.h"
 
 #include "filter_widget/filter_widget.h"
 
 #include <QDialogButtonBox>
 #include <QVBoxLayout>
 
-ContentsFilterDialog::ContentsFilterDialog(QWidget *parent)
+FilterDialog::FilterDialog(QWidget *parent)
 : QDialog(parent)
 {   
     setWindowTitle(tr("Filter contents"));

--- a/src/admc/filter_dialog.h
+++ b/src/admc/filter_dialog.h
@@ -17,19 +17,25 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CONTENTS_FILTER_DIALOG_H
-#define CONTENTS_FILTER_DIALOG_H
+#ifndef FILTER_DIALOG_H
+#define FILTER_DIALOG_H
+
+/**
+ * Contains FilterWidget. When a filter is entered and
+ * dialog is accepted, emits filter_changed() signal. Used
+ * for filtering ObjectModel.
+ */
 
 #include <QDialog>
 
-class ContentsFilterDialog final : public QDialog {
+class FilterDialog final : public QDialog {
 Q_OBJECT
 
 public:
-    ContentsFilterDialog(QWidget *parent);
+    FilterDialog(QWidget *parent);
 
 signals:
     void filter_changed(const QString &filter);
 };
 
-#endif /* CONTENTS_FILTER_DIALOG_H */
+#endif /* FILTER_DIALOG_H */

--- a/src/admc/find_dialog.cpp
+++ b/src/admc/find_dialog.cpp
@@ -67,7 +67,7 @@ FindDialog::FindDialog(QWidget *parent)
     auto find_button = new QPushButton(tr("Find"));
     find_button->setAutoDefault(false);
 
-    find_results = new ObjectListWidget(ObjectListWidgetType_Find);
+    find_results = new ObjectListWidget();
 
     auto filter_widget_frame = new QFrame();
     filter_widget_frame->setFrameStyle(QFrame::Raised);
@@ -153,5 +153,5 @@ void FindDialog::find() {
         return item_data.toString();
     }();
 
-    find_results->load_filter(filter, search_base);
+    find_results->load(filter, search_base);
 }

--- a/src/admc/find_dialog.cpp
+++ b/src/admc/find_dialog.cpp
@@ -47,8 +47,6 @@
 FindDialog::FindDialog(QWidget *parent)
 : QDialog(parent)
 {
-    setAttribute(Qt::WA_DeleteOnClose);
-
     setWindowTitle(tr("Find objects"));
 
     // TODO: technically, entire directory does NOT equal to the domain. In cases where we're browsing multiple domains at the same time (or maybe some other situations as well), we'd need "Entire directory" AND all of domains. Currently search base is set to domain anyway, so would need to start from reworking that.

--- a/src/admc/find_dialog.cpp
+++ b/src/admc/find_dialog.cpp
@@ -26,7 +26,7 @@
 #include "utils.h"
 #include "filter.h"
 #include "filter_widget/filter_widget.h"
-#include "object_list_widget.h"
+#include "find_results.h"
 #include "select_dialog.h"
 
 #include <QString>
@@ -67,7 +67,7 @@ FindDialog::FindDialog(QWidget *parent)
     auto find_button = new QPushButton(tr("Find"));
     find_button->setAutoDefault(false);
 
-    find_results = new ObjectListWidget();
+    find_results = new FindResults();
 
     auto filter_widget_frame = new QFrame();
     filter_widget_frame->setFrameStyle(QFrame::Raised);

--- a/src/admc/find_dialog.h
+++ b/src/admc/find_dialog.h
@@ -30,7 +30,7 @@
 #include <QDialog>
 
 class FilterWidget;
-class ObjectListWidget;
+class FindResults;
 class QComboBox;
 
 class FindDialog final : public QDialog {
@@ -46,7 +46,7 @@ private slots:
 
 private:
     FilterWidget *filter_widget;
-    ObjectListWidget *find_results;
+    FindResults *find_results;
     QComboBox *search_base_combo;
 };
 

--- a/src/admc/find_results.cpp
+++ b/src/admc/find_results.cpp
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "object_list_widget.h"
+#include "find_results.h"
 #include "object_context_menu.h"
 #include "details_dialog.h"
 #include "utils.h"
@@ -37,7 +37,7 @@
 #include <QStandardItemModel>
 #include <QVBoxLayout>
 
-ObjectListWidget::ObjectListWidget()
+FindResults::FindResults()
 : QWidget()
 {   
     model = new QStandardItemModel(ADCONFIG()->get_columns().count(), ADCONFIG()->get_column_index(ATTRIBUTE_DISTINGUISHED_NAME), this);
@@ -90,10 +90,10 @@ ObjectListWidget::ObjectListWidget()
 
     QObject::connect(
         view, &QWidget::customContextMenuRequested,
-        this, &ObjectListWidget::on_context_menu);
+        this, &FindResults::on_context_menu);
 }
 
-void ObjectListWidget::on_context_menu(const QPoint pos) {
+void FindResults::on_context_menu(const QPoint pos) {
     const QString dn = get_dn_from_pos(pos, view, ADCONFIG()->get_column_index(ATTRIBUTE_DISTINGUISHED_NAME));
     if (dn.isEmpty()) {
         return;
@@ -103,7 +103,7 @@ void ObjectListWidget::on_context_menu(const QPoint pos) {
     exec_menu_from_view(&context_menu, view, pos);
 }
 
-void ObjectListWidget::load(const QString &filter, const QString &search_base) {
+void FindResults::load(const QString &filter, const QString &search_base) {
     model->removeRows(0, model->rowCount());
     
     const QList<QString> search_attributes = ADCONFIG()->get_columns();
@@ -124,7 +124,7 @@ void ObjectListWidget::load(const QString &filter, const QString &search_base) {
     object_count_label->setText(label_text);
 }
 
-void ObjectListWidget::showEvent(QShowEvent *event) {
+void FindResults::showEvent(QShowEvent *event) {
     resize_columns(view,
     {
         {ADCONFIG()->get_column_index(ATTRIBUTE_NAME), 0.4},

--- a/src/admc/find_results.cpp
+++ b/src/admc/find_results.cpp
@@ -42,16 +42,7 @@ FindResults::FindResults()
 {   
     model = new QStandardItemModel(ADCONFIG()->get_columns().count(), ADCONFIG()->get_column_index(ATTRIBUTE_DISTINGUISHED_NAME), this);
 
-    const QList<QString> header_labels =
-    [this]() {
-        QList<QString> out;
-        for (const QString attribute : ADCONFIG()->get_columns()) {
-            const QString attribute_display_name = ADCONFIG()->get_column_display_name(attribute);
-
-            out.append(attribute_display_name);
-        }
-        return out;
-    }();
+    const QList<QString> header_labels = object_model_header_labels();
     model->setHorizontalHeaderLabels(header_labels);
 
     view = new QTreeView(this);

--- a/src/admc/find_results.h
+++ b/src/admc/find_results.h
@@ -17,15 +17,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef OBJECTS_LIST_WIDGET_H
-#define OBJECTS_LIST_WIDGET_H
+#ifndef FIND_RESULTS_H
+#define FIND_RESULTS_H
 
 /**
- * Displays a detailed list of objects with many optional
- * toggleable columns. Can load children of a parent or load
- * all objects matching a filter. Does NOT update on AD
-   modifications. Intended to be used as a sub-widget
- * in some other widget.
+ * Used by find dialog to display find results as a list of
+ * objects.
  */
 
 #include <QWidget>
@@ -37,11 +34,11 @@ class AdObject;
 class QStandardItemModel;
 class QPoint;
 
-class ObjectListWidget final : public QWidget {
+class FindResults final : public QWidget {
 Q_OBJECT
 
 public:
-    ObjectListWidget();
+    FindResults();
 
     void load(const QString &filter, const QString &search_base);
 
@@ -57,4 +54,4 @@ private:
     void showEvent(QShowEvent *event);
 };
 
-#endif /* OBJECTS_LIST_WIDGET_H */
+#endif /* FIND_RESULTS_H */

--- a/src/admc/main_window.cpp
+++ b/src/admc/main_window.cpp
@@ -29,6 +29,7 @@
 #include "ad_interface.h"
 #include "object_model.h"
 #include "filter_dialog.h"
+#include "find_dialog.h"
 
 #include <QApplication>
 #include <QString>
@@ -103,6 +104,8 @@ void MainWindow::on_connected() {
 
     auto filter_dialog = new FilterDialog(this);
 
+    auto find_dialog = new FindDialog(this);
+
     auto object_model = new ObjectModel(this);
 
     auto containers_widget = new ContainersWidget(object_model, this);
@@ -161,6 +164,9 @@ void MainWindow::on_connected() {
     connect(
         menubar->filter_contents_action, &QAction::triggered,
         filter_dialog, &QDialog::open);
+    connect(
+        menubar->find_action, &QAction::triggered,
+        find_dialog, &QDialog::open);
 }
 
 void MainWindow::closeEvent(QCloseEvent *event) {

--- a/src/admc/main_window.cpp
+++ b/src/admc/main_window.cpp
@@ -28,7 +28,7 @@
 #include "policies_widget.h"
 #include "ad_interface.h"
 #include "object_model.h"
-#include "contents_filter_dialog.h"
+#include "filter_dialog.h"
 
 #include <QApplication>
 #include <QString>
@@ -101,7 +101,7 @@ void MainWindow::on_connected() {
     status_log->clear();
     STATUS()->status_bar->showMessage(tr("Ready"));
 
-    filter_dialog = new ContentsFilterDialog(this);
+    auto filter_dialog = new FilterDialog(this);
 
     auto object_model = new ObjectModel(this);
 
@@ -155,7 +155,7 @@ void MainWindow::on_connected() {
     connect_toggle_widget(status_log, BoolSetting_ShowStatusLog);
 
     connect(
-        filter_dialog, &ContentsFilterDialog::filter_changed,
+        filter_dialog, &FilterDialog::filter_changed,
         object_model, &ObjectModel::on_filter_changed);
 
     connect(

--- a/src/admc/main_window.cpp
+++ b/src/admc/main_window.cpp
@@ -100,7 +100,7 @@ void MainWindow::on_connected() {
     status_log->clear();
     STATUS()->status_bar->showMessage(tr("Ready"));
 
-    auto object_model = new ObjectModel(ObjectModel::Column::COUNT, ObjectModel::Column::DN, this);
+    auto object_model = new ObjectModel(this);
 
     auto containers_widget = new ContainersWidget(object_model, this);
 

--- a/src/admc/main_window.cpp
+++ b/src/admc/main_window.cpp
@@ -110,7 +110,7 @@ void MainWindow::on_connected() {
 
     auto containers_widget = new ContainersWidget(object_model, this);
 
-    auto contents_widget = new ContentsWidget(object_model, containers_widget, menubar->filter_contents_action);
+    auto contents_widget = new ContentsWidget(object_model, containers_widget);
 
     auto details_widget_docked_container = DetailsDialog::get_docked_container();
     auto policies_widget = new PoliciesWidget();
@@ -162,7 +162,7 @@ void MainWindow::on_connected() {
         object_model, &ObjectModel::on_filter_changed);
 
     connect(
-        menubar->filter_contents_action, &QAction::triggered,
+        menubar->filter_action, &QAction::triggered,
         filter_dialog, &QDialog::open);
     connect(
         menubar->find_action, &QAction::triggered,

--- a/src/admc/main_window.cpp
+++ b/src/admc/main_window.cpp
@@ -28,6 +28,7 @@
 #include "policies_widget.h"
 #include "ad_interface.h"
 #include "object_model.h"
+#include "contents_filter_dialog.h"
 
 #include <QApplication>
 #include <QString>
@@ -100,6 +101,8 @@ void MainWindow::on_connected() {
     status_log->clear();
     STATUS()->status_bar->showMessage(tr("Ready"));
 
+    filter_dialog = new ContentsFilterDialog(this);
+
     auto object_model = new ObjectModel(this);
 
     auto containers_widget = new ContainersWidget(object_model, this);
@@ -150,6 +153,14 @@ void MainWindow::on_connected() {
 
     connect_toggle_widget(containers_widget, BoolSetting_ShowContainers);
     connect_toggle_widget(status_log, BoolSetting_ShowStatusLog);
+
+    connect(
+        filter_dialog, &ContentsFilterDialog::filter_changed,
+        object_model, &ObjectModel::on_filter_changed);
+
+    connect(
+        menubar->filter_contents_action, &QAction::triggered,
+        filter_dialog, &QDialog::open);
 }
 
 void MainWindow::closeEvent(QCloseEvent *event) {

--- a/src/admc/main_window.cpp
+++ b/src/admc/main_window.cpp
@@ -27,6 +27,7 @@
 #include "confirmation_dialog.h"
 #include "policies_widget.h"
 #include "ad_interface.h"
+#include "object_model.h"
 
 #include <QApplication>
 #include <QString>
@@ -99,9 +100,11 @@ void MainWindow::on_connected() {
     status_log->clear();
     STATUS()->status_bar->showMessage(tr("Ready"));
 
-    auto containers_widget = new ContainersWidget(this);
+    auto object_model = new ObjectModel(ObjectModel::Column::COUNT, ObjectModel::Column::DN, this);
 
-    auto contents_widget = new ContentsWidget(containers_widget, menubar->filter_contents_action);
+    auto containers_widget = new ContainersWidget(object_model, this);
+
+    auto contents_widget = new ContentsWidget(object_model, containers_widget, menubar->filter_contents_action);
     
     auto details_widget_docked_container = DetailsDialog::get_docked_container();
     auto policies_widget = new PoliciesWidget();

--- a/src/admc/main_window.cpp
+++ b/src/admc/main_window.cpp
@@ -105,7 +105,7 @@ void MainWindow::on_connected() {
     auto containers_widget = new ContainersWidget(object_model, this);
 
     auto contents_widget = new ContentsWidget(object_model, containers_widget, menubar->filter_contents_action);
-    
+
     auto details_widget_docked_container = DetailsDialog::get_docked_container();
     auto policies_widget = new PoliciesWidget();
 

--- a/src/admc/main_window.h
+++ b/src/admc/main_window.h
@@ -23,6 +23,7 @@
 #include <QMainWindow>
 
 class MenuBar;
+class ContentsFilterDialog;
 
 class MainWindow final : public QMainWindow {
 Q_OBJECT
@@ -38,6 +39,7 @@ private slots:
 
 private:
     MenuBar *menubar;
+    ContentsFilterDialog *filter_dialog;
 
 };
 

--- a/src/admc/main_window.h
+++ b/src/admc/main_window.h
@@ -23,7 +23,6 @@
 #include <QMainWindow>
 
 class MenuBar;
-class ContentsFilterDialog;
 
 class MainWindow final : public QMainWindow {
 Q_OBJECT
@@ -39,7 +38,6 @@ private slots:
 
 private:
     MenuBar *menubar;
-    ContentsFilterDialog *filter_dialog;
 
 };
 

--- a/src/admc/menubar.cpp
+++ b/src/admc/menubar.cpp
@@ -21,7 +21,6 @@
 #include "ad_interface.h"
 #include "settings.h"
 #include "confirmation_dialog.h"
-#include "find_dialog.h"
 #include "toggle_widgets_dialog.h"
 #include "status.h"
 
@@ -43,11 +42,7 @@ MenuBar::MenuBar()
             STATUS()->end_error_log(this);
         });
 
-    action_menu->addAction(tr("Find"),
-        [this]() {
-            auto find_dialog = new FindDialog(this);
-            find_dialog->open();
-        });
+    find_action = action_menu->addAction(tr("Find"));
 
     action_menu->addAction(tr("Test"),
         []() {

--- a/src/admc/menubar.cpp
+++ b/src/admc/menubar.cpp
@@ -49,11 +49,6 @@ MenuBar::MenuBar()
             find_dialog->open();
         });
 
-    action_menu->addAction(tr("Refresh"),
-        []() {
-            AD()->refresh();
-        });
-
     action_menu->addAction(tr("Test"),
         []() {
             AD()->object_add("CN=testslot,CN=Users,DC=domain,DC=alt", CLASS_USER);

--- a/src/admc/menubar.cpp
+++ b/src/admc/menubar.cpp
@@ -44,11 +44,6 @@ MenuBar::MenuBar()
 
     find_action = action_menu->addAction(tr("Find"));
 
-    action_menu->addAction(tr("Test"),
-        []() {
-            AD()->object_add("CN=testslot,CN=Users,DC=domain,DC=alt", CLASS_USER);
-        });
-
     filter_action = action_menu->addAction(tr("Filter contents"));
 
     auto quit_action = action_menu->addAction(tr("Quit"),

--- a/src/admc/menubar.cpp
+++ b/src/admc/menubar.cpp
@@ -49,7 +49,7 @@ MenuBar::MenuBar()
             AD()->object_add("CN=testslot,CN=Users,DC=domain,DC=alt", CLASS_USER);
         });
 
-    filter_contents_action = action_menu->addAction(tr("Filter contents"));
+    filter_action = action_menu->addAction(tr("Filter contents"));
 
     auto quit_action = action_menu->addAction(tr("Quit"),
         []() {

--- a/src/admc/menubar.cpp
+++ b/src/admc/menubar.cpp
@@ -54,6 +54,11 @@ MenuBar::MenuBar()
             AD()->refresh();
         });
 
+    action_menu->addAction(tr("Test"),
+        []() {
+            AD()->object_add("CN=testslot,CN=Users,DC=domain,DC=alt", CLASS_USER);
+        });
+
     filter_contents_action = action_menu->addAction(tr("Filter contents"));
 
     auto quit_action = action_menu->addAction(tr("Quit"),

--- a/src/admc/menubar.h
+++ b/src/admc/menubar.h
@@ -30,7 +30,7 @@ class MenuBar final : public QMenuBar {
 Q_OBJECT
 
 public:
-    QAction *filter_contents_action;
+    QAction *filter_action;
     QAction *find_action;
 
     MenuBar();

--- a/src/admc/menubar.h
+++ b/src/admc/menubar.h
@@ -31,6 +31,7 @@ Q_OBJECT
 
 public:
     QAction *filter_contents_action;
+    QAction *find_action;
 
     MenuBar();
 

--- a/src/admc/object_list_widget.cpp
+++ b/src/admc/object_list_widget.cpp
@@ -18,7 +18,6 @@
  */
 
 #include "object_list_widget.h"
-#include "object_model.h"
 #include "object_context_menu.h"
 #include "details_dialog.h"
 #include "utils.h"
@@ -37,6 +36,7 @@
 #include <QSortFilterProxyModel>
 #include <QLineEdit>
 #include <QGridLayout>
+#include <QStandardItemModel>
 
 ObjectListWidget::ObjectListWidget(const ObjectListWidgetType list_type_arg)
 : QWidget()
@@ -45,7 +45,7 @@ ObjectListWidget::ObjectListWidget(const ObjectListWidgetType list_type_arg)
 
     columns = ADCONFIG()->get_columns();
 
-    model = new ObjectModel(columns.count(), column_index(ATTRIBUTE_DISTINGUISHED_NAME), this);
+    model = new QStandardItemModel(columns.count(), column_index(ATTRIBUTE_DISTINGUISHED_NAME), this);
 
     const QList<QString> header_labels =
     [this]() {

--- a/src/admc/object_list_widget.cpp
+++ b/src/admc/object_list_widget.cpp
@@ -28,6 +28,7 @@
 #include "attribute_display.h"
 #include "filter.h"
 #include "settings.h"
+#include "object_model.h"
 
 #include <QTreeView>
 #include <QLabel>
@@ -142,40 +143,8 @@ void ObjectListWidget::load(const QHash<QString, AdObject> &objects) {
         const AdObject object  = objects[child_dn];
         
         const QList<QStandardItem *> row = make_item_row(ADCONFIG()->get_columns().count());
-        for (int i = 0; i < ADCONFIG()->get_columns().count(); i++) {
-            const QString attribute = ADCONFIG()->get_columns()[i];
 
-            if (!object.contains(attribute)) {
-                continue;
-            }
-
-            const QString display_value =
-            [attribute, object]() {
-                if (attribute == ATTRIBUTE_OBJECT_CLASS) {
-                    const QString object_class = object.get_string(attribute);
-
-                    if (object_class == CLASS_GROUP) {
-                        const GroupScope scope = object.get_group_scope(); 
-                        const QString scope_string = group_scope_string(scope);
-
-                        const GroupType type = object.get_group_type(); 
-                        const QString type_string = group_type_string(type);
-
-                        return QString("%1 Group - %2").arg(type_string, scope_string);
-                    } else {
-                        return ADCONFIG()->get_class_display_name(object_class);
-                    }
-                } else {
-                    const QByteArray value = object.get_value(attribute);
-                    return attribute_display_value(attribute, value);
-                }
-            }();
-
-            row[i]->setText(display_value);
-        }
-
-        const QIcon icon = object.get_icon();
-        row[0]->setIcon(icon);
+        load_attributes_row(row, object);
 
         model->appendRow(row);
     }

--- a/src/admc/object_list_widget.h
+++ b/src/admc/object_list_widget.h
@@ -29,44 +29,31 @@
  */
 
 #include <QWidget>
-#include <QHash>
-#include <QList>
-#include <QPoint>
 
 class QTreeView;
 class QLabel;
 class QLineEdit;
 class AdObject;
 class QStandardItemModel;
-class QLabel;
-
-enum ObjectListWidgetType {
-    ObjectListWidgetType_Contents,
-    ObjectListWidgetType_Find,
-};
+class QPoint;
 
 class ObjectListWidget final : public QWidget {
 Q_OBJECT
 
 public:
-    ObjectListWidget(const ObjectListWidgetType list_type_arg);
+    ObjectListWidget();
 
-    void load_children(const QString &new_parent_dn, const QString &filter = QString());
-    void load_filter(const QString &filter, const QString &search_base);
+    void load(const QString &filter, const QString &search_base);
 
 private slots:
     void on_context_menu(const QPoint pos);
 
 private:
-    ObjectListWidgetType list_type;
-    QString parent_dn;
     QLabel *label;
     QStandardItemModel *model;
     QTreeView *view;
-    QLineEdit *filter_name_edit;
     QLabel *object_count_label;
 
-    void load(const QHash<QString, AdObject> &objects);
     void showEvent(QShowEvent *event);
 };
 

--- a/src/admc/object_list_widget.h
+++ b/src/admc/object_list_widget.h
@@ -35,9 +35,9 @@
 
 class QTreeView;
 class QLabel;
-class ObjectModel;
 class QLineEdit;
 class AdObject;
+class QStandardItemModel;
 
 enum ObjectListWidgetType {
     ObjectListWidgetType_Contents,
@@ -63,7 +63,7 @@ private:
     QString parent_dn;
     QList<QString> columns;
     QLabel *label;
-    ObjectModel *model;
+    QStandardItemModel *model;
     QTreeView *view;
     QLineEdit *filter_name_edit;
     QWidget *header;

--- a/src/admc/object_list_widget.h
+++ b/src/admc/object_list_widget.h
@@ -61,7 +61,6 @@ private slots:
 private:
     ObjectListWidgetType list_type;
     QString parent_dn;
-    QList<QString> columns;
     QLabel *label;
     QStandardItemModel *model;
     QTreeView *view;
@@ -70,7 +69,6 @@ private:
 
     void load(const QHash<QString, AdObject> &objects);
     void showEvent(QShowEvent *event);
-    int column_index(const QString &attribute);
 };
 
 #endif /* OBJECTS_LIST_WIDGET_H */

--- a/src/admc/object_list_widget.h
+++ b/src/admc/object_list_widget.h
@@ -38,6 +38,7 @@ class QLabel;
 class QLineEdit;
 class AdObject;
 class QStandardItemModel;
+class QLabel;
 
 enum ObjectListWidgetType {
     ObjectListWidgetType_Contents,
@@ -52,11 +53,9 @@ public:
 
     void load_children(const QString &new_parent_dn, const QString &filter = QString());
     void load_filter(const QString &filter, const QString &search_base);
-    void reset_name_filter();
 
 private slots:
     void on_context_menu(const QPoint pos);
-    void on_header_toggled();
 
 private:
     ObjectListWidgetType list_type;
@@ -65,7 +64,7 @@ private:
     QStandardItemModel *model;
     QTreeView *view;
     QLineEdit *filter_name_edit;
-    QWidget *header;
+    QLabel *object_count_label;
 
     void load(const QHash<QString, AdObject> &objects);
     void showEvent(QShowEvent *event);

--- a/src/admc/object_model.cpp
+++ b/src/admc/object_model.cpp
@@ -30,13 +30,12 @@
 
 // TODO: remove dev mode once developing winds down OR extract it better because it adds a lot of confusion
 
-ObjectModel::ObjectModel(const int column_count, const int dn_column_arg, QObject *parent)
-: QStandardItemModel(0, column_count, parent)
-, dn_column(dn_column_arg)
+ObjectModel::ObjectModel(QObject *parent)
+: QStandardItemModel(0, Column::COUNT, parent)
 {
     set_horizontal_header_labels_from_map(this, {
-        {ObjectModel::Column::Name, tr("Name")},
-        {ObjectModel::Column::DN, tr("DN")}
+        {Column::Name, tr("Name")},
+        {Column::DN, tr("DN")}
     });
 
     // Make row for head object
@@ -62,7 +61,7 @@ void ObjectModel::fetchMore(const QModelIndex &parent) {
         return;
     }
 
-    const QString parent_dn = get_dn_from_index(parent, ObjectModel::Column::DN);
+    const QString parent_dn = get_dn_from_index(parent, Column::DN);
 
     QStandardItem *parent_item = itemFromIndex(parent);
 
@@ -109,7 +108,7 @@ QMimeData *ObjectModel::mimeData(const QModelIndexList &indexes) const {
 
     if (indexes.size() > 0) {
         QModelIndex index = indexes[0];
-        QString dn = get_dn_from_index(index, dn_column);
+        QString dn = get_dn_from_index(index, Column::DN);
 
         data->setText(dn);
     }
@@ -119,7 +118,7 @@ QMimeData *ObjectModel::mimeData(const QModelIndexList &indexes) const {
 
 bool ObjectModel::canDropMimeData(const QMimeData *data, Qt::DropAction, int, int, const QModelIndex &parent) const {
     const QString dn = data->text();
-    const QString target_dn = get_dn_from_index(parent, dn_column);
+    const QString target_dn = get_dn_from_index(parent, Column::DN);
 
     const bool can_drop = AD()->object_can_drop(dn, target_dn);
 
@@ -136,7 +135,7 @@ bool ObjectModel::dropMimeData(const QMimeData *data, Qt::DropAction action, int
     }
 
     const QString dn = data->text();
-    const QString target_dn = get_dn_from_index(parent, dn_column);
+    const QString target_dn = get_dn_from_index(parent, Column::DN);
 
     AD()->object_drop(dn, target_dn);
 
@@ -145,12 +144,12 @@ bool ObjectModel::dropMimeData(const QMimeData *data, Qt::DropAction action, int
 
 // Make row in model at given parent based on object with given dn
 QStandardItem *ObjectModel::make_row(QStandardItem *parent, const AdObject &object) {
-    const QList<QStandardItem *> row = make_item_row(ObjectModel::Column::COUNT);
+    const QList<QStandardItem *> row = make_item_row(Column::COUNT);
     
     const QString name = object.get_string(ATTRIBUTE_NAME);
     const QString dn = object.get_dn();
-    row[ObjectModel::Column::Name]->setText(name);
-    row[ObjectModel::Column::DN]->setText(dn);
+    row[Column::Name]->setText(name);
+    row[Column::DN]->setText(dn);
 
     const QIcon icon = object.get_icon();
     row[0]->setIcon(icon);

--- a/src/admc/object_model.cpp
+++ b/src/admc/object_model.cpp
@@ -49,14 +49,7 @@ ObjectModel::ObjectModel(QObject *parent)
     }();
     setHorizontalHeaderLabels(header_labels);
 
-    // Make row for head object
-    QStandardItem *invis_root = invisibleRootItem();
-    const QString head_dn = AD()->domain_head();
-    const AdObject head_object = AD()->search_object(head_dn);
-
-    const QList<QStandardItem *> row = make_item_row(ADCONFIG()->get_columns().size());
-    invis_root->appendRow(row);
-    load_row(row, head_object);
+    reset();
 
     connect(
         AD(), &AdInterface::object_added,
@@ -245,7 +238,7 @@ void ObjectModel::on_object_changed(const QString &dn) {
 void ObjectModel::on_filter_changed(const QString &filter) {
     current_filter = filter;
 
-    // reset();    
+    reset();    
 }
 
 // Make row in model at given parent based on object with given dn
@@ -327,4 +320,17 @@ QStandardItem *ObjectModel::find_object(const QString &dn) const {
 
         return item;
     }
+}
+
+void ObjectModel::reset() {
+    removeRows(0, rowCount());
+
+    // Make row for head object
+    QStandardItem *invis_root = invisibleRootItem();
+    const QString head_dn = AD()->domain_head();
+    const AdObject head_object = AD()->search_object(head_dn);
+
+    const QList<QStandardItem *> row = make_item_row(ADCONFIG()->get_columns().size());
+    invis_root->appendRow(row);
+    load_row(row, head_object);
 }

--- a/src/admc/object_model.cpp
+++ b/src/admc/object_model.cpp
@@ -114,8 +114,8 @@ void ObjectModel::fetchMore(const QModelIndex &parent) {
 
     for (const AdObject object : search_results.values()) {
         const QList<QStandardItem *> row = make_item_row(ADCONFIG()->get_columns().size());
-        parent_item->appendRow(row);
         load_attributes_row(row, object);
+        parent_item->appendRow(row);
     }
 
     // Unset CanFetch flag since we are done fetching

--- a/src/admc/object_model.cpp
+++ b/src/admc/object_model.cpp
@@ -89,7 +89,7 @@ void ObjectModel::fetchMore(const QModelIndex &parent) {
     QStandardItem *parent_item = itemFromIndex(parent);
 
     // Add children
-    const QList<QString> search_attributes = {ATTRIBUTE_NAME, ATTRIBUTE_DISTINGUISHED_NAME, ATTRIBUTE_OBJECT_CLASS};
+    const QList<QString> search_attributes = QList<QString>();
     const QString filter = QString();
     QHash<QString, AdObject> search_results = AD()->search(filter, search_attributes, SearchScope_Children, parent_dn);
 

--- a/src/admc/object_model.cpp
+++ b/src/admc/object_model.cpp
@@ -36,17 +36,7 @@
 ObjectModel::ObjectModel(QObject *parent)
 : QStandardItemModel(0, ADCONFIG()->get_columns().count(), parent)
 {
-    // TODO: duplicated in object list widget
-    const QList<QString> header_labels =
-    [this]() {
-        QList<QString> out;
-        for (const QString attribute : ADCONFIG()->get_columns()) {
-            const QString attribute_display_name = ADCONFIG()->get_column_display_name(attribute);
-
-            out.append(attribute_display_name);
-        }
-        return out;
-    }();
+    const QList<QString> header_labels = object_model_header_labels();
     setHorizontalHeaderLabels(header_labels);
 
     reset();
@@ -333,4 +323,16 @@ void ObjectModel::reset() {
     const QList<QStandardItem *> row = make_item_row(ADCONFIG()->get_columns().size());
     invis_root->appendRow(row);
     load_attributes_row(row, head_object);
+}
+
+QList<QString> object_model_header_labels() {
+    QList<QString> out;
+
+    for (const QString attribute : ADCONFIG()->get_columns()) {
+        const QString attribute_display_name = ADCONFIG()->get_column_display_name(attribute);
+
+        out.append(attribute_display_name);
+    }
+    
+    return out;
 }

--- a/src/admc/object_model.cpp
+++ b/src/admc/object_model.cpp
@@ -82,7 +82,9 @@ void ObjectModel::fetchMore(const QModelIndex &parent) {
     QStandardItem *parent_item = itemFromIndex(parent);
 
     // Add children
-    const QList<QString> search_attributes = QList<QString>();
+    QList<QString> search_attributes = ADCONFIG()->get_columns();
+    search_attributes += ATTRIBUTE_SHOW_IN_ADVANCED_VIEW_ONLY;
+    
     const QString filter =
     [this]() {
         // NOTE: when filtering, don't apply it to container objects by OR'ing with container filter

--- a/src/admc/object_model.cpp
+++ b/src/admc/object_model.cpp
@@ -123,7 +123,7 @@ void ObjectModel::fetchMore(const QModelIndex &parent) {
     for (const AdObject object : search_results.values()) {
         const QList<QStandardItem *> row = make_item_row(ADCONFIG()->get_columns().size());
         parent_item->appendRow(row);
-        load_row(row, object);
+        load_attributes_row(row, object);
     }
 
     // Unset CanFetch flag since we are done fetching
@@ -192,7 +192,7 @@ void ObjectModel::on_object_added(const QString &dn) {
     if (parent_fetched) {
         const AdObject object = AD()->search_object(dn);
         const QList<QStandardItem *> row = make_item_row(ADCONFIG()->get_columns().size());
-        load_row(row, object);
+        load_attributes_row(row, object);
         parent_item->appendRow(row);
     }
 }
@@ -232,7 +232,7 @@ void ObjectModel::on_object_changed(const QString &dn) {
     }();
 
     const AdObject object = AD()->search_object(dn);
-    load_row(row, object);
+    load_attributes_row(row, object);
 }
 
 void ObjectModel::on_filter_changed(const QString &filter) {
@@ -241,9 +241,7 @@ void ObjectModel::on_filter_changed(const QString &filter) {
     reset();    
 }
 
-// Make row in model at given parent based on object with given dn
-void ObjectModel::load_row(const QList<QStandardItem *> row, const AdObject &object) {
-    // TODO: duplicated
+void load_attributes_row(const QList<QStandardItem *> row, const AdObject &object) {
     // Load attribute columns
     for (int i = 0; i < ADCONFIG()->get_columns().count(); i++) {
         const QString attribute = ADCONFIG()->get_columns()[i];
@@ -332,5 +330,5 @@ void ObjectModel::reset() {
 
     const QList<QStandardItem *> row = make_item_row(ADCONFIG()->get_columns().size());
     invis_root->appendRow(row);
-    load_row(row, head_object);
+    load_attributes_row(row, head_object);
 }

--- a/src/admc/object_model.cpp
+++ b/src/admc/object_model.cpp
@@ -64,9 +64,9 @@ ObjectModel::ObjectModel(QObject *parent)
     connect(
         AD(), &AdInterface::object_deleted,
         this, &ObjectModel::on_object_deleted);
-    // connect(
-    //     AD(), &AdInterface::object_changed,
-    //     this, &ObjectModel::on_object_changed);
+    connect(
+        AD(), &AdInterface::object_changed,
+        this, &ObjectModel::on_object_changed);
 }
 
 bool ObjectModel::canFetchMore(const QModelIndex &parent) const {

--- a/src/admc/object_model.h
+++ b/src/admc/object_model.h
@@ -62,8 +62,14 @@ public:
     bool dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent) override;
     bool canDropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent) const override;
 
+private slots:
+    void on_object_added(const QString &dn);
+    void on_object_deleted(const QString &dn);
+    void on_object_changed(const QString &dn);
+
 private:
-    QStandardItem *make_row(QStandardItem *parent, const AdObject &object);
+    void load_row(const QList<QStandardItem *> row, const AdObject &object);
+    QStandardItem *find_object(const QString &dn) const;
 };
 
 #endif /* OBJECT_MODEL_H */

--- a/src/admc/object_model.h
+++ b/src/admc/object_model.h
@@ -56,12 +56,17 @@ public:
     bool dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent) override;
     bool canDropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent) const override;
 
+public slots:
+    void on_filter_changed(const QString &filter);
+
 private slots:
     void on_object_added(const QString &dn);
     void on_object_deleted(const QString &dn);
     void on_object_changed(const QString &dn);
 
 private:
+    QString current_filter;
+
     void load_row(const QList<QStandardItem *> row, const AdObject &object);
     QStandardItem *find_object(const QString &dn) const;
 };

--- a/src/admc/object_model.h
+++ b/src/admc/object_model.h
@@ -26,24 +26,45 @@
 class QMimeData;
 class QModelIndex;
 class QString;
+class QStandardItem;
+class AdObject;
 
+/**
+ * TODO: comment
+ */
 // Model for objects
 // Requires at least a DN column
 // Implements drag/drop of objects using their DN's
+
 class ObjectModel : public QStandardItemModel {
 Q_OBJECT
 
 public:
+    enum Roles {
+        CanFetch = Qt::UserRole + 1,
+        IsContainer = Qt::UserRole + 2,
+    };
+
+    enum Column {
+        Name,
+        DN,
+        COUNT
+    };
+
     const int dn_column;
     
-    ObjectModel(int column_count, int dn_column_in, QObject *parent);
+    ObjectModel(const int column_count, const int dn_column_arg, QObject *parent);
+
+    bool canFetchMore(const QModelIndex &parent) const;
+    void fetchMore(const QModelIndex &parent);
+    bool hasChildren(const QModelIndex &parent) const override;
 
     QMimeData *mimeData(const QModelIndexList &indexes) const override;
     bool dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent) override;
     bool canDropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent) const override;
-    QList<QStandardItem *> find_row(const QString &dn);
-    QStandardItem *find_item(const QString &dn, int col);
 
+private:
+    QStandardItem *make_row(QStandardItem *parent, const AdObject &object);
 };
 
 #endif /* OBJECT_MODEL_H */

--- a/src/admc/object_model.h
+++ b/src/admc/object_model.h
@@ -67,9 +67,10 @@ private slots:
 private:
     QString current_filter;
 
-    void load_row(const QList<QStandardItem *> row, const AdObject &object);
     QStandardItem *find_object(const QString &dn) const;
     void reset();
 };
+
+void load_attributes_row(const QList<QStandardItem *> row, const AdObject &object);
 
 #endif /* OBJECT_MODEL_H */

--- a/src/admc/object_model.h
+++ b/src/admc/object_model.h
@@ -43,6 +43,7 @@ public:
     enum Roles {
         CanFetch = Qt::UserRole + 1,
         IsContainer = Qt::UserRole + 2,
+        AdvancedViewOnly = Qt::UserRole + 3,
     };
 
     enum Column {

--- a/src/admc/object_model.h
+++ b/src/admc/object_model.h
@@ -30,11 +30,10 @@ class QStandardItem;
 class AdObject;
 
 /**
- * TODO: comment
+ * Model used by containers and contents widgets. Contains
+ * attributes of objects. Doesn't load the whole directory
+ * but instead loads it gradually as user expands objects.
  */
-// Model for objects
-// Requires at least a DN column
-// Implements drag/drop of objects using their DN's
 
 class ObjectModel : public QStandardItemModel {
 Q_OBJECT
@@ -72,5 +71,6 @@ private:
 };
 
 void load_attributes_row(const QList<QStandardItem *> row, const AdObject &object);
+QList<QString> object_model_header_labels();
 
 #endif /* OBJECT_MODEL_H */

--- a/src/admc/object_model.h
+++ b/src/admc/object_model.h
@@ -52,9 +52,7 @@ public:
         COUNT
     };
 
-    const int dn_column;
-    
-    ObjectModel(const int column_count, const int dn_column_arg, QObject *parent);
+    ObjectModel(QObject *parent);
 
     bool canFetchMore(const QModelIndex &parent) const;
     void fetchMore(const QModelIndex &parent);

--- a/src/admc/object_model.h
+++ b/src/admc/object_model.h
@@ -69,6 +69,7 @@ private:
 
     void load_row(const QList<QStandardItem *> row, const AdObject &object);
     QStandardItem *find_object(const QString &dn) const;
+    void reset();
 };
 
 #endif /* OBJECT_MODEL_H */

--- a/src/admc/object_model.h
+++ b/src/admc/object_model.h
@@ -46,12 +46,6 @@ public:
         AdvancedViewOnly = Qt::UserRole + 3,
     };
 
-    enum Column {
-        Name,
-        DN,
-        COUNT
-    };
-
     ObjectModel(QObject *parent);
 
     bool canFetchMore(const QModelIndex &parent) const;

--- a/src/admc/policies_widget.cpp
+++ b/src/admc/policies_widget.cpp
@@ -38,6 +38,8 @@ enum PoliciesColumn {
     PoliciesColumn_COUNT,
 };
 
+// TODO: respond to AD object signals
+
 PoliciesWidget::PoliciesWidget()
 : QWidget()
 {   
@@ -69,9 +71,7 @@ PoliciesWidget::PoliciesWidget()
 
     show_only_in_dev_mode(this);
 
-    connect(
-        AD(), &AdInterface::modified,
-        this, &PoliciesWidget::reload);
+    // TODO: inline if won't use this with ad signals
     reload();
 }
 

--- a/src/admc/rename_dialog.cpp
+++ b/src/admc/rename_dialog.cpp
@@ -115,26 +115,22 @@ void RenameDialog::accept() {
 
     STATUS()->start_error_log();
 
-    AD()->start_batch();
-    {
-        const QString new_name = name_edit->text();
-        const bool rename_success = AD()->object_rename(target, new_name);
+    const QString new_name = name_edit->text();
+    const bool rename_success = AD()->object_rename(target, new_name);
 
-        if (rename_success) {
-            const QString new_dn = dn_rename(target, new_name);
-            const bool apply_success = edits_apply(all_edits, new_dn);
+    if (rename_success) {
+        const QString new_dn = dn_rename(target, new_name);
+        const bool apply_success = edits_apply(all_edits, new_dn);
 
-            if (apply_success) {
-                success_msg(old_name);
-                QDialog::close();
-            } else {
-                fail_msg(old_name, this);
-            }
+        if (apply_success) {
+            success_msg(old_name);
+            QDialog::close();
         } else {
             fail_msg(old_name, this);
         }
+    } else {
+        fail_msg(old_name, this);
     }
-    AD()->end_batch();
 }
 
 void RenameDialog::on_edited() {

--- a/translations/en.ts
+++ b/translations/en.ts
@@ -973,14 +973,14 @@
     </message>
 </context>
 <context>
-    <name>ObjectListWidget</name>
+    <name>FindResults</name>
     <message>
-        <location filename="../src/admc/object_list_widget.cpp" line="90"/>
+        <location filename="../src/admc/find_results.cpp" line="90"/>
         <source>Search: </source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/admc/object_list_widget.cpp" line="199"/>
+        <location filename="../src/admc/find_results.cpp" line="199"/>
         <source>%n object(s)</source>
         <translation type="unfinished">
             <numerusform>%n object</numerusform>

--- a/translations/ru.ts
+++ b/translations/ru.ts
@@ -974,14 +974,14 @@
     </message>
 </context>
 <context>
-    <name>ObjectListWidget</name>
+    <name>FindResults</name>
     <message>
-        <location filename="../src/admc/object_list_widget.cpp" line="90"/>
+        <location filename="../src/admc/find_results.cpp" line="90"/>
         <source>Search: </source>
         <translation>Поиск: </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/admc/object_list_widget.cpp" line="199"/>
+        <location filename="../src/admc/find_results.cpp" line="199"/>
         <source>%n object(s)</source>
         <translation>
             <numerusform>%n объект</numerusform>


### PR DESCRIPTION
Share object model between containers and contents. Object model is what was previously the containers model. Contents widgets uses setRootIndex() to focus on a specific container and show it's children. Advanced view and containers filtering is now done through proxies.
Remove AdInterface::modified() signal. Instead object model responds to more specific object change signals which means that a full reload can be avoided (good for perfomance). Dialogs and other widgets are not as responsive to AD changes now, but that can be re-added if necessary.
Object list widget is not used by contents anymore, so now it's just FindResults.
Removed search bar from contents because that doesn't work well with setRootIndex().
Removed columns/columns index stuff and just using ADCONFIG f-ns directly now.
