### PR TITLE
Edit verify

### DIFF
--- a/src/admc/details_dialog.cpp
+++ b/src/admc/details_dialog.cpp
@@ -263,6 +263,13 @@ void DetailsDialog::ok() {
 }
 
 bool DetailsDialog::apply() {
+    for (auto tab : tabs) {
+        const bool verify_success = tab->verify(target);
+        if (!verify_success) {
+            return false;
+        }
+    }
+
     show_busy_indicator();
 
     STATUS()->start_error_log();

--- a/src/admc/edits/attribute_edit.cpp
+++ b/src/admc/edits/attribute_edit.cpp
@@ -42,6 +42,10 @@ void AttributeEdit::load(const AdObject &object) {
     m_modified = false;
 }
 
+bool AttributeEdit::verify(const QString &dn) const {
+    return true;
+}
+
 bool AttributeEdit::modified() const {
     return m_modified;
 }
@@ -50,6 +54,19 @@ void edits_add_to_layout(QList<AttributeEdit *> edits, QFormLayout *layout) {
     for (auto edit : edits) {
         edit->add_to_layout(layout);
     }
+}
+
+bool edits_verify(QList<AttributeEdit *> edits, const QString &dn) {
+    for (auto edit : edits) {
+        if (edit->modified()) {
+            const bool verify_success = edit->verify(dn);
+            if (!verify_success) {
+                return false;
+            }
+        }
+    }
+
+    return true;
 }
 
 bool edits_apply(QList<AttributeEdit *> edits, const QString &dn) {

--- a/src/admc/edits/attribute_edit.h
+++ b/src/admc/edits/attribute_edit.h
@@ -50,6 +50,12 @@ public:
     // Layout all widgets that are part of this edit
     virtual void add_to_layout(QFormLayout *layout) = 0;
 
+    // Verify current input. This is for the kinds of errors
+    // that the server doesn't or can't check for. For
+    // example password confirmation matching password.
+    // Should be called before apply().
+    virtual bool verify(const QString &dn) const;
+
     // Apply current input by making a modification to the
     // AD server
     virtual bool apply(const QString &dn) const = 0;
@@ -84,8 +90,15 @@ public:\
 // Helper f-ns that iterate over edit lists for you
 void edits_connect_to_tab(QList<AttributeEdit *> edits, DetailsTab *tab);
 void edits_add_to_layout(QList<AttributeEdit *> edits, QFormLayout *layout);
+
+// Verify all edits that were modified. Verify process will
+// stop on first failure. This is so that only one failure
+// message is shown at a time.
+bool edits_verify(QList<AttributeEdit *> edits, const QString &dn);
+
 // Applies all edits that were modified
 bool edits_apply(QList<AttributeEdit *> edits, const QString &dn);
+
 void edits_load(QList<AttributeEdit *> edits, const AdObject &object);
 
 #endif /* ATTRIBUTE_EDIT_H */

--- a/src/admc/edits/password_edit.cpp
+++ b/src/admc/edits/password_edit.cpp
@@ -62,7 +62,7 @@ void PasswordEdit::add_to_layout(QFormLayout *layout) {
     layout->addRow(tr("Confirm password:"), confirm_edit);
 }
 
-bool PasswordEdit::check_confirm() const {
+bool PasswordEdit::verify(const QString &) const {
     const QString pass = edit->text();
     const QString confirm_pass = confirm_edit->text();
     if (pass != confirm_pass) {

--- a/src/admc/edits/password_edit.h
+++ b/src/admc/edits/password_edit.h
@@ -30,8 +30,7 @@ public:
     PasswordEdit(QList<AttributeEdit *> *edits_out, QObject *parent);
     DECL_ATTRIBUTE_EDIT_VIRTUALS();
 
-    // Checks that password confirmation matches input
-    bool check_confirm() const;
+    bool verify(const QString &dn) const override;
 
 private:
     QLineEdit *edit;

--- a/src/admc/edits/string_edit.h
+++ b/src/admc/edits/string_edit.h
@@ -40,6 +40,7 @@ public:
     QString get_input() const;
     void set_input(const QString &value);
     bool is_empty() const;
+    bool verify(const QString &dn) const override;
 
 private:
     QLineEdit *edit;
@@ -47,6 +48,8 @@ private:
     QString objectClass;
 
     friend class StringOtherEdit;
+
+    QString get_new_value() const;
 };
 
 #endif /* STRING_EDIT_H */

--- a/src/admc/password_dialog.cpp
+++ b/src/admc/password_dialog.cpp
@@ -44,7 +44,7 @@ PasswordDialog::PasswordDialog(const QString &target_arg, QWidget *parent)
     const QString title = QString(tr("Change password of object \"%1\"")).arg(name);
     setWindowTitle(title);
 
-    pass_edit = new PasswordEdit(&edits, this);
+    new PasswordEdit(&edits, this);
     new AccountOptionEdit(AccountOption_PasswordExpired, &edits, this);
     new UnlockEdit(&edits, this);
 
@@ -71,15 +71,16 @@ PasswordDialog::PasswordDialog(const QString &target_arg, QWidget *parent)
 }
 
 void PasswordDialog::accept() {
-    const bool pass_confirmed = pass_edit->check_confirm();
-
-    if (pass_confirmed) {
-        STATUS()->start_error_log();
-
-        edits_apply(edits, target);
-
-        QDialog::close();
-
-        STATUS()->end_error_log(this);
+    const bool verify_success = edits_verify(edits, target);
+    if (!verify_success) {
+        return;
     }
+
+    STATUS()->start_error_log();
+
+    edits_apply(edits, target);
+
+    QDialog::close();
+
+    STATUS()->end_error_log(this);
 }

--- a/src/admc/password_dialog.h
+++ b/src/admc/password_dialog.h
@@ -40,7 +40,6 @@ private slots:
 private:
     QString target;
     QList<AttributeEdit *> edits;
-    PasswordEdit *pass_edit;
 
 };
 

--- a/src/admc/rename_dialog.cpp
+++ b/src/admc/rename_dialog.cpp
@@ -111,6 +111,11 @@ void RenameDialog::fail_msg(const QString &old_name) {
 void RenameDialog::accept() {
     const QString old_name = dn_get_name(target);
 
+    const bool verify_success = edits_verify(all_edits, target);
+    if (!verify_success) {
+        return;
+    }
+
     STATUS()->start_error_log();
 
     const QString new_name = name_edit->text();

--- a/src/admc/tabs/details_tab.cpp
+++ b/src/admc/tabs/details_tab.cpp
@@ -24,6 +24,10 @@ void DetailsTab::load(const AdObject &object) {
     edits_load(edits, object);
 }
 
+bool DetailsTab::verify(const QString &target) const {
+    return edits_verify(edits, target);
+}
+
 void DetailsTab::apply(const QString &target) const {
     edits_apply(edits, target);
 }

--- a/src/admc/tabs/details_tab.h
+++ b/src/admc/tabs/details_tab.h
@@ -40,6 +40,7 @@ Q_OBJECT
 
 public:
     virtual void load(const AdObject &object);
+    virtual bool verify(const QString &target) const;
     virtual void apply(const QString &target) const;
 
 protected:


### PR DESCRIPTION
Restore old attribute edit feature called "verify". Implement verification for unique UPN. Also rename pass edit's check_confirm to verify().

Closes #90 