### PR TITLE
setup tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,3 +11,4 @@ set(LIBRARY_OUTPUT_PATH ${EXECUTABLE_OUTPUT_PATH})
 
 add_subdirectory(translations)
 add_subdirectory(src)
+add_subdirectory(tests)

--- a/src/admc/ad_utils.cpp
+++ b/src/admc/ad_utils.cpp
@@ -241,3 +241,17 @@ QString dn_canonical(const QString &dn) {
 
     return canonical;
 }
+
+QString dn_from_name_and_parent(const QString &name, const QString &parent, const QString &object_class) {
+    const QString suffix =
+    [object_class]() {
+        if (object_class == CLASS_OU) {
+            return "ou";
+        } else {
+            return "cn";
+        }
+    }();
+    const QString dn = QString("%1=%2,%3").arg(suffix, name, parent);
+
+    return dn;
+}

--- a/src/admc/ad_utils.h
+++ b/src/admc/ad_utils.h
@@ -54,5 +54,6 @@ QString dn_get_parent(const QString &dn);
 QString dn_get_parent_canonical(const QString &dn);
 QString dn_rename(const QString &dn, const QString &new_name);
 QString dn_canonical(const QString &dn);
+QString dn_from_name_and_parent(const QString &name, const QString &parent, const QString &object_class);
 
 #endif /* AD_UTILS_H */

--- a/src/admc/create_dialog.cpp
+++ b/src/admc/create_dialog.cpp
@@ -201,16 +201,7 @@ CreateDialog::CreateDialog(const QString &parent_dn_arg, const QString &object_c
 void CreateDialog::accept() {
     const QString name = name_edit->text();
 
-    const QString suffix =
-    [this]() {
-        if (object_class == CLASS_OU) {
-            return "OU";
-        } else {
-            return "CN";
-        }
-    }();
-
-    const QString dn = suffix + "=" + name + "," + parent_dn;
+    const QString dn = dn_from_name_and_parent(name, parent_dn, object_class);
 
     // Verify edits
     const bool verify_success =

--- a/src/admc/status.cpp
+++ b/src/admc/status.cpp
@@ -25,6 +25,7 @@
 #include <QPlainTextEdit>
 #include <QDialogButtonBox>
 #include <QVBoxLayout>
+#include <QDebug>
 
 #define MAX_MESSAGES_IN_LOG 200
 
@@ -82,6 +83,10 @@ void Status::message(const QString &msg, const StatusType &type) {
     QTextCursor end_cursor = status_log->textCursor();
     end_cursor.movePosition(QTextCursor::End);
     status_log->setTextCursor(end_cursor);
+
+    if (print_errors && type == StatusType_Error) {
+        qInfo() << msg;
+    }
 }
 
 void Status::start_error_log() {

--- a/src/admc/status.h
+++ b/src/admc/status.h
@@ -40,6 +40,7 @@ class Status final : public QObject {
 Q_OBJECT
 
 public:   
+    bool print_errors = false;
     QStatusBar *status_bar;
     QTextEdit *status_log;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,133 @@
+
+find_package(Qt5 REQUIRED
+    COMPONENTS
+        Core
+        Widgets
+        Test
+)
+
+find_package(Uuid REQUIRED)
+find_package(Smbclient REQUIRED)
+find_package(Krb5 REQUIRED)
+find_package(Ldap REQUIRED)
+find_package(Resolv REQUIRED)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(ADMC_APPLICATION_NAME "ADMC")
+set(ADMC_APPLICATION_DISPLAY_NAME "ADMC")
+set(ADMC_ORGANIZATION "BaseALT")
+set(ADMC_ORGANIZATION_DOMAIN "basealt.ru")
+
+# TODO: configure_file() call in admc's cmakelists is much cleaner, but doesn't work here. Fix this.
+configure_file(${PROJECT_SOURCE_DIR}/src/admc/config.h.in "config.h")
+
+enable_testing()
+
+# TODO: not sure how to avoid duplicating the list of ADMC sources here. Maybe could make a shared list somehow? Also maybe move "tests" so that it's inside "src/admc".
+add_executable(test_admc
+    test_admc.cpp
+
+    ${PROJECT_SOURCE_DIR}/src/admc/ad_interface.cpp
+    
+    ${PROJECT_SOURCE_DIR}/src/admc/ad_config.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/ad_utils.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/ad_object.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/properties_dialog.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/main_window.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/status.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/object_model.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/select_dialog.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/object_menu.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/confirmation_dialog.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/password_dialog.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/menubar.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/attribute_display.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/find_results.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/toggle_widgets_dialog.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/filter_dialog.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/find_widget.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/tab_widget.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/console.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/console_drag_model.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/rename_dialog.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/rename_policy_dialog.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/create_dialog.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/find_dialog.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/find_select_dialog.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/select_container_dialog.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/policies_widget.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/gplink.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/filter_widget/filter_widget.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/filter_widget/filter_widget_simple_tab.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/filter_widget/filter_widget_normal_tab.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/filter_widget/filter_widget_advanced_tab.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/filter_widget/select_classes_widget.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/filter_widget/filter_builder.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/tabs/properties_tab.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/tabs/general_tab.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/tabs/object_tab.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/tabs/attributes_tab.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/tabs/account_tab.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/tabs/membership_tab.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/tabs/address_tab.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/tabs/group_policy_tab.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/tabs/gpo_links_tab.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/tabs/organization_tab.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/tabs/telephones_tab.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/tabs/profile_tab.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/editors/attribute_editor.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/editors/multi_editor.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/editors/string_editor.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/editors/octet_editor.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/editors/bool_editor.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/editors/datetime_editor.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/edits/attribute_edit.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/edits/string_edit.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/edits/string_other_edit.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/edits/string_large_edit.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/edits/country_edit.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/edits/expiry_edit.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/edits/unlock_edit.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/edits/group_scope_edit.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/edits/group_type_edit.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/edits/account_option_edit.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/edits/password_edit.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/edits/datetime_edit.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/edits/gpoptions_edit.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/edits/manager_edit.cpp
+
+    ${PROJECT_SOURCE_DIR}/src/common/utils.cpp
+    ${PROJECT_SOURCE_DIR}/src/common/settings.cpp
+    ${PROJECT_SOURCE_DIR}/src/common/filter.cpp
+
+    ${PROJECT_SOURCE_DIR}/src/admc/admc.qrc
+    ${PROJECT_SOURCE_DIR}/translations/translations.qrc
+)
+
+add_test(test_admc
+    test_admc
+)
+
+target_include_directories(test_admc
+    PRIVATE
+        ${CMAKE_CURRENT_BINARY_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${PROJECT_SOURCE_DIR}/src/common
+        ${PROJECT_SOURCE_DIR}/src/admc
+        ${PROJECT_SOURCE_DIR}/tests
+)
+
+target_link_libraries(test_admc
+    Qt5::Core
+    Qt5::Widgets
+    Qt5::Test
+    Uuid::Uuid
+    Smbclient::Smbclient
+    Krb5::Krb5
+    Ldap::Ldap
+    Resolv::Resolv
+)

--- a/tests/test_admc.cpp
+++ b/tests/test_admc.cpp
@@ -32,7 +32,7 @@
 #include <QDebug>
 
 // Delay between tabbing through input widgets, in milliseconds. Set this to some non-zero value if you want to watch the test play out in real time.
-#define TAB_DELAY 100
+#define TAB_DELAY 0
 
 #define TEST_USER "test-user"
 #define TEST_USER_LOGON "test-user-logon"

--- a/tests/test_admc.cpp
+++ b/tests/test_admc.cpp
@@ -1,0 +1,210 @@
+/*
+ * ADMC - AD Management Center
+ *
+ * Copyright (C) 2020 BaseALT Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "test_admc.h"
+
+#include "ad_interface.h"
+#include "ad_defines.h"
+#include "ad_object.h"
+#include "ad_utils.h"
+#include "filter.h"
+#include "create_dialog.h"
+#include "utils.h"
+#include "status.h"
+
+#include <QTest>
+#include <QDebug>
+
+// Delay between tabbing through input widgets, in milliseconds. Set this to some non-zero value if you want to watch the test play out in real time.
+#define TAB_DELAY 100
+
+#define TEST_USER "test-user"
+#define TEST_USER_LOGON "test-user-logon"
+#define TEST_PASSWORD "pass123!"
+#define TEST_OU "test-ou"
+
+void TestADMC::initTestCase() {
+    const bool connected = AD()->connect();
+    QVERIFY2(connected, "Failed to connect to AD server");
+
+    // NOTE: temporary band-aid until messages are routed correctly throgh AdInterface instance. This makes status error messages be printed to console. I think it's useful to understand why a test failed. When messages are collected in an AdInterface instances, can just print them here ourselves and avoid touching Status.
+    STATUS()->print_errors = true;
+
+    // Cleanup before all tests in-case this test suite was
+    // previously interrupted and a cleanup wasn't performed
+    cleanup();
+}
+
+void TestADMC::cleanupTestCase() {
+
+}
+
+void TestADMC::init() {
+    parent_widget = new QWidget();
+    
+    const QString dn = test_arena_dn();
+    const bool create_success = AD()->object_add(dn, CLASS_OU);
+
+    QVERIFY2(create_success, "Failed to create test-arena");
+}
+
+void TestADMC::cleanup_recurse(const QString &parent) {
+    const QHash<QString, AdObject> search_results = AD()->search(QString(), QList<QString>(), SearchScope_Children, parent);
+
+    const bool has_children = (search_results.size() > 0);
+    if (has_children) {
+        for (const QString child : search_results.keys()) {
+            cleanup_recurse(child);
+        }
+    }
+
+    const bool delete_success = AD()->object_delete(parent);
+    QVERIFY2(delete_success, "Failed to delete test-arena or one of it's contents");
+}
+
+void TestADMC::cleanup() {
+    if (parent_widget != nullptr) {
+        delete parent_widget;
+        parent_widget = nullptr;
+    }
+
+    // Delete test arena, if it exists
+    // Delete all children of test arena recursively and then delete test arena itself
+    // NOTE: can't just delete test arena while it has children because LDAP forbids deleting non-leaf objects
+    const QString dn = test_arena_dn();
+
+    const QHash<QString, AdObject> search_results = AD()->search(QString(), QList<QString>(), SearchScope_Object, dn);
+    const bool test_arena_exists = (search_results.size() == 1);
+    if (test_arena_exists) {
+        cleanup_recurse(dn);
+    }
+}
+
+void TestADMC::object_add() {
+    const QString name = TEST_USER;
+    const QString dn = test_object_dn(name, CLASS_USER);
+
+    const bool create_success = AD()->object_add(dn, CLASS_USER);
+
+    QVERIFY2(create_success, "Failed to create object");
+    QVERIFY2(object_exists(dn), "Created object doesn't exist");
+}
+
+void TestADMC::object_delete() {
+    const QString name = TEST_USER;
+    const QString dn = test_object_dn(name, CLASS_USER);
+
+    const bool create_success = AD()->object_add(dn, CLASS_USER);
+    QVERIFY2(create_success, "Failed to create object for deletion");
+
+    const bool delete_success = AD()->object_delete(dn);
+    QVERIFY2(delete_success, "Failed to delete object");
+    QVERIFY2(!object_exists(dn), "Deleted object exists");
+}
+
+void TestADMC::create_dialog_user() {
+    const QString name = TEST_USER;
+    const QString logon_name = TEST_USER_LOGON;
+    const QString password = TEST_PASSWORD;
+    const QString parent = test_arena_dn();
+    const QString dn = test_object_dn(name, CLASS_USER);
+
+    // Create user
+    const auto create_dialog = new CreateDialog(parent, CLASS_USER, parent_widget);
+    create_dialog->open();
+    QApplication::setActiveWindow(create_dialog);
+
+    // Enter name
+    QTest::keyClicks(QApplication::focusWidget(), name);
+
+    // Enter logon name
+    tab(4);
+    QTest::keyClicks(QApplication::focusWidget(), logon_name);
+
+    // Enter password
+    tab(2);
+    QTest::keyClicks(QApplication::focusWidget(), password);
+    // Confirm password
+    tab();
+    QTest::keyClicks(QApplication::focusWidget(), password);
+
+    // Accept dialog. Need to only tab once since we're at the last line edit. After that focus goes to create button
+    tab();
+    QTest::keyClick(QApplication::focusWidget(), Qt::Key_Enter);
+
+    QVERIFY2(object_exists(dn), "Created user doesn't exist");
+
+    QVERIFY(true);
+}
+
+void TestADMC::create_dialog_ou() {
+    const QString name = TEST_OU;
+    const QString parent = test_arena_dn();
+    const QString dn = test_object_dn(name, CLASS_OU);
+
+    // Create ou
+    const auto create_dialog = new CreateDialog(parent, CLASS_OU, parent_widget);
+    create_dialog->open();
+    QApplication::setActiveWindow(create_dialog);
+
+    // Enter name
+    QTest::keyClicks(QApplication::focusWidget(), name);
+
+    // Accept dialog. Need to only tab once since we're at the last line edit. After that focus goes to create button
+    tab();
+    QTest::keyClick(QApplication::focusWidget(), Qt::Key_Enter);
+
+    QVERIFY2(object_exists(dn), "Created OU doesn't exist");
+
+    QVERIFY(true);
+}
+
+QString TestADMC::test_arena_dn() {
+    const QString head_dn = AD()->domain_head();
+    const QString dn = QString("ou=test-arena,%1").arg(head_dn);
+
+    return dn;
+}
+
+// TODO: for OU's need to change from cn to ou, SO make a f-n in ad_utils.cpp that does what's currently in CreateDialog::accept(). Takes object name, parent dn and object class, returns dn.
+QString TestADMC::test_object_dn(const QString &name, const QString &object_class) {
+    const QString parent = test_arena_dn();
+    const QString dn = dn_from_name_and_parent(name, parent, object_class);
+
+    return dn;
+}
+
+bool TestADMC::object_exists(const QString &dn) {
+    const QHash<QString, AdObject> search_results = AD()->search(QString(), QList<QString>(), SearchScope_Object, dn);
+    const bool exists = (search_results.size() == 1);
+
+    return exists;
+}
+
+void TestADMC::tab(const int n) {
+    for (int i = 0; i < n; i++) {
+        QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+
+        if (TAB_DELAY > 0) {
+            QTest::qWait(TAB_DELAY);
+        }
+    }
+}
+
+QTEST_MAIN(TestADMC)

--- a/tests/test_admc.h
+++ b/tests/test_admc.h
@@ -1,0 +1,90 @@
+/*
+ * ADMC - AD Management Center
+ *
+ * Copyright (C) 2020 BaseALT Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TEST_ADMC_H
+#define TEST_ADMC_H
+
+/*
+ * ADMC - AD Management Center
+ *
+ * Copyright (C) 2020 BaseALT Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <QObject>
+
+#include <QTest>
+
+class QString;
+
+class TestADMC : public QObject {
+    Q_OBJECT
+
+private slots:
+    // Called before first test
+    void initTestCase();
+    // Called after last test
+    void cleanupTestCase();
+
+    // Run before and after each test
+    void init();
+    void cleanup_recurse(const QString &dn);
+    void cleanup();
+
+    // Tests
+    void object_add();
+    void object_delete();
+    void create_dialog_user();
+    void create_dialog_ou();
+
+private:
+    // Use this as parents for widgets used inside tests.
+    // For every test a new parent will be created and after
+    // test completes, parent is deleted which deletes all
+    // child widgets as well.
+    QWidget *parent_widget = nullptr;
+
+    // For easy setup and cleanup of each test, we use an
+    // object named "test-arena" which is an OU. It is
+    // created before every test and deleted after every
+    // test. All test activity should happen inside this
+    // object.
+    QString test_arena_dn();
+
+    // Creates dn for object with given name whose parent is
+    // test arena. Class is used to determine suffix.
+    QString test_object_dn(const QString &name, const QString &object_class);
+
+    bool object_exists(const QString &dn);
+    void tab(const int n = 1);
+};
+
+#endif /* TEST_ADMC_H */

--- a/tests/test_admc.h
+++ b/tests/test_admc.h
@@ -49,6 +49,9 @@ class TestADMC : public QObject {
     Q_OBJECT
 
 private slots:
+    // NOTE: initTestCase(), cleanupTestCase(), init() and
+    // cleanup() are special slots called by QTest.
+
     // Called before first test
     void initTestCase();
     // Called after last test

--- a/tests/test_admc.h
+++ b/tests/test_admc.h
@@ -56,7 +56,6 @@ private slots:
 
     // Run before and after each test
     void init();
-    void cleanup_recurse(const QString &dn);
     void cleanup();
 
     // Tests
@@ -83,8 +82,14 @@ private:
     // test arena. Class is used to determine suffix.
     QString test_object_dn(const QString &name, const QString &object_class);
 
+    // Tests object's existance on the server.
     bool object_exists(const QString &dn);
+
+    // Presses the Tab button. Use to cycle through input
+    // widgets.
     void tab(const int n = 1);
+
+    void delete_test_arena_recursive(const QString &dn);
 };
 
 #endif /* TEST_ADMC_H */


### PR DESCRIPTION
make sample tests for adinterface and create dialogs

Create subdirectory called "tests".

Add ad_utils f-n dn_from_name_and_parent() used in tests.

Add temp flag called "print_errors" to Status. TEMPORARY, will be removed soon (tm), but requires AdInterface rework first.