### PR TITLE
Fix memory leaks

### DIFF
--- a/src/admc/ad_interface.cpp
+++ b/src/admc/ad_interface.cpp
@@ -323,7 +323,7 @@ QHash<QString, AdObject> AdInterface::search(const QString &filter, const QList<
                 [=]() {
                     QList<QByteArray> values_bytes_out;
 
-                    // if (values_ldap != NULL) {
+                    if (values_ldap != NULL) {
                         const int values_count = ldap_count_values_len(values_ldap);
                         for (int i = 0; i < values_count; i++) {
                             struct berval value_berval = *values_ldap[i];
@@ -331,7 +331,7 @@ QHash<QString, AdObject> AdInterface::search(const QString &filter, const QList<
 
                             values_bytes_out.append(value_bytes);
                         }
-                    // }
+                    }
 
                     return values_bytes_out;
                 }();

--- a/src/admc/ad_interface.cpp
+++ b/src/admc/ad_interface.cpp
@@ -239,11 +239,14 @@ QHash<QString, AdObject> AdInterface::search(const QString &filter, const QList<
             attrs_out = NULL;
         } else {
             attrs_out = (char **) malloc((attributes.size() + 1) * sizeof(char *));
-            for (int i = 0; i < attributes.size(); i++) {
-                const QString attribute = attributes[i];
-                attrs_out[i] = strdup(cstr(attribute));
+
+            if (attrs_out != NULL) {
+                for (int i = 0; i < attributes.size(); i++) {
+                    const QString attribute = attributes[i];
+                    attrs_out[i] = strdup(cstr(attribute));
+                }
+                attrs_out[attributes.size()] = NULL;
             }
-            attrs_out[attributes.size()] = NULL;
         }
 
         return attrs_out;
@@ -457,6 +460,9 @@ bool AdInterface::attribute_replace_value(const QString &dn, const QString &attr
 
 bool AdInterface::attribute_add_value(const QString &dn, const QString &attribute, const QByteArray &value, const DoStatusMsg do_msg) {
     char *data_copy = (char *) malloc(value.size());
+    if (data_copy == NULL) {
+        return false;
+    }
     memcpy(data_copy, value.constData(), value.size());
 
     struct berval ber_data;
@@ -500,6 +506,9 @@ bool AdInterface::attribute_delete_value(const QString &dn, const QString &attri
     const QString value_display = attribute_display_value(attribute, value);
 
     char *data_copy = (char *) malloc(value.size());
+    if (data_copy == NULL) {
+        return false;
+    }
     memcpy(data_copy, value.constData(), value.size());
 
     struct berval ber_data;

--- a/src/admc/ad_interface.cpp
+++ b/src/admc/ad_interface.cpp
@@ -82,26 +82,33 @@ bool AdInterface::connect() {
     []() {
         krb5_error_code result;
         krb5_context context;
+        char *realm_cstr = NULL;
+
+        auto cleanup =
+        [&]() {
+            krb5_free_default_realm(context, realm_cstr);
+            krb5_free_context(context);
+        };
 
         result = krb5_init_context(&context);
         if (result) {
             qDebug() << "Failed to init krb5 context";
+
+            cleanup();
             return QString();
         }
 
-        char *realm_cstr = NULL;
         result = krb5_get_default_realm(context, &realm_cstr);
         if (result) {
             qDebug() << "Failed to get default realm";
 
-            krb5_free_context(context);
-
+            cleanup();
             return QString();
         }
 
         const QString out = QString(realm_cstr);
 
-        krb5_free_default_realm(context, realm_cstr);
+        cleanup();
 
         return out;
     }();

--- a/src/admc/edits/attribute_edit.cpp
+++ b/src/admc/edits/attribute_edit.cpp
@@ -20,7 +20,9 @@
 #include "edits/attribute_edit.h"
 #include "tabs/properties_tab.h"
 
-AttributeEdit::AttributeEdit(QList<AttributeEdit *> *edits_out, QObject *parent) {
+AttributeEdit::AttributeEdit(QList<AttributeEdit *> *edits_out, QObject *parent)
+: QObject(parent)
+{
     if (edits_out != nullptr) {
         if (edits_out->contains(this)) {
             printf("ERROR: attribute edit added twice to list!");

--- a/src/admc/edits/expiry_edit.cpp
+++ b/src/admc/edits/expiry_edit.cpp
@@ -46,7 +46,7 @@ ExpiryEdit::ExpiryEdit(QList<AttributeEdit *> *edits_out, QObject *parent)
 
     edit = new QDateEdit();
 
-    auto button_group = new QButtonGroup();
+    auto button_group = new QButtonGroup(this);
     button_group->addButton(never_check);
     button_group->addButton(end_of_check);
 

--- a/src/admc/edits/unlock_edit.cpp
+++ b/src/admc/edits/unlock_edit.cpp
@@ -50,11 +50,10 @@ void UnlockEdit::add_to_layout(QFormLayout *layout) {
 bool UnlockEdit::apply(const QString &dn) const {
     if (check->isChecked()) {
         const bool result = AD()->user_unlock(dn);
+        check->setChecked(false);
         
         return result;
     } else {
         return true;
     }
-
-    check->setChecked(false);
 }

--- a/src/admc/find_results.h
+++ b/src/admc/find_results.h
@@ -44,7 +44,7 @@ public:
 
     void load(const QString &filter, const QString &search_base);
 
-    // Returns a copy of item's rows, so these items need to become owned by something or deleted
+    // NOTE: returned items need to be re-parented or deleted!
     QList<QList<QStandardItem *>> get_selected_rows() const;
 
     void load_menu(QMenu *menu);

--- a/src/admc/find_widget.h
+++ b/src/admc/find_widget.h
@@ -44,6 +44,7 @@ public:
     
     FindWidget(const QList<QString> classes, const QString &default_search_base);
 
+    // NOTE: returned items need to be re-parented or deleted!
     QList<QList<QStandardItem *>> get_selected_rows() const;
 
 private slots:

--- a/src/admc/select_dialog.cpp
+++ b/src/admc/select_dialog.cpp
@@ -152,6 +152,10 @@ void SelectDialog::open_find_dialog() {
                 
                 if (!model_contains_object) {
                     model->appendRow(row);
+                } else {
+                    for (auto item : row) {
+                        delete item;
+                    }
                 }
             }
         });

--- a/tests/admc_test.cpp
+++ b/tests/admc_test.cpp
@@ -519,7 +519,6 @@ void ADMCTest::object_menu_add_to_group() {
     navigate_until_object(find_results_view, group_dn);
     const QModelIndex selected_index = find_results_view->selectionModel()->currentIndex();
     const QString selected_dn = selected_index.data(Role_DN).toString();
-    const QList<QList<QStandardItem *>> selected_rows = find_select_dialog->get_selected_rows();
 
     find_select_dialog->accept();
 


### PR DESCRIPTION
Fix memory leaks and other errors detected in static analysis by valgrind and PVS.

Did not include search() refactor into search_paged() so that the diff is easier to read.