### PR TITLE
Offline drag

### DIFF
--- a/src/admc/ad_interface.cpp
+++ b/src/admc/ad_interface.cpp
@@ -279,7 +279,10 @@ bool search_paged(LDAP *ld, const char *filter, char **attributes, const int sco
         }
         ber_free(berptr, 0);
 
-        out->insert(dn, AdObject(dn, object_attributes));
+        AdObject object;
+        object.load(dn, object_attributes);
+
+        out->insert(dn, object);
     }
 
     // Parse the results to retrieve returned controls

--- a/src/admc/ad_interface.h
+++ b/src/admc/ad_interface.h
@@ -100,8 +100,8 @@ public:
     bool user_set_account_option(const QString &dn, AccountOption option, bool set);
     bool user_unlock(const QString &dn);
 
-    bool object_can_drop(const QString &dn, const QString &target_dn);
-    void object_drop(const QString &dn, const QString &target_dn);
+    bool object_can_drop(const AdObject &dropped, const AdObject &target);
+    void object_drop(const AdObject &dropped, const AdObject &target);
 
     bool create_gpo(const QString &name);
     bool delete_gpo(const QString &dn);

--- a/src/admc/ad_object.cpp
+++ b/src/admc/ad_object.cpp
@@ -29,15 +29,17 @@ AdObject::AdObject()
 
 }
 
-AdObject::AdObject(const QString &dn_arg, const AdObjectAttributes &attributes_data_arg)
-: dn(dn_arg)
-, attributes_data(attributes_data_arg)
-{
-
+void AdObject::load(const QString &dn_arg, const AdObjectAttributes &attributes_data_arg) {
+    dn = dn_arg;
+    attributes_data = attributes_data_arg;
 }
 
 QString AdObject::get_dn() const {
     return dn;
+}
+
+AdObjectAttributes AdObject::get_attributes_data() const {
+    return attributes_data;
 }
 
 bool AdObject::is_empty() const {
@@ -263,4 +265,21 @@ QIcon AdObject::get_icon() const {
     const QIcon icon = QIcon::fromTheme(icon_name);
 
     return icon;
+}
+
+// NOTE: these f-ns are used to serialize adobject's into
+// mimedata for console drag and drop
+QDataStream &operator<<(QDataStream &out, const AdObject &obj) {
+    out << obj.get_dn() << obj.get_attributes_data();
+    return out;
+}
+
+QDataStream &operator>>(QDataStream &in, AdObject &obj) {
+    QString dn;
+    AdObjectAttributes attributes_data;
+    in >> dn >> attributes_data;
+
+    obj.load(dn, attributes_data);
+
+    return in;
 }

--- a/src/admc/ad_object.h
+++ b/src/admc/ad_object.h
@@ -37,15 +37,18 @@
 // afterwards so it WILL become out of date after any
 // AD modification. Therefore, do not keep it around for too long.
 
+class QDataStream;
 typedef QHash<QString, QList<QByteArray>> AdObjectAttributes;
 
 class AdObject {
 
 public:
     AdObject();
-    AdObject(const QString &dn_arg, const AdObjectAttributes &attributes_data_arg);
+    
+    void load(const QString &dn_arg, const AdObjectAttributes &attributes_data_arg);
 
     QString get_dn() const;
+    AdObjectAttributes get_attributes_data() const;
     bool is_empty() const;
     bool contains(const QString &attribute) const;
     QList<QString> attributes() const;
@@ -85,5 +88,7 @@ private:
 };
 
 Q_DECLARE_METATYPE(AdObject);
+QDataStream &operator<<(QDataStream &out, const AdObject &obj);
+QDataStream &operator>>(QDataStream &in, AdObject &obj);
 
 #endif /* AD_OBJECT_H */

--- a/src/admc/ad_object.h
+++ b/src/admc/ad_object.h
@@ -84,4 +84,6 @@ private:
     AdObjectAttributes attributes_data;
 };
 
+Q_DECLARE_METATYPE(AdObject);
+
 #endif /* AD_OBJECT_H */

--- a/src/admc/console.cpp
+++ b/src/admc/console.cpp
@@ -646,6 +646,9 @@ void Console::fetch_scope_node(const QModelIndex &index) {
         // NOTE: load_object_row() needs this for loading group type/scope
         out += ATTRIBUTE_GROUP_TYPE;
 
+        // NOTE: system flags are needed for drag and drop logic
+        out += ATTRIBUTE_SYSTEM_FLAGS;
+
         return out;
     }();
 

--- a/src/admc/console.cpp
+++ b/src/admc/console.cpp
@@ -720,14 +720,8 @@ QStandardItem *Console::make_scope_item(const AdObject &object) {
     dummy_item->setData(DUMMY_ITEM_ID, ScopeRole_Id);
     item->appendRow(dummy_item);
     
-    const QString dn = object.get_dn();
-    item->setData(dn, Role_DN);
-    
-    const QString name = dn_get_name(dn);
+    const QString name = dn_get_name(object.get_dn());
     item->setText(name);
-
-    const QString object_class = object.get_string(ATTRIBUTE_OBJECT_CLASS);
-    item->setData(object_class, Role_ObjectClass);
 
     static int id_max = 0;
     const int id = id_max;
@@ -736,6 +730,8 @@ QStandardItem *Console::make_scope_item(const AdObject &object) {
 
     const QIcon icon = object.get_icon();
     item->setIcon(icon);
+
+    load_object_item_data(item, object);
 
     return item;
 }

--- a/src/admc/console.cpp
+++ b/src/admc/console.cpp
@@ -49,8 +49,8 @@
 #include <QSortFilterProxyModel>
 
 enum ScopeRole {
-    ScopeRole_Id = Role_ObjectClass + 1,
-    ScopeRole_Fetched = Role_ObjectClass + 2,
+    ScopeRole_Id = Role_AdObject + 1,
+    ScopeRole_Fetched = Role_AdObject + 2,
 };
 
 #define DUMMY_ITEM_ID -1

--- a/src/admc/console_drag_model.cpp
+++ b/src/admc/console_drag_model.cpp
@@ -30,6 +30,8 @@
 // TODO: dragging queries and query folders
 // TODO: move object_can_drop() and object_drop() here, shouldnt be in AD() 
 
+const QString MIME_TYPE_OBJECT = "MIME_TYPE_OBJECT";
+
 QMimeData *ConsoleDragModel::mimeData(const QModelIndexList &indexes) const {
     QMimeData *data = QStandardItemModel::mimeData(indexes);
 
@@ -47,6 +49,24 @@ QMimeData *ConsoleDragModel::mimeData(const QModelIndexList &indexes) const {
     }();
 
     data->setUrls(dns);
+
+    const QList<QVariant> objects =
+    [=]() {
+        QList<QVariant> out;
+        for (const QModelIndex index : indexes) {
+            if (index.column() == 0) {
+                const QVariant object_variant = index.data(Role_AdObject);
+                out.append(object_variant);
+            }
+        }
+
+        return out;
+    }();
+
+    QByteArray objects_as_bytes;
+    QDataStream stream(&objects_as_bytes, QIODevice::WriteOnly);
+    stream << QVariant(objects);
+    data->setData(MIME_TYPE_OBJECT, objects_as_bytes);
 
     return data;
 }

--- a/src/admc/console_drag_model.cpp
+++ b/src/admc/console_drag_model.cpp
@@ -21,7 +21,6 @@
 
 #include "ad_interface.h"
 #include "ad_object.h"
-#include "ad_object.h"
 #include "status.h"
 #include "object_model.h"
 

--- a/src/admc/main.cpp
+++ b/src/admc/main.cpp
@@ -20,12 +20,15 @@
 #include "config.h"
 #include "main_window.h"
 #include "settings.h"
+#include "ad_object.h"
 
 #include <QApplication>
 #include <QTranslator>
 #include <QLibraryInfo>
 
 int main(int argc, char **argv) {
+    qRegisterMetaTypeStreamOperators<AdObject>("AdObject");
+
     QApplication app(argc, argv);
     app.setApplicationDisplayName(ADMC_APPLICATION_DISPLAY_NAME);
     app.setApplicationName(ADMC_APPLICATION_NAME);

--- a/src/admc/object_model.cpp
+++ b/src/admc/object_model.cpp
@@ -67,9 +67,12 @@ void load_object_row(const QList<QStandardItem *> row, const AdObject &object) {
     const QIcon icon = object.get_icon();
     row[0]->setIcon(icon);
 
-    row[0]->setData(object.get_dn(), Role_DN);
-    row[0]->setData(object.get_dn(), Role_DN);
-    row[0]->setData(object.get_string(ATTRIBUTE_OBJECT_CLASS), Role_ObjectClass);
+    load_object_item_data(row[0], object);
+}
+
+void load_object_item_data(QStandardItem *item, const AdObject &object) {
+    item->setData(object.get_dn(), Role_DN);
+    item->setData(object.get_string(ATTRIBUTE_OBJECT_CLASS), Role_ObjectClass);
 }
 
 QList<QString> object_model_header_labels() {

--- a/src/admc/object_model.cpp
+++ b/src/admc/object_model.cpp
@@ -73,6 +73,8 @@ void load_object_row(const QList<QStandardItem *> row, const AdObject &object) {
 void load_object_item_data(QStandardItem *item, const AdObject &object) {
     item->setData(object.get_dn(), Role_DN);
     item->setData(object.get_string(ATTRIBUTE_OBJECT_CLASS), Role_ObjectClass);
+
+    item->setData(QVariant::fromValue(object), Role_AdObject);
 }
 
 QList<QString> object_model_header_labels() {

--- a/src/admc/object_model.h
+++ b/src/admc/object_model.h
@@ -36,6 +36,7 @@ class AdObject;
 enum ObjectRole {
     Role_DN = Qt::UserRole + 1,
     Role_ObjectClass = Qt::UserRole + 2,
+    Role_AdObject = Qt::UserRole + 3,
 };
 
 void load_object_row(const QList<QStandardItem *> row, const AdObject &object);

--- a/src/admc/object_model.h
+++ b/src/admc/object_model.h
@@ -39,6 +39,7 @@ enum ObjectRole {
 };
 
 void load_object_row(const QList<QStandardItem *> row, const AdObject &object);
+void load_object_item_data(QStandardItem *item, const AdObject &object);
 QList<QString> object_model_header_labels();
 
 #endif /* OBJECT_MODEL_H */


### PR DESCRIPTION
Remove server communication from drag and drop process. Previously drag and drop downloaded data about hovered objects to determine if object can be dropped.

Reason for this PR: communicating with the server while dragging makes the user experience laggy, especially with slower connections.

AdObject is now stored in item data of console models. ConsoleDragModel retrieves adobject's from item data and puts them in mimedata.

Had to make AdObject a qt metatype and implement stream operators. This is required for storing AdObject in QVariant and QMimeData.

Now that item data contains adobject, other item data are obsolete (dn and object class, both can be obtained from adobject). Will switch to using adobject where old item roles are used in a different PR/commit.

Added a bandaid for a qt drag bug. See comment in console_drag_model.cpp. I think the bug wasn't active before this PR and is active now because canDropMimeData() took a long time to run (due to server communication).

Closes #111 