### PR TITLE
Fix memory leaks

### DIFF
--- a/src/admc/ad_interface.cpp
+++ b/src/admc/ad_interface.cpp
@@ -82,27 +82,34 @@ bool AdInterface::connect() {
     []() {
         krb5_error_code result;
         krb5_context context;
+        char *realm_cstr = NULL;
 
         result = krb5_init_context(&context);
+
+        auto cleanup =
+        [=]() {
+            krb5_free_default_realm(context, realm_cstr);
+            krb5_free_context(context);
+        };
+
         if (result) {
             qDebug() << "Failed to init krb5 context";
+            
+            cleanup();
             return QString();
         }
 
-        char *realm_cstr = NULL;
         result = krb5_get_default_realm(context, &realm_cstr);
         if (result) {
             qDebug() << "Failed to get default realm";
 
-            krb5_free_context(context);
-
+            cleanup();
             return QString();
         }
 
         const QString out = QString(realm_cstr);
 
-        krb5_free_default_realm(context, realm_cstr);
-
+        cleanup();
         return out;
     }();
 

--- a/src/admc/ad_interface.cpp
+++ b/src/admc/ad_interface.cpp
@@ -239,11 +239,6 @@ bool search_paged(LDAP* ld, const char *filter, char **attrs, const int scope, c
         BerElement *berptr;
         for (char *attr = ldap_first_attribute(ld, entry, &berptr); attr != NULL; attr = ldap_next_attribute(ld, entry, berptr)) {
             struct berval **values_ldap = ldap_get_values_len(ld, entry, attr);
-            if (values_ldap == NULL) {
-                ldap_value_free_len(values_ldap);
-
-                continue;
-            }
 
             const QList<QByteArray> values_bytes =
             [=]() {
@@ -260,9 +255,7 @@ bool search_paged(LDAP* ld, const char *filter, char **attrs, const int scope, c
                 return values_bytes_out;
             }();
 
-            const QString attribute(attr);
-
-            object_attributes[attribute] = values_bytes;
+            object_attributes[QString(attr)] = values_bytes;
 
             ldap_value_free_len(values_ldap);
             ldap_memfree(attr);

--- a/src/admc/ad_interface.cpp
+++ b/src/admc/ad_interface.cpp
@@ -355,13 +355,17 @@ QHash<QString, AdObject> AdInterface::search(const QString &filter, const QList<
 
     // Convert attributes list to NULL-terminated array
     char **attrs =
-    [attributes]() {
+    [attributes]() -> char** {
         char **attrs_out;
         if (attributes.isEmpty()) {
             // Pass NULL so LDAP gets all attributes
             attrs_out = NULL;
         } else {
             attrs_out = (char **) malloc((attributes.size() + 1) * sizeof(char *));
+            if (attrs_out == NULL) {
+                return NULL;
+            }
+
             for (int i = 0; i < attributes.size(); i++) {
                 const QString attribute = attributes[i];
                 attrs_out[i] = strdup(cstr(attribute));
@@ -484,6 +488,10 @@ bool AdInterface::attribute_replace_value(const QString &dn, const QString &attr
 
 bool AdInterface::attribute_add_value(const QString &dn, const QString &attribute, const QByteArray &value, const DoStatusMsg do_msg) {
     char *data_copy = (char *) malloc(value.size());
+    if (data_copy == NULL) {
+        return false;
+    }
+
     memcpy(data_copy, value.constData(), value.size());
 
     struct berval ber_data;
@@ -527,6 +535,10 @@ bool AdInterface::attribute_delete_value(const QString &dn, const QString &attri
     const QString value_display = attribute_display_value(attribute, value);
 
     char *data_copy = (char *) malloc(value.size());
+    if (data_copy == NULL) {
+        return false;
+    }
+
     memcpy(data_copy, value.constData(), value.size());
 
     struct berval ber_data;

--- a/src/admc/ad_interface.h
+++ b/src/admc/ad_interface.h
@@ -72,7 +72,7 @@ public:
     QString schema_dn() const;
 
     // NOTE: If request attributes list is empty, all attributes are returned
-    QHash<QString, AdObject> search(const QString &filter, const QList<QString> &attributes, const SearchScope scope_enum, const QString &search_base = QString());
+    QHash<QString, AdObject> search(const QString &filter, const QList<QString> &attributes, const SearchScope scope_enum, const QString &search_base_arg = QString());
     AdObject search_object(const QString &dn, const QList<QString> &attributes = QList<QString>());
 
     bool attribute_replace_values(const QString &dn, const QString &attribute, const QList<QByteArray> &values, const DoStatusMsg do_msg = DoStatusMsg_Yes);

--- a/src/admc/edits/attribute_edit.cpp
+++ b/src/admc/edits/attribute_edit.cpp
@@ -20,7 +20,8 @@
 #include "edits/attribute_edit.h"
 #include "tabs/properties_tab.h"
 
-AttributeEdit::AttributeEdit(QList<AttributeEdit *> *edits_out, QObject *parent) {
+AttributeEdit::AttributeEdit(QList<AttributeEdit *> *edits_out, QObject *parent)
+: QObject(parent) {
     if (edits_out != nullptr) {
         if (edits_out->contains(this)) {
             printf("ERROR: attribute edit added twice to list!");

--- a/src/admc/edits/expiry_edit.cpp
+++ b/src/admc/edits/expiry_edit.cpp
@@ -46,7 +46,7 @@ ExpiryEdit::ExpiryEdit(QList<AttributeEdit *> *edits_out, QObject *parent)
 
     edit = new QDateEdit();
 
-    auto button_group = new QButtonGroup();
+    auto button_group = new QButtonGroup(this);
     button_group->addButton(never_check);
     button_group->addButton(end_of_check);
 

--- a/src/admc/edits/unlock_edit.cpp
+++ b/src/admc/edits/unlock_edit.cpp
@@ -50,11 +50,10 @@ void UnlockEdit::add_to_layout(QFormLayout *layout) {
 bool UnlockEdit::apply(const QString &dn) const {
     if (check->isChecked()) {
         const bool result = AD()->user_unlock(dn);
+        check->setChecked(false);
         
         return result;
     } else {
         return true;
     }
-
-    check->setChecked(false);
 }


### PR DESCRIPTION
- AdInterface::connect()
- AdInterface::search()
- AttributeEdit (all of them)
- check for NULL returns from malloc
Create search_paged() which used to be the inner part of the while loop in search(). Clearer and easier to understand.