### PR TITLE
add ability to save column widths in result view

### DIFF
--- a/src/admc/console.cpp
+++ b/src/admc/console.cpp
@@ -83,6 +83,9 @@ Console::Console(MenuBar *menubar_arg)
     results_view->setSortingEnabled(true);
     results_view->sortByColumn(0, Qt::AscendingOrder);
     results_view->setSelectionMode(QAbstractItemView::ExtendedSelection);
+
+    auto results_header_width = SETTINGS()->get_variant(VariantSetting_ResultsHeader).toByteArray();
+    results_view->header()->restoreState(results_header_width);
     
     auto results_wrapper = new QWidget();
 
@@ -214,6 +217,10 @@ Console::Console(MenuBar *menubar_arg)
     scope_view->selectionModel()->setCurrentIndex(scope_model->index(0, 0), QItemSelectionModel::Current | QItemSelectionModel::ClearAndSelect);
 }
 
+Console::~Console() {
+    SETTINGS()->set_variant(VariantSetting_ResultsHeader, results_view->header()->saveState());
+}
+
 void Console::refresh_head() {
     fetch_scope_node(scope_model->index(0, 0));
 }
@@ -290,14 +297,6 @@ void Console::on_current_scope_changed(const QModelIndex &current, const QModelI
 
     QStandardItemModel *results_model = scope_id_to_results[id];
     results_view->setModel(results_model);
-
-    // TODO: remove this when implementing saved column widths
-    static bool set_column_widths = true;
-    if (set_column_widths) {
-        set_column_widths = false;
-        results_view->setColumnWidth(0, 400);
-        results_view->setColumnWidth(1, 400);
-    }
 
     // Update header with new object counts when rows are added/removed
     connect(

--- a/src/admc/console.cpp
+++ b/src/admc/console.cpp
@@ -84,12 +84,7 @@ Console::Console(MenuBar *menubar_arg)
     results_view->sortByColumn(0, Qt::AscendingOrder);
     results_view->setSelectionMode(QAbstractItemView::ExtendedSelection);
 
-    if (SETTINGS()->contains_variant(VariantSetting_ResultsHeader)) {
-        auto results_header_width = SETTINGS()->get_variant(VariantSetting_ResultsHeader).toByteArray();
-        results_view->header()->restoreState(results_header_width);
-    } else {
-        results_view->header()->setDefaultSectionSize(200);
-    }
+    SETTINGS()->load_header_state(results_view->header(), VariantSetting_ResultsHeader);
     
     auto results_wrapper = new QWidget();
 

--- a/src/admc/console.cpp
+++ b/src/admc/console.cpp
@@ -84,7 +84,7 @@ Console::Console(MenuBar *menubar_arg)
     results_view->sortByColumn(0, Qt::AscendingOrder);
     results_view->setSelectionMode(QAbstractItemView::ExtendedSelection);
 
-    SETTINGS()->load_header_state(results_view->header(), VariantSetting_ResultsHeader);
+    SETTINGS()->setup_header_state(results_view->header(), VariantSetting_ResultsHeader);
     
     auto results_wrapper = new QWidget();
 
@@ -214,10 +214,6 @@ Console::Console(MenuBar *menubar_arg)
 
     // Make head object current
     scope_view->selectionModel()->setCurrentIndex(scope_model->index(0, 0), QItemSelectionModel::Current | QItemSelectionModel::ClearAndSelect);
-}
-
-Console::~Console() {
-    SETTINGS()->set_variant(VariantSetting_ResultsHeader, results_view->header()->saveState());
 }
 
 void Console::refresh_head() {

--- a/src/admc/console.cpp
+++ b/src/admc/console.cpp
@@ -84,8 +84,12 @@ Console::Console(MenuBar *menubar_arg)
     results_view->sortByColumn(0, Qt::AscendingOrder);
     results_view->setSelectionMode(QAbstractItemView::ExtendedSelection);
 
-    auto results_header_width = SETTINGS()->get_variant(VariantSetting_ResultsHeader).toByteArray();
-    results_view->header()->restoreState(results_header_width);
+    if (SETTINGS()->contains_variant(VariantSetting_ResultsHeader)) {
+        auto results_header_width = SETTINGS()->get_variant(VariantSetting_ResultsHeader).toByteArray();
+        results_view->header()->restoreState(results_header_width);
+    } else {
+        results_view->header()->setDefaultSectionSize(200);
+    }
     
     auto results_wrapper = new QWidget();
 

--- a/src/admc/console.h
+++ b/src/admc/console.h
@@ -51,7 +51,6 @@ public:
     FilterDialog *filter_dialog;
     
     Console(MenuBar *menubar_arg);
-    ~Console();
 
 private slots:
     void refresh_head();

--- a/src/admc/console.h
+++ b/src/admc/console.h
@@ -51,6 +51,7 @@ public:
     FilterDialog *filter_dialog;
     
     Console(MenuBar *menubar_arg);
+    ~Console();
 
 private slots:
     void refresh_head();

--- a/src/admc/find_results.cpp
+++ b/src/admc/find_results.cpp
@@ -25,6 +25,7 @@
 #include "ad_interface.h"
 #include "ad_config.h"
 #include "object_model.h"
+#include "settings.h"
 
 #include <QTreeView>
 #include <QLabel>
@@ -58,9 +59,11 @@ FindResults::FindResults()
     view->setSortingEnabled(true);
     view->header()->setSectionsMovable(true);
 
+    SETTINGS()->load_header_state(view->header(), VariantSetting_FindResultsHeader);
+
     view->setModel(model);
 
-    setup_column_toggle_menu(view, model, 
+    setup_column_toggle_menu(view, model,
     {
         ADCONFIG()->get_column_index(ATTRIBUTE_NAME),
         ADCONFIG()->get_column_index(ATTRIBUTE_OBJECT_CLASS),
@@ -79,7 +82,11 @@ FindResults::FindResults()
 
     connect(
         view, &QWidget::customContextMenuRequested,
-        this, &FindResults::open_context_menu);
+                this, &FindResults::open_context_menu);
+}
+
+FindResults::~FindResults() {
+    SETTINGS()->set_variant(VariantSetting_FindResultsHeader, view->header()->saveState());
 }
 
 void FindResults::load_menu(QMenu *menu) {
@@ -149,12 +156,4 @@ QList<QList<QStandardItem *>> FindResults::get_selected_rows() const {
     }
 
     return out;
-}
-
-void FindResults::showEvent(QShowEvent *event) {
-    resize_columns(view,
-    {
-        {ADCONFIG()->get_column_index(ATTRIBUTE_NAME), 0.4},
-        {ADCONFIG()->get_column_index(ATTRIBUTE_OBJECT_CLASS), 0.4},
-    });
 }

--- a/src/admc/find_results.cpp
+++ b/src/admc/find_results.cpp
@@ -59,7 +59,7 @@ FindResults::FindResults()
     view->setSortingEnabled(true);
     view->header()->setSectionsMovable(true);
 
-    SETTINGS()->load_header_state(view->header(), VariantSetting_FindResultsHeader);
+    SETTINGS()->setup_header_state(view->header(), VariantSetting_FindResultsHeader);
 
     view->setModel(model);
 
@@ -83,10 +83,6 @@ FindResults::FindResults()
     connect(
         view, &QWidget::customContextMenuRequested,
                 this, &FindResults::open_context_menu);
-}
-
-FindResults::~FindResults() {
-    SETTINGS()->set_variant(VariantSetting_FindResultsHeader, view->header()->saveState());
 }
 
 void FindResults::load_menu(QMenu *menu) {

--- a/src/admc/find_results.h
+++ b/src/admc/find_results.h
@@ -41,7 +41,6 @@ public:
     QTreeView *view;
     
     FindResults();
-    ~FindResults();
 
     void load(const QString &filter, const QString &search_base);
 

--- a/src/admc/find_results.h
+++ b/src/admc/find_results.h
@@ -41,6 +41,7 @@ public:
     QTreeView *view;
     
     FindResults();
+    ~FindResults();
 
     void load(const QString &filter, const QString &search_base);
 
@@ -53,7 +54,6 @@ private:
     QStandardItemModel *model;
     QLabel *object_count_label;
 
-    void showEvent(QShowEvent *event);
     void open_context_menu(const QPoint pos);
 };
 

--- a/src/admc/tabs/attributes_tab.cpp
+++ b/src/admc/tabs/attributes_tab.cpp
@@ -24,6 +24,7 @@
 #include "ad_object.h"
 #include "utils.h"
 #include "attribute_display.h"
+#include "settings.h"
 
 #include <QTreeView>
 #include <QVBoxLayout>
@@ -35,6 +36,7 @@
 #include <QCheckBox>
 #include <QFrame>
 #include <QLabel>
+#include <QHeaderView>
 
 enum AttributesColumn {
     AttributesColumn_Name,
@@ -74,6 +76,8 @@ AttributesTab::AttributesTab() {
     proxy->setSourceModel(model);
     view->setModel(proxy);
 
+    SETTINGS()->load_header_state(view->header(), VariantSetting_AttributesHeader);
+
     auto edit_button = new QPushButton(tr("Edit"));
     auto filter_button = new QPushButton(tr("Filter"));
     auto buttons = new QHBoxLayout();
@@ -96,7 +100,11 @@ AttributesTab::AttributesTab() {
         this, &AttributesTab::edit_attribute);
     connect(
         filter_button, &QAbstractButton::clicked,
-        this, &AttributesTab::open_filter_dialog);
+                this, &AttributesTab::open_filter_dialog);
+}
+
+AttributesTab::~AttributesTab() {
+    SETTINGS()->set_variant(VariantSetting_AttributesHeader, view->header()->saveState());
 }
 
 void AttributesTab::edit_attribute() {
@@ -235,14 +243,6 @@ void AttributesTab::open_filter_dialog() {
         });
 
     dialog->open();
-}
-
-void AttributesTab::showEvent(QShowEvent *event) {
-    resize_columns(view,
-    {
-        {AttributesColumn_Name, 0.4},
-        {AttributesColumn_Value, 0.8},
-    });
 }
 
 void AttributesTab::load(const AdObject &object) {

--- a/src/admc/tabs/attributes_tab.cpp
+++ b/src/admc/tabs/attributes_tab.cpp
@@ -76,7 +76,7 @@ AttributesTab::AttributesTab() {
     proxy->setSourceModel(model);
     view->setModel(proxy);
 
-    SETTINGS()->load_header_state(view->header(), VariantSetting_AttributesHeader);
+    SETTINGS()->setup_header_state(view->header(), VariantSetting_AttributesHeader);
 
     auto edit_button = new QPushButton(tr("Edit"));
     auto filter_button = new QPushButton(tr("Filter"));
@@ -101,10 +101,6 @@ AttributesTab::AttributesTab() {
     connect(
         filter_button, &QAbstractButton::clicked,
                 this, &AttributesTab::open_filter_dialog);
-}
-
-AttributesTab::~AttributesTab() {
-    SETTINGS()->set_variant(VariantSetting_AttributesHeader, view->header()->saveState());
 }
 
 void AttributesTab::edit_attribute() {

--- a/src/admc/tabs/attributes_tab.h
+++ b/src/admc/tabs/attributes_tab.h
@@ -55,6 +55,7 @@ Q_OBJECT
 
 public:
     AttributesTab();
+    ~AttributesTab();
 
     void load(const AdObject &object) override;
     void apply(const QString &target) const override;
@@ -71,7 +72,6 @@ private:
     QHash<QString, QList<QByteArray>> current;
 
     void load_row(const QList<QStandardItem *> &row, const QString &attribute, const QList<QByteArray> &values);
-    void showEvent(QShowEvent *event);
 };
 
 class AttributesTabProxy final : public QSortFilterProxyModel {

--- a/src/admc/tabs/attributes_tab.h
+++ b/src/admc/tabs/attributes_tab.h
@@ -55,7 +55,6 @@ Q_OBJECT
 
 public:
     AttributesTab();
-    ~AttributesTab();
 
     void load(const AdObject &object) override;
     void apply(const QString &target) const override;

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -125,13 +125,19 @@ void Settings::save_geometry(QWidget *widget, const VariantSetting geometry_sett
     set_variant(VariantSetting_MainWindowGeometry, QVariant(geometry));
 }
 
-void Settings::load_header_state(QHeaderView *header, const VariantSetting setting) {
+void Settings::setup_header_state(QHeaderView *header, const VariantSetting setting) {
     if (contains_variant(setting)) {
         auto header_width = get_variant(setting).toByteArray();
         header->restoreState(header_width);
     } else {
         header->setDefaultSectionSize(200);
     }
+
+    connect(
+        header, &QHeaderView::destroyed,
+        [this, header, setting]() {
+            set_variant(setting, header->saveState());
+        });
 }
 
 void Settings::connect_toggle_widget(QWidget *widget, const BoolSetting setting) {

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -25,6 +25,7 @@
 #include <QSettings>
 #include <QLocale>
 #include <QCoreApplication>
+#include <QHeaderView>
 
 bool bool_default_value(const BoolSetting setting);
 QString bool_to_string(const BoolSetting setting);
@@ -124,6 +125,15 @@ void Settings::save_geometry(QWidget *widget, const VariantSetting geometry_sett
     set_variant(VariantSetting_MainWindowGeometry, QVariant(geometry));
 }
 
+void Settings::load_header_state(QHeaderView *header, const VariantSetting setting) {
+    if (contains_variant(setting)) {
+        auto header_width = get_variant(setting).toByteArray();
+        header->restoreState(header_width);
+    } else {
+        header->setDefaultSectionSize(200);
+    }
+}
+
 void Settings::connect_toggle_widget(QWidget *widget, const BoolSetting setting) {
     const BoolSettingSignal *signal = get_bool_signal(setting);
 
@@ -194,6 +204,8 @@ QString variant_to_string(const VariantSetting setting) {
         CASE_ENUM_TO_STRING(VariantSetting_MainWindowGeometry);
         CASE_ENUM_TO_STRING(VariantSetting_Locale);
         CASE_ENUM_TO_STRING(VariantSetting_ResultsHeader);
+        CASE_ENUM_TO_STRING(VariantSetting_FindResultsHeader);
+        CASE_ENUM_TO_STRING(VariantSetting_AttributesHeader);
         CASE_ENUM_TO_STRING(VariantSetting_COUNT);
     }
     return "";

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -193,6 +193,7 @@ QString variant_to_string(const VariantSetting setting) {
         CASE_ENUM_TO_STRING(VariantSetting_Site);
         CASE_ENUM_TO_STRING(VariantSetting_MainWindowGeometry);
         CASE_ENUM_TO_STRING(VariantSetting_Locale);
+        CASE_ENUM_TO_STRING(VariantSetting_ResultsHeader);
         CASE_ENUM_TO_STRING(VariantSetting_COUNT);
     }
     return "";

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -41,6 +41,7 @@ enum VariantSetting {
     VariantSetting_Domain,    
     VariantSetting_Site,    
     VariantSetting_Locale,
+    VariantSetting_ResultsHeader,
 
     // GPGUI
 

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -105,7 +105,7 @@ public:
     void restore_geometry(QWidget *widget, const VariantSetting geometry_setting);
     void save_geometry(QWidget *widget, const VariantSetting geometry_setting);
 
-    void load_header_state(QHeaderView* header, const VariantSetting setting);
+    void setup_header_state(QHeaderView* header, const VariantSetting setting);
 
     void connect_toggle_widget(QWidget *widget, const BoolSetting setting);
 

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -35,6 +35,7 @@ class QSettings;
 class QVariant;
 class QWidget;
 class QCheckBox;
+class QHeaderView;
 
 enum VariantSetting {
     // ADMC
@@ -42,6 +43,8 @@ enum VariantSetting {
     VariantSetting_Site,    
     VariantSetting_Locale,
     VariantSetting_ResultsHeader,
+    VariantSetting_FindResultsHeader,
+    VariantSetting_AttributesHeader,
 
     // GPGUI
 
@@ -101,6 +104,8 @@ public:
 
     void restore_geometry(QWidget *widget, const VariantSetting geometry_setting);
     void save_geometry(QWidget *widget, const VariantSetting geometry_setting);
+
+    void load_header_state(QHeaderView* header, const VariantSetting setting);
 
     void connect_toggle_widget(QWidget *widget, const BoolSetting setting);
 


### PR DESCRIPTION
This PR resolves issue #92. It also adds functionality to rearrange columns in the result view.