### PR TITLE
Tree delete

### DIFF
--- a/tests/admc_test.h
+++ b/tests/admc_test.h
@@ -118,8 +118,6 @@ private:
     // widgets.
     void tab(const int n = 1);
 
-    void delete_test_arena_recursive(const QString &dn);
-
     void navigate_until_object(QTreeView *view, const QString &target_dn);
     void wait_for_widget_exposed(QWidget *widget);
 };


### PR DESCRIPTION
To enable recursive delete, have to give a "tree delete control" to the ldap delete function. The control is like a setting for the f-n.

Removed manual recursive delete of test arena from tests since it's not needed anymore.

Closes #132 