### PR TITLE
fix double click not changing scope current item

### DIFF
--- a/src/admc/console.cpp
+++ b/src/admc/console.cpp
@@ -726,17 +726,12 @@ void Console::on_result_item_double_clicked(const QModelIndex &index)
 
     const QString dn = index.data(Role_DN).toString();
     if (is_container) {
-        const QList<QModelIndex> scope_index_matches
-                = scope_model->match(scope_model->index(0, 0), Role_DN, dn, 1, Qt::MatchFlags(Qt::MatchExactly | Qt::MatchRecursive));
+        // Find the scope item that represents this object
+        // and make it the current item of scope tree.
+        const QList<QModelIndex> scope_index_matches = scope_model->match(scope_model->index(0, 0), Role_DN, dn, 1, Qt::MatchFlags(Qt::MatchExactly | Qt::MatchRecursive));
         if (!scope_index_matches.empty()) {
             auto current_index = scope_index_matches[0];
-            on_current_scope_changed(current_index, current_index);
-            
-            // Expand scope tree to selected object
-            while (current_index.isValid()) {
-                scope_view->expand(current_index);
-                current_index = current_index.parent();
-            }
+            scope_view->selectionModel()->setCurrentIndex(current_index, QItemSelectionModel::Current | QItemSelectionModel::ClearAndSelect);
         }
     } else {
         PropertiesDialog::open_for_target(dn);


### PR DESCRIPTION
Late bugfix for #108

Double clicking was changing results target but wasn't changing the current item of scope.
That's bad behavior because the logic is that results target equals to current item of scope. Caused weird behavior where you double clicked on object A in results, that switched results target to A, but scope was still targeted at B. Then when you wanted to switch back to B, you clicked on B in scope and it didnt switch (due to B already being current item).

Also, setCurrentIndex() takes care of expansions stuff for us.