### PR TITLE
Improve drag drop

### DIFF
--- a/src/admc/ad_interface.cpp
+++ b/src/admc/ad_interface.cpp
@@ -945,10 +945,9 @@ DropType get_drop_type(const QString &dn, const QString &target_dn) {
 
     const AdObject target = AD()->search_object(target_dn, {ATTRIBUTE_OBJECT_CLASS});
 
-    const bool dropped_is_user = dropped.is_class(CLASS_USER);
-    const bool dropped_is_group = dropped.is_class(CLASS_GROUP);
-    const bool target_is_group = target.is_class(CLASS_GROUP);
-
+    const bool dropped_is_user = dropped.contains_class(CLASS_USER);
+    const bool dropped_is_group = dropped.contains_class(CLASS_GROUP);
+    const bool target_is_group = target.contains_class(CLASS_GROUP);
 
     if (dropped_is_user && target_is_group) {
         return DropType_AddToGroup;

--- a/src/admc/ad_interface.cpp
+++ b/src/admc/ad_interface.cpp
@@ -946,9 +946,13 @@ DropType get_drop_type(const QString &dn, const QString &target_dn) {
     const AdObject target = AD()->search_object(target_dn, {ATTRIBUTE_OBJECT_CLASS});
 
     const bool dropped_is_user = dropped.is_class(CLASS_USER);
+    const bool dropped_is_group = dropped.is_class(CLASS_GROUP);
     const bool target_is_group = target.is_class(CLASS_GROUP);
 
+
     if (dropped_is_user && target_is_group) {
+        return DropType_AddToGroup;
+    } else if (dropped_is_group && target_is_group) {
         return DropType_AddToGroup;
     } else {
         const bool system_flags_forbid_move = dropped.get_system_flag(SystemFlagsBit_CannotMove);

--- a/src/admc/ad_object.cpp
+++ b/src/admc/ad_object.cpp
@@ -222,6 +222,12 @@ bool AdObject::is_class(const QString &object_class) const {
     return is_class;
 }
 
+bool AdObject::contains_class(const QString &object_class) const {
+    const QList<QString> object_class_list = get_strings(ATTRIBUTE_OBJECT_CLASS);
+    
+    return object_class_list.contains(object_class);
+}
+
 QIcon AdObject::get_icon() const {
     // TODO: change to custom, good icons, add those icons to installation?
     static const QMap<QString, QString> class_to_icon = {

--- a/src/admc/ad_object.h
+++ b/src/admc/ad_object.h
@@ -74,6 +74,9 @@ public:
     // NOTE: this compares for the most derived class, so each object only maps to one class. For example computers have objectClass values of both "user" and "computer" but "computer" is more derived so they are only computers and not users.
     bool is_class(const QString &object_class) const;
 
+    // True if ANY of object's classes equal to given class
+    bool contains_class(const QString &object_class) const;
+
     QIcon get_icon() const;
 
 private:

--- a/src/admc/console.cpp
+++ b/src/admc/console.cpp
@@ -72,6 +72,9 @@ Console::Console(MenuBar *menubar_arg)
     scope_view->setContextMenuPolicy(Qt::CustomContextMenu);
     scope_view->setDragDropMode(QAbstractItemView::DragDrop);
     scope_view->setSortingEnabled(true);
+    scope_view->setSortingEnabled(true);
+    // NOTE: this makes it so that you can't drag drop between rows (even though name/description don't say anything about that)
+    scope_view->setDragDropOverwriteMode(true);
 
     scope_view->setModel(scope_model);
 
@@ -83,6 +86,7 @@ Console::Console(MenuBar *menubar_arg)
     results_view->setSortingEnabled(true);
     results_view->sortByColumn(0, Qt::AscendingOrder);
     results_view->setSelectionMode(QAbstractItemView::ExtendedSelection);
+    results_view->setDragDropOverwriteMode(true);
 
     SETTINGS()->setup_header_state(results_view->header(), VariantSetting_ResultsHeader);
     

--- a/src/admc/console.cpp
+++ b/src/admc/console.cpp
@@ -72,7 +72,6 @@ Console::Console(MenuBar *menubar_arg)
     scope_view->setContextMenuPolicy(Qt::CustomContextMenu);
     scope_view->setDragDropMode(QAbstractItemView::DragDrop);
     scope_view->setSortingEnabled(true);
-    scope_view->setSortingEnabled(true);
     // NOTE: this makes it so that you can't drag drop between rows (even though name/description don't say anything about that)
     scope_view->setDragDropOverwriteMode(true);
 

--- a/src/admc/console_drag_model.cpp
+++ b/src/admc/console_drag_model.cpp
@@ -51,13 +51,8 @@ QMimeData *ConsoleDragModel::mimeData(const QModelIndexList &indexes) const {
     return data;
 }
 
-bool ConsoleDragModel::canDropMimeData(const QMimeData *data, Qt::DropAction, int row, int, const QModelIndex &parent) const {
+bool ConsoleDragModel::canDropMimeData(const QMimeData *data, Qt::DropAction, int, int, const QModelIndex &parent) const {
     if (!data->hasUrls()) {
-        return false;
-    }
-
-    const bool dropping_between_rows = (row != -1);
-    if (dropping_between_rows) {
         return false;
     }
 
@@ -74,13 +69,7 @@ bool ConsoleDragModel::canDropMimeData(const QMimeData *data, Qt::DropAction, in
     }
 }
 
-bool ConsoleDragModel::dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int, const QModelIndex &parent) {
-    // TODO: implement dropping next to parent (which happens if row or column aren't equal to -1). In that case would need to insert within other rows instead of just appending.
-    const bool dropping_between_rows = (row != -1);
-    if (dropping_between_rows) {
-        return false;
-    }
-
+bool ConsoleDragModel::dropMimeData(const QMimeData *data, Qt::DropAction action, int, int, const QModelIndex &parent) {
     if (!data->hasUrls()) {
         return true;
     }


### PR DESCRIPTION
A couple improvements to drag and drop.

Allow computers to be added to groups via drag and drop.
Add AdObject::contains_class() for that.

Allow groups to be added to groups via drag and drop.

Improve method of disabling drag and dropping between rows.