### PR TITLE
Fix users being add to scope

### DIFF
--- a/src/admc/console.cpp
+++ b/src/admc/console.cpp
@@ -369,7 +369,7 @@ void Console::on_object_added(const QString &dn) {
         const QString parent_dn = dn_get_parent(dn);
         const QList<QModelIndex> scope_parent_matches = scope_model->match(scope_model->index(0, 0), Role_DN, parent_dn, 1, Qt::MatchFlags(Qt::MatchExactly | Qt::MatchRecursive));
         
-        if (scope_parent_matches.isEmpty()) {
+        if (!scope_parent_matches.isEmpty()) {
             return scope_parent_matches[0];
         } else {
             return QModelIndex();

--- a/src/admc/console.cpp
+++ b/src/admc/console.cpp
@@ -731,7 +731,7 @@ QModelIndex Console::get_scope_node_from_id(const int id) const {
 void Console::on_result_item_double_clicked(const QModelIndex &index)
 {
     const QString dn = index.data(Role_DN).toString();
-    const QString object_class = index.data(Role_DN).toString();
+    const QString object_class = index.data(Role_ObjectClass).toString();
     const bool should_be_in_scope = object_should_be_in_scope(object_class);
 
     if (should_be_in_scope) {


### PR DESCRIPTION
Fixes users being added to scope tree (while show non-containers setting is OFF). Users were added to scope if you dragged them. Happened because on_object_added() slot that responded to new objects appearing, put all objects into scope even if they shouldn't be there.

This also slightly alters "double-click in results" behavior. Now, if show non-containers setting is ON, it will navigate instead of opening properties for non-containers also. So essentially, double-click logic becomes: "navigate if object is in scope tree". Before it was "navigate if object is container". But, this double click behavior is now the same as in ADUC, which is ... good?