### PR TITLE
Rework selecting objects

### DIFF
--- a/src/admc/CMakeLists.txt
+++ b/src/admc/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(admc
     rename_policy_dialog.cpp
     create_dialog.cpp
     find_dialog.cpp
+    move_dialog.cpp
     policies_widget.cpp
     gplink.cpp
 

--- a/src/admc/CMakeLists.txt
+++ b/src/admc/CMakeLists.txt
@@ -45,7 +45,7 @@ add_executable(admc
     rename_policy_dialog.cpp
     create_dialog.cpp
     find_dialog.cpp
-    move_dialog.cpp
+    select_container_dialog.cpp
     policies_widget.cpp
     gplink.cpp
 

--- a/src/admc/edits/manager_edit.cpp
+++ b/src/admc/edits/manager_edit.cpp
@@ -81,7 +81,8 @@ bool ManagerEdit::apply(const QString &dn) const {
 
 void ManagerEdit::on_change() {
     const QString title = QString(tr("Select manager"));
-    const QList<QString> selected_objects = SelectDialog::open({CLASS_USER}, SelectDialogMultiSelection_No, title, edit);
+    const QList<QString> classes = {CLASS_USER, CLASS_CONTACT};
+    const QList<QString> selected_objects = SelectDialog::open(classes, SelectDialogMultiSelection_No, title, edit);
 
     if (selected_objects.size() > 0) {
         load_value(selected_objects[0]);

--- a/src/admc/filter_dialog.cpp
+++ b/src/admc/filter_dialog.cpp
@@ -18,6 +18,8 @@
  */
 
 #include "filter_dialog.h"
+#include "filter.h"
+#include "ad_config.h"
 
 #include "filter_widget/filter_widget.h"
 
@@ -29,7 +31,21 @@ FilterDialog::FilterDialog(QWidget *parent)
 {   
     setWindowTitle(tr("Filter contents"));
 
-    auto filter_widget = new FilterWidget();
+    // NOTE: Can't filter out container objects, because otherwise the whole tree can't be displayed, so only allow filtering by non-container classes.
+    // = all classes - container classes
+    const QList<QString> noncontainer_classes =
+    []() {
+        QList<QString> out = filter_classes;
+
+        const QList<QString> container_classes = ADCONFIG()->get_filter_containers();
+        for (const QString container_class : container_classes) {
+            out.removeAll(container_class);
+        }
+
+        return out;
+    }();
+
+    auto filter_widget = new FilterWidget(noncontainer_classes);
 
     auto buttonbox = new QDialogButtonBox();
     buttonbox->addButton(QDialogButtonBox::Ok);

--- a/src/admc/filter_widget/filter_widget.cpp
+++ b/src/admc/filter_widget/filter_widget.cpp
@@ -26,7 +26,7 @@
 #include <QTabWidget>
 #include <QVBoxLayout>
 
-FilterWidget::FilterWidget()
+FilterWidget::FilterWidget(const QList<QString> classes)
 : QWidget()
 {
     tab_widget = new QTabWidget();
@@ -42,9 +42,9 @@ FilterWidget::FilterWidget()
             });
     };
 
-    auto simple_tab = new FilterWidgetSimpleTab();
+    auto simple_tab = new FilterWidgetSimpleTab(classes);
     add_tab(simple_tab, tr("Simple"));
-    add_tab(new FilterWidgetNormalTab(), tr("Normal"));
+    add_tab(new FilterWidgetNormalTab(classes), tr("Normal"));
     add_tab(new FilterWidgetAdvancedTab(), tr("Advanced"));
 
     auto layout = new QVBoxLayout();

--- a/src/admc/filter_widget/filter_widget.h
+++ b/src/admc/filter_widget/filter_widget.h
@@ -36,7 +36,7 @@ class FilterWidget final : public QWidget {
 Q_OBJECT
 
 public:
-    FilterWidget();
+    FilterWidget(const QList<QString> classes);
 
     QString get_filter() const;
 

--- a/src/admc/filter_widget/filter_widget.h
+++ b/src/admc/filter_widget/filter_widget.h
@@ -27,9 +27,9 @@
  */
 
 #include <QWidget>
-#include <QString>
 
 class QTabWidget;
+class QString;
 class FilterWidgetTab;
 
 class FilterWidget final : public QWidget {

--- a/src/admc/filter_widget/filter_widget_normal_tab.cpp
+++ b/src/admc/filter_widget/filter_widget_normal_tab.cpp
@@ -29,10 +29,10 @@
 #include <QListWidget>
 #include <QDebug>
 
-FilterWidgetNormalTab::FilterWidgetNormalTab()
+FilterWidgetNormalTab::FilterWidgetNormalTab(const QList<QString> classes)
 : FilterWidgetTab()
 {
-    select_classes = new SelectClassesWidget();
+    select_classes = new SelectClassesWidget(classes);
 
     filter_builder = new FilterBuilder();
 

--- a/src/admc/filter_widget/filter_widget_normal_tab.h
+++ b/src/admc/filter_widget/filter_widget_normal_tab.h
@@ -31,8 +31,7 @@
 
 #include "filter_widget/filter_widget.h"
 
-#include <QString>
-
+class QString;
 class QListWidget;
 class SelectClassesWidget;
 class FilterBuilder;

--- a/src/admc/filter_widget/filter_widget_normal_tab.h
+++ b/src/admc/filter_widget/filter_widget_normal_tab.h
@@ -41,7 +41,7 @@ class FilterWidgetNormalTab final : public FilterWidgetTab {
 Q_OBJECT
 
 public:
-    FilterWidgetNormalTab();
+    FilterWidgetNormalTab(const QList<QString> classes);
 
     QString get_filter() const;
 

--- a/src/admc/filter_widget/filter_widget_simple_tab.cpp
+++ b/src/admc/filter_widget/filter_widget_simple_tab.cpp
@@ -26,10 +26,10 @@
 #include <QFormLayout>
 #include <QLabel>
 
-FilterWidgetSimpleTab::FilterWidgetSimpleTab()
+FilterWidgetSimpleTab::FilterWidgetSimpleTab(const QList<QString> classes)
 : FilterWidgetTab()
 {
-    select_classes = new SelectClassesWidget();
+    select_classes = new SelectClassesWidget(classes);
 
     name_edit = new QLineEdit(this);
 

--- a/src/admc/filter_widget/filter_widget_simple_tab.cpp
+++ b/src/admc/filter_widget/filter_widget_simple_tab.cpp
@@ -24,7 +24,6 @@
 
 #include <QLineEdit>
 #include <QFormLayout>
-#include <QLabel>
 
 FilterWidgetSimpleTab::FilterWidgetSimpleTab(const QList<QString> classes)
 : FilterWidgetTab()

--- a/src/admc/filter_widget/filter_widget_simple_tab.h
+++ b/src/admc/filter_widget/filter_widget_simple_tab.h
@@ -33,7 +33,7 @@ class FilterWidgetSimpleTab final : public FilterWidgetTab {
 Q_OBJECT
 
 public:
-    FilterWidgetSimpleTab();
+    FilterWidgetSimpleTab(const QList<QString> classes);
 
     QString get_filter() const;
 

--- a/src/admc/filter_widget/select_classes_widget.cpp
+++ b/src/admc/filter_widget/select_classes_widget.cpp
@@ -31,7 +31,7 @@
 #include <QDialogButtonBox>
 #include <QPushButton>
 
-SelectClassesWidget::SelectClassesWidget()
+SelectClassesWidget::SelectClassesWidget(const QList<QString> classes)
 : QWidget()
 {
     classes_display = new QLineEdit();
@@ -48,10 +48,6 @@ SelectClassesWidget::SelectClassesWidget()
 
     dialog = new QDialog(this);
 
-    for (const QString object_class : filter_classes) {
-        dialog_checks[object_class] = new QCheckBox();
-    }
-
     auto select_all_button = new QPushButton(tr("Select all"));
     auto clear_selection_button = new QPushButton(tr("Clear selection"));
 
@@ -60,9 +56,11 @@ SelectClassesWidget::SelectClassesWidget()
     dialog_buttons->addButton(QDialogButtonBox::Cancel);
 
     auto checks_layout = new QFormLayout();
-    for (const QString object_class : filter_classes) {
-        auto check = dialog_checks[object_class];
+    for (const QString object_class : classes) {
+        auto check = new QCheckBox();
         check->setChecked(true);
+        
+        dialog_checks[object_class] = check;
 
         const QString class_display = ADCONFIG()->get_class_display_name(object_class);
         checks_layout->addRow(class_display, check);
@@ -142,6 +140,7 @@ void SelectClassesWidget::on_dialog_accepted() {
     }();
 
     classes_display->setText(classes_display_text);
+    classes_display->setCursorPosition(0);
 }
 
 void SelectClassesWidget::select_all() {
@@ -174,7 +173,7 @@ void SelectClassesWidget::on_check_changed() {
 QList<QString> SelectClassesWidget::get_selected_classes() const {
     QList<QString> out;
 
-    for (const QString object_class : filter_classes) {
+    for (const QString object_class : dialog_checks.keys()) {
         const QCheckBox *check = dialog_checks[object_class];
 
         if (check->isChecked()) {

--- a/src/admc/filter_widget/select_classes_widget.cpp
+++ b/src/admc/filter_widget/select_classes_widget.cpp
@@ -29,13 +29,13 @@
 #include <QCheckBox>
 #include <QLineEdit>
 #include <QDialogButtonBox>
+#include <QPushButton>
 
 SelectClassesWidget::SelectClassesWidget()
 : QWidget()
 {
     classes_display = new QLineEdit();
     classes_display->setReadOnly(true);
-    classes_display->setPlaceholderText(tr("All classes"));
 
     auto select_classes_button = new QPushButton(tr("Select"));
     select_classes_button->setAutoDefault(false);
@@ -52,19 +52,31 @@ SelectClassesWidget::SelectClassesWidget()
         dialog_checks[object_class] = new QCheckBox();
     }
 
-    auto dialog_buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+    auto select_all_button = new QPushButton(tr("Select all"));
+    auto clear_selection_button = new QPushButton(tr("Clear selection"));
+
+    auto dialog_buttons = new QDialogButtonBox();
+    ok_button = dialog_buttons->addButton(QDialogButtonBox::Ok);
+    dialog_buttons->addButton(QDialogButtonBox::Cancel);
 
     auto checks_layout = new QFormLayout();
     for (const QString object_class : filter_classes) {
         auto check = dialog_checks[object_class];
+        check->setChecked(true);
 
         const QString class_display = ADCONFIG()->get_class_display_name(object_class);
         checks_layout->addRow(class_display, check);
+
+        connect(
+            check, &QCheckBox::stateChanged,
+            this, &SelectClassesWidget::on_check_changed);
     }
 
     auto dialog_layout = new QVBoxLayout();
     dialog->setLayout(dialog_layout);
     dialog_layout->addLayout(checks_layout);
+    dialog_layout->addWidget(select_all_button);
+    dialog_layout->addWidget(clear_selection_button);
     dialog_layout->addWidget(dialog_buttons);
     
     connect(
@@ -73,10 +85,16 @@ SelectClassesWidget::SelectClassesWidget()
     connect(
         dialog_buttons, &QDialogButtonBox::rejected,
         dialog, &QDialog::reject);
-
+    connect(
+        select_all_button, &QPushButton::clicked,
+        this, &SelectClassesWidget::select_all);
+    connect(
+        clear_selection_button, &QPushButton::clicked,
+        this, &SelectClassesWidget::clear_selection);
     connect(
         dialog, &QDialog::accepted,
         this, &SelectClassesWidget::on_dialog_accepted);
+    on_dialog_accepted();
 
     connect(
         select_classes_button, &QAbstractButton::clicked,
@@ -124,6 +142,33 @@ void SelectClassesWidget::on_dialog_accepted() {
     }();
 
     classes_display->setText(classes_display_text);
+}
+
+void SelectClassesWidget::select_all() {
+    for (QCheckBox *check : dialog_checks.values()) {
+        check->setChecked(true);
+    }
+}
+
+void SelectClassesWidget::clear_selection() {
+    for (QCheckBox *check : dialog_checks.values()) {
+        check->setChecked(false);
+    }
+}
+
+void SelectClassesWidget::on_check_changed() {
+    const bool any_checked =
+    [this]() {
+        for (QCheckBox *check : dialog_checks.values()) {
+            if (check->isChecked()) {
+                return true;
+            }
+        }
+
+        return false;
+    }();
+
+    ok_button->setEnabled(any_checked);
 }
 
 QList<QString> SelectClassesWidget::get_selected_classes() const {

--- a/src/admc/filter_widget/select_classes_widget.h
+++ b/src/admc/filter_widget/select_classes_widget.h
@@ -25,13 +25,13 @@
  */
 
 #include <QWidget>
-#include <QString>
 #include <QHash>
 
 class QLineEdit;
 class QDialog;
 class QCheckBox;
 class QPushButton;
+class QString;
 
 class SelectClassesWidget final : public QWidget {
 Q_OBJECT

--- a/src/admc/filter_widget/select_classes_widget.h
+++ b/src/admc/filter_widget/select_classes_widget.h
@@ -37,7 +37,7 @@ class SelectClassesWidget final : public QWidget {
 Q_OBJECT
     
 public:
-    SelectClassesWidget();
+    SelectClassesWidget(const QList<QString> classes);
 
     // Return a filter that accepts only selected classes
     QString get_filter() const;

--- a/src/admc/filter_widget/select_classes_widget.h
+++ b/src/admc/filter_widget/select_classes_widget.h
@@ -31,6 +31,7 @@
 class QLineEdit;
 class QDialog;
 class QCheckBox;
+class QPushButton;
 
 class SelectClassesWidget final : public QWidget {
 Q_OBJECT
@@ -43,11 +44,15 @@ public:
 
 private slots:
     void on_dialog_accepted();
+    void select_all();
+    void clear_selection();
+    void on_check_changed();
 
 private:
     QLineEdit *classes_display;
     QDialog *dialog;
     QHash<QString, QCheckBox *> dialog_checks;
+    QPushButton *ok_button;
 
     QList<QString> get_selected_classes() const;
 };

--- a/src/admc/find_dialog.cpp
+++ b/src/admc/find_dialog.cpp
@@ -22,7 +22,6 @@
 #include "ad_utils.h"
 #include "ad_config.h"
 #include "settings.h"
-#include "containers_widget.h"
 #include "utils.h"
 #include "filter.h"
 #include "filter_widget/filter_widget.h"
@@ -32,16 +31,10 @@
 
 #include <QString>
 #include <QList>
-#include <QLineEdit>
-#include <QFormLayout>
-#include <QGroupBox>
-#include <QLabel>
 #include <QTreeView>
-#include <QSortFilterProxyModel>
+#include <QFormLayout>
 #include <QComboBox>
 #include <QPushButton>
-#include <QItemSelectionModel>
-#include <QStandardItemModel>
 #include <QDebug>
 #include <QCheckBox>
 #include <QMenuBar>

--- a/src/admc/find_dialog.cpp
+++ b/src/admc/find_dialog.cpp
@@ -47,7 +47,7 @@
 #include <QMenuBar>
 #include <QDialogButtonBox>
 
-FindDialog::FindDialog(const FindDialogType type_arg, const QString &default_search_base, QWidget *parent)
+FindDialog::FindDialog(const FindDialogType type_arg, const QList<QString> classes, const QString &default_search_base, QWidget *parent)
 : QDialog(parent)
 {
     type = type_arg;
@@ -67,7 +67,7 @@ FindDialog::FindDialog(const FindDialogType type_arg, const QString &default_sea
     auto custom_search_base_button = new QPushButton(tr("Browse"));
     custom_search_base_button->setAutoDefault(false);
 
-    filter_widget = new FilterWidget();
+    filter_widget = new FilterWidget(classes);
 
     auto quick_find_check = new QCheckBox(tr("Quick find"));
 

--- a/src/admc/find_dialog.cpp
+++ b/src/admc/find_dialog.cpp
@@ -144,6 +144,7 @@ FindDialog::FindDialog(const QString &default_search_base, QWidget *parent)
 
 void FindDialog::select_custom_search_base() {
     auto dialog = new SelectContainerDialog(parentWidget());
+    dialog->setWindowTitle(tr("Select custom search base"));
 
     connect(
         dialog, &SelectContainerDialog::accepted,

--- a/src/admc/find_dialog.cpp
+++ b/src/admc/find_dialog.cpp
@@ -27,7 +27,7 @@
 #include "filter.h"
 #include "filter_widget/filter_widget.h"
 #include "find_results.h"
-#include "select_dialog.h"
+#include "select_container_dialog.h"
 #include "object_menu.h"
 
 #include <QString>
@@ -143,20 +143,22 @@ FindDialog::FindDialog(const QString &default_search_base, QWidget *parent)
 }
 
 void FindDialog::select_custom_search_base() {
-    // TODO: maybe need some other classes?
-    const QString title = QString(tr("Select search base"));
-    const QList<QString> selecteds = SelectDialog::open({CLASS_CONTAINER, CLASS_OU}, SelectDialogMultiSelection_Yes, title, this);
+    auto dialog = new SelectContainerDialog(parentWidget());
 
-    if (!selecteds.isEmpty()) {
-        const QString selected = selecteds[0];
-        const QString name = dn_get_name(selected);
+    connect(
+        dialog, &SelectContainerDialog::accepted,
+        [this, dialog]() {
+            const QString selected = dialog->get_selected();
+            const QString name = dn_get_name(selected);
 
-        search_base_combo->addItem(name, selected);
+            search_base_combo->addItem(name, selected);
 
-        // Select newly added search base in combobox
-        const int new_base_index = search_base_combo->count() - 1;
-        search_base_combo->setCurrentIndex(new_base_index);
-    }
+            // Select newly added search base in combobox
+            const int new_base_index = search_base_combo->count() - 1;
+            search_base_combo->setCurrentIndex(new_base_index);
+        });
+
+    dialog->open();
 }
 
 void FindDialog::on_filter_changed() {

--- a/src/admc/find_dialog.h
+++ b/src/admc/find_dialog.h
@@ -33,12 +33,21 @@ class FilterWidget;
 class FindResults;
 class QComboBox;
 class ObjectMenu;
+class QStandardItem;
+template <typename T> class QList;
+
+enum FindDialogType {
+    FindDialogType_Normal,
+    FindDialogType_Select,
+};
 
 class FindDialog final : public QDialog {
 Q_OBJECT
 
 public:
-    FindDialog(const QString &default_search_base, QWidget *parent);
+    FindDialog(const FindDialogType type_arg, const QString &default_search_base, QWidget *parent);
+
+    QList<QList<QStandardItem *>> get_selected_rows() const;
 
 private slots:
     void select_custom_search_base();
@@ -46,6 +55,7 @@ private slots:
     void find();
 
 private:
+    FindDialogType type;
     FilterWidget *filter_widget;
     FindResults *find_results;
     QComboBox *search_base_combo;

--- a/src/admc/find_dialog.h
+++ b/src/admc/find_dialog.h
@@ -32,7 +32,6 @@
 class FilterWidget;
 class FindResults;
 class QComboBox;
-class ObjectMenu;
 class QStandardItem;
 template <typename T> class QList;
 

--- a/src/admc/find_dialog.h
+++ b/src/admc/find_dialog.h
@@ -45,7 +45,7 @@ class FindDialog final : public QDialog {
 Q_OBJECT
 
 public:
-    FindDialog(const FindDialogType type_arg, const QString &default_search_base, QWidget *parent);
+    FindDialog(const FindDialogType type_arg, const QList<QString> classes, const QString &default_search_base, QWidget *parent);
 
     QList<QList<QStandardItem *>> get_selected_rows() const;
 

--- a/src/admc/find_results.cpp
+++ b/src/admc/find_results.cpp
@@ -21,21 +21,15 @@
 #include "object_menu.h"
 #include "details_dialog.h"
 #include "utils.h"
+#include "filter.h"
 #include "ad_interface.h"
 #include "ad_config.h"
-#include "ad_utils.h"
-#include "ad_object.h"
-#include "attribute_display.h"
-#include "filter.h"
-#include "settings.h"
 #include "object_model.h"
-#include "find_dialog.h"
 
 #include <QTreeView>
 #include <QLabel>
 #include <QHeaderView>
 #include <QDebug>
-#include <QStandardItemModel>
 #include <QVBoxLayout>
 
 FindResults::FindResults(const FindDialogType type)

--- a/src/admc/find_results.h
+++ b/src/admc/find_results.h
@@ -26,10 +26,13 @@
  */
 
 #include <QWidget>
+#include "find_dialog.h"
 
 class QTreeView;
 class QLabel;
 class QStandardItemModel;
+class QStandardItem;
+template <typename T> class QList;
 
 class FindResults final : public QWidget {
 Q_OBJECT
@@ -37,9 +40,12 @@ Q_OBJECT
 public:
     QTreeView *view;
     
-    FindResults();
+    FindResults(const FindDialogType type);
 
     void load(const QString &filter, const QString &search_base);
+
+    // Returns a copy of item's rows, so these items need to become owned by something or deleted
+    QList<QList<QStandardItem *>> get_selected_rows() const;
 
 private:
     QStandardItemModel *model;

--- a/src/admc/find_results.h
+++ b/src/admc/find_results.h
@@ -26,6 +26,8 @@
  */
 
 #include <QWidget>
+
+// TODO: remove when merged with find dialog
 #include "find_dialog.h"
 
 class QTreeView;

--- a/src/admc/move_dialog.cpp
+++ b/src/admc/move_dialog.cpp
@@ -1,0 +1,103 @@
+/*
+ * ADMC - AD Management Center
+ *
+ * Copyright (C) 2020 BaseALT Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "move_dialog.h"
+
+#include "object_model.h"
+#include "containers_proxy.h"
+#include "advanced_view_proxy.h"
+#include "ad_interface.h"
+#include "ad_config.h"
+#include "ad_defines.h"
+#include "utils.h"
+#include "status.h"
+
+#include <QTreeView>
+#include <QVBoxLayout>
+#include <QDialogButtonBox>
+#include <QPushButton>
+
+MoveDialog::MoveDialog(const QList<QString> targets_arg, QWidget *parent)
+: QDialog(parent)
+{
+    targets = targets_arg;
+    
+    setAttribute(Qt::WA_DeleteOnClose);
+    
+    resize(400, 500);
+
+    auto model = new ObjectModel(this);
+
+    view = new QTreeView(this);
+    view->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    view->setExpandsOnDoubleClick(true);
+    view->setAllColumnsShowFocus(true);
+    view->setSortingEnabled(true);
+    view->sortByColumn(ADCONFIG()->get_column_index(ATTRIBUTE_NAME), Qt::AscendingOrder);
+
+    auto advanced_view_proxy = new AdvancedViewProxy(this);
+    auto containers_proxy = new ContainersProxy(this);
+
+    containers_proxy->setSourceModel(model);
+    advanced_view_proxy->setSourceModel(containers_proxy);
+    view->setModel(advanced_view_proxy);
+
+    setup_column_toggle_menu(view, model, {ADCONFIG()->get_column_index(ATTRIBUTE_NAME)});
+
+    auto buttonbox = new QDialogButtonBox();
+    auto ok_button = buttonbox->addButton(QDialogButtonBox::Ok);
+    buttonbox->addButton(QDialogButtonBox::Cancel);
+
+    connect(
+        buttonbox, &QDialogButtonBox::accepted,
+        this, &QDialog::accept);
+    connect(
+        buttonbox, &QDialogButtonBox::rejected,
+        this, &QDialog::reject);
+
+    enable_widget_on_selection(ok_button, view);
+
+    const auto layout = new QVBoxLayout();
+    setLayout(layout);
+    layout->addWidget(view);
+    layout->addWidget(buttonbox);
+}
+
+void MoveDialog::accept() {
+    const QModelIndex selected = view->selectionModel()->currentIndex();
+    const QString container = get_dn_from_index(selected, ADCONFIG()->get_column_index(ATTRIBUTE_DN));
+
+    STATUS()->start_error_log();
+
+    for (const QString target : targets) {
+        AD()->object_move(target, container);
+    }
+
+    STATUS()->end_error_log(parentWidget());
+
+    QDialog::accept();
+}
+
+void MoveDialog::showEvent(QShowEvent *event) {
+    resize_columns(view,
+    {
+        {ADCONFIG()->get_column_index(ATTRIBUTE_NAME), 0.5},
+        {ADCONFIG()->get_column_index(ATTRIBUTE_DN), 0.5},
+    });
+}

--- a/src/admc/move_dialog.h
+++ b/src/admc/move_dialog.h
@@ -22,9 +22,7 @@
 
 /**
  * Displays a tree of container objects, similarly to
- * Containers widget. Once user selects a container and
- * accepts the dialog, targets will be moved to selected
- * container.
+ * Containers widget. User can selected a container.
  */
 
 #include <QDialog>
@@ -35,16 +33,12 @@ class MoveDialog final : public QDialog {
 Q_OBJECT
 
 public:
-    MoveDialog(const QList<QString> targets_arg, QWidget *parent);
+    MoveDialog(QWidget *parent);
 
-private slots:
-    void accept();
+    QString get_selected() const;
 
 private:
     QTreeView *view;
-    QList<QString> targets;
-
-    void showEvent(QShowEvent *event);
 
 };
 

--- a/src/admc/move_dialog.h
+++ b/src/admc/move_dialog.h
@@ -17,36 +17,35 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SELECT_DIALOG_H
-#define SELECT_DIALOG_H
+#ifndef MOVE_DIALOG_H
+#define MOVE_DIALOG_H
+
+/**
+ * Displays a tree of container objects, similarly to
+ * Containers widget. Once user selects a container and
+ * accepts the dialog, targets will be moved to selected
+ * container.
+ */
 
 #include <QDialog>
-#include <QString>
-#include <QList>
 
 class QTreeView;
 
-enum SelectDialogMultiSelection {
-    SelectDialogMultiSelection_Yes,
-    SelectDialogMultiSelection_No
-};
-
-class SelectDialog final : public QDialog {
+class MoveDialog final : public QDialog {
 Q_OBJECT
 
 public:
-    static QList<QString> open(QList<QString> classes, SelectDialogMultiSelection multi_selection, const QString &title, QWidget *parent);
+    MoveDialog(const QList<QString> targets_arg, QWidget *parent);
 
 private slots:
     void accept();
 
 private:
     QTreeView *view;
-    QList<QString> selected_objects;
-
-    SelectDialog(QList<QString> classes, SelectDialogMultiSelection multi_selection, QWidget *parent);
+    QList<QString> targets;
 
     void showEvent(QShowEvent *event);
+
 };
 
-#endif /* SELECT_DIALOG_H */
+#endif /* MOVE_DIALOG_H */

--- a/src/admc/object_menu.cpp
+++ b/src/admc/object_menu.cpp
@@ -31,6 +31,7 @@
 #include "select_container_dialog.h"
 #include "utils.h"
 #include "find_dialog.h"
+#include "filter.h"
 #include "status.h"
 #include "object_model.h"
 
@@ -338,7 +339,7 @@ void ObjectMenu::disable_account() const {
 
 void ObjectMenu::find() const {
     if (targets.size() == 1) {
-        auto find_dialog = new FindDialog(FindDialogType_Normal, targets[0], parentWidget());
+        auto find_dialog = new FindDialog(FindDialogType_Normal, filter_classes, targets[0], parentWidget());
         find_dialog->open();
     }
 }

--- a/src/admc/object_menu.cpp
+++ b/src/admc/object_menu.cpp
@@ -277,6 +277,7 @@ void ObjectMenu::move() const {
     dialog->open();
 }
 
+// TODO: aduc also includes "built-in security principals" which equates to groups that are located in builtin container. Those objects are otherwise completely identical to other group objects, same class and everything. Adding this would be convenient but also a massive PITA because that would mean making select classes widget somehow have mixed options for classes and whether parent object is the Builtin
 void ObjectMenu::add_to_group() const {
     const QList<QString> classes = {CLASS_GROUP};
     const QString title = QString(tr("Add %1 to group")).arg(targets_display_string());

--- a/src/admc/object_menu.cpp
+++ b/src/admc/object_menu.cpp
@@ -338,7 +338,7 @@ void ObjectMenu::disable_account() const {
 
 void ObjectMenu::find() const {
     if (targets.size() == 1) {
-        auto find_dialog = new FindDialog(targets[0], parentWidget());
+        auto find_dialog = new FindDialog(FindDialogType_Normal, targets[0], parentWidget());
         find_dialog->open();
     }
 }

--- a/src/admc/object_menu.cpp
+++ b/src/admc/object_menu.cpp
@@ -28,6 +28,7 @@
 #include "password_dialog.h"
 #include "create_dialog.h"
 #include "details_dialog.h"
+#include "move_dialog.h"
 #include "utils.h"
 #include "find_dialog.h"
 #include "status.h"
@@ -253,23 +254,8 @@ void ObjectMenu::delete_object() const {
 }
 
 void ObjectMenu::move() const {
-    // NOTE: object classes have "possible superiors" in schema which technically means that certain objects have certain sets of possible move targets. Going the simple route and just showing all objects that show up in container tree instead.
-    const QList<QString> move_targets = ADCONFIG()->get_filter_containers();
-
-    const QString title = QString(tr("Move %1")).arg(targets_display_string());
-    const QList<QString> selected_objects = SelectDialog::open(move_targets, SelectDialogMultiSelection_No, title, parentWidget());
-
-    if (selected_objects.size() == 1) {
-        const QString container = selected_objects[0];
-
-        STATUS()->start_error_log();
-
-        for (const QString target : targets) {
-            AD()->object_move(target, container);
-        }
-
-        STATUS()->end_error_log(parentWidget());
-    }
+    auto move_dialog = new MoveDialog(targets, parentWidget());
+    move_dialog->open();
 }
 
 void ObjectMenu::add_to_group() const {

--- a/src/admc/object_menu.cpp
+++ b/src/admc/object_menu.cpp
@@ -287,7 +287,6 @@ void ObjectMenu::add_to_group() const {
     const QList<QString> classes = {CLASS_GROUP};
     const QString title = QString(tr("Add %1 to group")).arg(targets_display_string());
     const QList<QString> selected_objects = SelectDialog::open(classes, SelectDialogMultiSelection_Yes, title, parentWidget());
-
     if (selected_objects.size() > 0) {
         STATUS()->start_error_log();
         

--- a/src/admc/object_menu.cpp
+++ b/src/admc/object_menu.cpp
@@ -256,6 +256,9 @@ void ObjectMenu::delete_object() const {
 void ObjectMenu::move() const {
     auto dialog = new SelectContainerDialog(parentWidget());
 
+    const QString title = QString(tr("Move %1")).arg(targets_display_string());
+    dialog->setWindowTitle(title);
+
     connect(
         dialog, &SelectContainerDialog::accepted,
         [this, dialog]() {

--- a/src/admc/object_menu.cpp
+++ b/src/admc/object_menu.cpp
@@ -254,8 +254,23 @@ void ObjectMenu::delete_object() const {
 }
 
 void ObjectMenu::move() const {
-    auto move_dialog = new MoveDialog(targets, parentWidget());
-    move_dialog->open();
+    auto dialog = new MoveDialog(parentWidget());
+
+    connect(
+        dialog, &MoveDialog::accepted,
+        [this, dialog]() {
+            const QString selected = dialog->get_selected();
+
+            STATUS()->start_error_log();
+
+            for (const QString target : targets) {
+                AD()->object_move(target, selected);
+            }
+
+            STATUS()->end_error_log(parentWidget());
+        });
+
+    dialog->open();
 }
 
 void ObjectMenu::add_to_group() const {

--- a/src/admc/object_menu.cpp
+++ b/src/admc/object_menu.cpp
@@ -260,18 +260,23 @@ void ObjectMenu::move() const {
     const QString title = QString(tr("Move %1")).arg(targets_display_string());
     dialog->setWindowTitle(title);
 
+    // NOTE: can't pass "this" ptr to access member vars
+    // because menu is deleted when dialog is opened, so it
+    // no longer exists by the time dialog is accepted
+    QWidget *parent_widget = parentWidget();
+    const QList<QString> targets_copy = targets;
+
     connect(
         dialog, &SelectContainerDialog::accepted,
-        [this, dialog]() {
+        [dialog, parent_widget, targets_copy]() {
             const QString selected = dialog->get_selected();
-
             STATUS()->start_error_log();
 
-            for (const QString target : targets) {
+            for (const QString target : targets_copy) {
                 AD()->object_move(target, selected);
             }
 
-            STATUS()->end_error_log(parentWidget());
+            STATUS()->end_error_log(parent_widget);
         });
 
     dialog->open();

--- a/src/admc/object_menu.cpp
+++ b/src/admc/object_menu.cpp
@@ -28,7 +28,7 @@
 #include "password_dialog.h"
 #include "create_dialog.h"
 #include "details_dialog.h"
-#include "move_dialog.h"
+#include "select_container_dialog.h"
 #include "utils.h"
 #include "find_dialog.h"
 #include "status.h"
@@ -254,10 +254,10 @@ void ObjectMenu::delete_object() const {
 }
 
 void ObjectMenu::move() const {
-    auto dialog = new MoveDialog(parentWidget());
+    auto dialog = new SelectContainerDialog(parentWidget());
 
     connect(
-        dialog, &MoveDialog::accepted,
+        dialog, &SelectContainerDialog::accepted,
         [this, dialog]() {
             const QString selected = dialog->get_selected();
 

--- a/src/admc/select_container_dialog.cpp
+++ b/src/admc/select_container_dialog.cpp
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "move_dialog.h"
+#include "select_container_dialog.h"
 
 #include "object_model.h"
 #include "containers_proxy.h"
@@ -32,7 +32,7 @@
 #include <QPushButton>
 #include <QHeaderView>
 
-MoveDialog::MoveDialog(QWidget *parent)
+SelectContainerDialog::SelectContainerDialog(QWidget *parent)
 : QDialog(parent)
 {
     setAttribute(Qt::WA_DeleteOnClose);
@@ -83,7 +83,7 @@ MoveDialog::MoveDialog(QWidget *parent)
     layout->addWidget(buttonbox);
 }
 
-QString MoveDialog::get_selected() const {
+QString SelectContainerDialog::get_selected() const {
     const QModelIndex selected_index = view->selectionModel()->currentIndex();
     const QString selected = get_dn_from_index(selected_index, ADCONFIG()->get_column_index(ATTRIBUTE_DN));
 

--- a/src/admc/select_container_dialog.cpp
+++ b/src/admc/select_container_dialog.cpp
@@ -40,6 +40,7 @@ SelectContainerDialog::SelectContainerDialog(QWidget *parent)
     resize(400, 500);
 
     auto model = new ObjectModel(this);
+    model->load_head_object();
 
     view = new QTreeView(this);
     view->setEditTriggers(QAbstractItemView::NoEditTriggers);

--- a/src/admc/select_container_dialog.h
+++ b/src/admc/select_container_dialog.h
@@ -17,8 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MOVE_DIALOG_H
-#define MOVE_DIALOG_H
+#ifndef SELECT_CONTAINER_DIALOG_H
+#define SELECT_CONTAINER_DIALOG_H
 
 /**
  * Displays a tree of container objects, similarly to
@@ -29,11 +29,11 @@
 
 class QTreeView;
 
-class MoveDialog final : public QDialog {
+class SelectContainerDialog final : public QDialog {
 Q_OBJECT
 
 public:
-    MoveDialog(QWidget *parent);
+    SelectContainerDialog(QWidget *parent);
 
     QString get_selected() const;
 
@@ -42,4 +42,4 @@ private:
 
 };
 
-#endif /* MOVE_DIALOG_H */
+#endif /* SELECT_CONTAINER_DIALOG_H */

--- a/src/admc/select_dialog.cpp
+++ b/src/admc/select_dialog.cpp
@@ -29,15 +29,11 @@
 #include "object_model.h"
 #include "find_dialog.h"
 
-#include <QLineEdit>
-#include <QGridLayout>
-#include <QLabel>
+#include <QHBoxLayout>
+#include <QVBoxLayout>
 #include <QTreeView>
-#include <QSortFilterProxyModel>
-#include <QComboBox>
 #include <QPushButton>
 #include <QItemSelectionModel>
-#include <QStandardItemModel>
 #include <QDialogButtonBox>
 #include <QMessageBox>
 

--- a/src/admc/select_dialog.cpp
+++ b/src/admc/select_dialog.cpp
@@ -60,9 +60,10 @@ QList<QString> SelectDialog::open(QList<QString> classes, SelectDialogMultiSelec
     return dialog.get_selected();
 }
 
-SelectDialog::SelectDialog(QList<QString> classes, SelectDialogMultiSelection multi_selection_arg, QWidget *parent)
+SelectDialog::SelectDialog(QList<QString> classes_arg, SelectDialogMultiSelection multi_selection_arg, QWidget *parent)
 : QDialog(parent)
 {
+    classes = classes_arg;
     multi_selection = multi_selection_arg;
 
     resize(400, 300);
@@ -144,7 +145,7 @@ void SelectDialog::accept() {
 }
 
 void SelectDialog::open_find_dialog() {
-    auto dialog = new FindDialog(FindDialogType_Select, AD()->domain_head(), this);
+    auto dialog = new FindDialog(FindDialogType_Select, classes, AD()->domain_head(), this);
 
     connect(
         dialog, &FindDialog::accepted,

--- a/src/admc/select_dialog.cpp
+++ b/src/admc/select_dialog.cpp
@@ -152,9 +152,10 @@ void SelectDialog::open_find_dialog() {
         [this, dialog]() {
             // Add objects selected in find dialog to select
             // objects list
+            // NOTE: adding selected objects could've been done by just getting selected DN's, BUT that would involve performing a search for each of the objects to get necessary attributes to create rows. Object amounts can be potentially huge, so that would really hurt performance. So, instead we're getting raw rows of items even though it's kinda messy. In summary: DN's = simple, very slow; items = messy, fast.
             const QList<QString> current_selected = get_selected();
 
-            QList<QList<QStandardItem *>> selected_rows = dialog->get_selected_rows();
+            const QList<QList<QStandardItem *>> selected_rows = dialog->get_selected_rows();
 
             for (auto row : selected_rows) {
                 const bool model_contains_object =

--- a/src/admc/select_dialog.cpp
+++ b/src/admc/select_dialog.cpp
@@ -115,12 +115,10 @@ SelectDialog::SelectDialog(QList<QString> classes_arg, SelectDialogMultiSelectio
 }
 
 QList<QString> SelectDialog::get_selected() const {
-    const QItemSelectionModel *selection_model = view->selectionModel();
-    const QList<QModelIndex> selected_indexes = selection_model->selectedIndexes();
-
     QSet<QString> selected_dns;
 
-    for (auto index : selected_indexes) {
+    for (int row = 0; row < model->rowCount(); row++) {
+        const QModelIndex index = model->index(row, 0);
         const QString dn = get_dn_from_index(index, SelectDialogColumn_DN);
 
         selected_dns.insert(dn);

--- a/src/admc/select_dialog.h
+++ b/src/admc/select_dialog.h
@@ -48,9 +48,10 @@ private slots:
 private:
     QTreeView *view;
     ObjectModel *model;
+    QList<QString> classes;
     SelectDialogMultiSelection multi_selection;
 
-    SelectDialog(QList<QString> classes, SelectDialogMultiSelection multi_selection, QWidget *parent);
+    SelectDialog(QList<QString> classes_arg, SelectDialogMultiSelection multi_selection, QWidget *parent);
 
     void showEvent(QShowEvent *event);
 };

--- a/src/admc/select_dialog.h
+++ b/src/admc/select_dialog.h
@@ -21,10 +21,11 @@
 #define SELECT_DIALOG_H
 
 #include <QDialog>
-#include <QString>
-#include <QList>
 
 class QTreeView;
+class ObjectModel;
+class QString;
+template <typename T> class QList;
 
 enum SelectDialogMultiSelection {
     SelectDialogMultiSelection_Yes,
@@ -35,14 +36,19 @@ class SelectDialog final : public QDialog {
 Q_OBJECT
 
 public:
-    static QList<QString> open(QList<QString> classes, SelectDialogMultiSelection multi_selection, const QString &title, QWidget *parent);
+    static QList<QString> open(QList<QString> classes, SelectDialogMultiSelection multi_selection_arg, const QString &title, QWidget *parent);
+
+    QList<QString> get_selected() const;
 
 private slots:
     void accept();
+    void open_find_dialog();
+    void remove_from_list();
 
 private:
     QTreeView *view;
-    QList<QString> selected_objects;
+    ObjectModel *model;
+    SelectDialogMultiSelection multi_selection;
 
     SelectDialog(QList<QString> classes, SelectDialogMultiSelection multi_selection, QWidget *parent);
 

--- a/src/admc/tabs/membership_tab.cpp
+++ b/src/admc/tabs/membership_tab.cpp
@@ -249,10 +249,14 @@ void MembershipTab::apply(const QString &target) const {
 }
 
 void MembershipTab::on_add_button() {
+    // TODO: aduc has "other objects" section in class selection for adding members to groups. No idea what "other objects" are. No results come up when searching for other objects in current test domain.
+    // TODO: there's also "service account", no idea what that is either.
     const QList<QString> classes =
     [this]() -> QList<QString> {
         switch (type) {
-            case MembershipTabType_Members: return {CLASS_USER};
+            case MembershipTabType_Members: return {
+                CLASS_USER, CLASS_GROUP, CLASS_CONTACT, CLASS_COMPUTER
+            };
             case MembershipTabType_MemberOf: return {CLASS_GROUP};
         }
         return QList<QString>();


### PR DESCRIPTION
Before was using select dialog for all types of selection. Also select dialog only allowed searching by class and name. Now, there is a special different dialog for selecting containers and the normal select dialog has been improved.

1. Make a different select dialog just for containers. It shows container objects as a tree, without filtering options. For containers, tree is better than list (like in select dialog). Also, filters aren't useful due to the fact that the amount of containers is almost always small.
2. Rework select dialog. Base select dialog now shows a list of currently selected objects and add/remove buttons under list. Add button opens find dialog. User operates find dialog to select some objects, then when find dialog is accepted, those objects are added to the list. Finally the list of selected objects is confirmed when select dialog is accepted. This solves the problem where in old select dialog you could only select objects from one find result, whereas now you can perform multiple searches and add objects from each one to a common list. Also, searching for objects through find dialog is much more powerful than just by class/name.
3. Change find dialog slightly so it can be used by select dialog. Make two types of operation: normal and select. In select type, ok/cancel buttons are shown and object menu is disabled. Add f-n to get selected objects so they can be inserted into select dialog.
4. Rework select classes widget. Doesn't always show a predetermined list of filter classes anymore. Instead, possible classes list changes depending on context. For example, when adding to group, it would allow only to select groups. Also, require at least one class to be selected. Remove implicit logic of "no classes selected = all classes". Add "select all" and "clear selection" buttons.