### PR TITLE
fix slow refresh of objects with many children

### DIFF
--- a/src/admc/console.cpp
+++ b/src/admc/console.cpp
@@ -46,6 +46,7 @@
 #include <QStack>
 #include <QMenu>
 #include <QLabel>
+#include <QSortFilterProxyModel>
 
 enum ScopeRole {
     ScopeRole_Id = Role_ObjectClass + 1,
@@ -88,6 +89,9 @@ Console::Console(MenuBar *menubar_arg)
     results_view->sortByColumn(0, Qt::AscendingOrder);
     results_view->setSelectionMode(QAbstractItemView::ExtendedSelection);
     results_view->setDragDropOverwriteMode(true);
+
+    results_proxy_model = new QSortFilterProxyModel(this);
+    results_view->setModel(results_proxy_model);
 
     SETTINGS()->setup_header_state(results_view->header(), VariantSetting_ResultsHeader);
     
@@ -300,7 +304,7 @@ void Console::on_current_scope_changed(const QModelIndex &current, const QModelI
     const int id = current.data(ScopeRole_Id).toInt();
 
     QStandardItemModel *results_model = scope_id_to_results[id];
-    results_view->setModel(results_model);
+    results_proxy_model->setSourceModel(results_model);
 
     // Update header with new object counts when rows are added/removed
     connect(

--- a/src/admc/console.h
+++ b/src/admc/console.h
@@ -42,6 +42,7 @@ class QStandardItem;
 class AdObject;
 class MenuBar;
 class QLabel;
+class QSortFilterProxyModel;
 template <typename T> class QList;
 
 class Console final : public QWidget {
@@ -76,6 +77,7 @@ private:
     MenuBar *menubar;
     QWidget *results_header;
     QLabel *results_header_label;
+    QSortFilterProxyModel *results_proxy_model;
 
     // NOTE: store target history as scope node id's
     // Last is closest to current


### PR DESCRIPTION
This happened if you loaded an object with many children and then refreshed it. It also affected changing settings like "Advanced View" because they refreshed the whole tree.

The problem was with sorting of the results model containing many objects. Model's sort() call appeared to create some kind of complex data structure that caused deletion of the model to take too long. For reference, if a model took 10s to load data from server and populate, it would take 60s to delete.

Fix was to put a QSortFilterProxyModel between results view and results model.

Before: view - model
After: view - proxy - model

This way, the proxy model is sorted and stores that complex data structure. The model is deleted in reasonable time (almost instantly).

In addition, the proxy model is also a better way to sort because it has options for case insensitive sort and other sort features.

One thing to look out for is if for whatever reason it will be needed to delete the proxy model, it might take a long time to delete as well.

Closes #121
