### PR TITLE
Separate adconfig from adinterface

### DIFF
--- a/src/admc/ad_config.cpp
+++ b/src/admc/ad_config.cpp
@@ -58,9 +58,25 @@
 QString get_locale_dir();
 QList<QString> add_auxiliary_classes(const QList<QString> &object_classes);
 
-AdConfig::AdConfig(QObject *parent)
-: QObject(parent)
-{
+AdConfig *AdConfig::instance() {
+    static AdConfig m_instance;
+    return &m_instance;
+}
+
+AdConfig::AdConfig() {
+
+}
+
+void AdConfig::load() {
+    filter_containers.clear();
+    columns.clear();
+    column_display_names.clear();
+    class_display_names.clear();
+    find_attributes.clear();
+    attribute_display_names.clear();
+    attribute_schemas.clear();
+    class_schemas.clear();
+
     // Attribute schemas
     {
         const QString filter = filter_CONDITION(Condition_Equals, ATTRIBUTE_OBJECT_CLASS, CLASS_ATTRIBUTE_SCHEMA);
@@ -212,10 +228,10 @@ AdConfig::AdConfig(QObject *parent)
             column_display_names[attribute] = display_name;
         };
 
-        add_custom(ATTRIBUTE_DN, tr("Distinguished name"));
-        add_custom(ATTRIBUTE_DESCRIPTION, tr("Description"));
-        add_custom(ATTRIBUTE_OBJECT_CLASS, tr("Class"));
-        add_custom(ATTRIBUTE_NAME, tr("Name"));
+        add_custom(ATTRIBUTE_DN, QObject::tr("Distinguished name"));
+        add_custom(ATTRIBUTE_DESCRIPTION, QObject::tr("Description"));
+        add_custom(ATTRIBUTE_OBJECT_CLASS, QObject::tr("Class"));
+        add_custom(ATTRIBUTE_NAME, QObject::tr("Name"));
     }
 
     filter_containers =
@@ -259,7 +275,7 @@ AdConfig::AdConfig(QObject *parent)
 }
 
 AdConfig *ADCONFIG() {
-    return AdInterface::instance()->config();
+    return AdConfig::instance();
 }
 
 QString AdConfig::get_attribute_display_name(const Attribute &attribute, const ObjectClass &objectClass) const {
@@ -271,19 +287,19 @@ QString AdConfig::get_attribute_display_name(const Attribute &attribute, const O
 
     // NOTE: display specifier doesn't cover all attributes for all classes, so need to hardcode some of them here
     static const QHash<Attribute, QString> fallback_display_names = {
-        {ATTRIBUTE_NAME, tr("Name")},
-        {ATTRIBUTE_DN, tr("Distinguished name")},
-        {ATTRIBUTE_OBJECT_CLASS, tr("Object class")},
-        {ATTRIBUTE_WHEN_CREATED, tr("Created")},
-        {ATTRIBUTE_WHEN_CHANGED, tr("Changed")},
-        {ATTRIBUTE_USN_CREATED, tr("USN created")},
-        {ATTRIBUTE_USN_CHANGED, tr("USN changed")},
-        {ATTRIBUTE_ACCOUNT_EXPIRES, tr("Account expires")},
-        {ATTRIBUTE_OBJECT_CATEGORY, tr("Type")},
-        {ATTRIBUTE_PROFILE_PATH, tr("Profile path")},
-        {ATTRIBUTE_SCRIPT_PATH, tr("Logon script")},
-        {ATTRIBUTE_SAMACCOUNT_NAME, tr("Logon name (pre-Windows 2000)")},
-        {ATTRIBUTE_MAIL, tr("E-mail")},
+        {ATTRIBUTE_NAME, QObject::tr("Name")},
+        {ATTRIBUTE_DN, QObject::tr("Distinguished name")},
+        {ATTRIBUTE_OBJECT_CLASS, QObject::tr("Object class")},
+        {ATTRIBUTE_WHEN_CREATED, QObject::tr("Created")},
+        {ATTRIBUTE_WHEN_CHANGED, QObject::tr("Changed")},
+        {ATTRIBUTE_USN_CREATED, QObject::tr("USN created")},
+        {ATTRIBUTE_USN_CHANGED, QObject::tr("USN changed")},
+        {ATTRIBUTE_ACCOUNT_EXPIRES, QObject::tr("Account expires")},
+        {ATTRIBUTE_OBJECT_CATEGORY, QObject::tr("Type")},
+        {ATTRIBUTE_PROFILE_PATH, QObject::tr("Profile path")},
+        {ATTRIBUTE_SCRIPT_PATH, QObject::tr("Logon script")},
+        {ATTRIBUTE_SAMACCOUNT_NAME, QObject::tr("Logon name (pre-Windows 2000)")},
+        {ATTRIBUTE_MAIL, QObject::tr("E-mail")},
     };
 
     return fallback_display_names.value(attribute, attribute);

--- a/src/admc/ad_config.h
+++ b/src/admc/ad_config.h
@@ -26,7 +26,6 @@
 
 #include "ad_object.h"
 
-#include <QObject>
 #include <QString>
 #include <QList>
 #include <QHash>
@@ -70,11 +69,11 @@ typedef QString Attribute;
 class QLineEdit;
 class AdObject;
 
-class AdConfig final : public QObject {
-Q_OBJECT
-
+class AdConfig {
 public:
-    AdConfig(QObject *parent);
+    static AdConfig *instance();
+
+    void load();
 
     QString get_attribute_display_name(const Attribute &attribute, const ObjectClass &objectClass) const;
 
@@ -117,6 +116,12 @@ private:
     QHash<ObjectClass, AdObject> class_schemas;
 
     QList<QString> add_auxiliary_classes(const QList<QString> &object_classes) const;
+
+    AdConfig();
+    AdConfig(const AdConfig&) = delete;
+    AdConfig& operator=(const AdConfig&) = delete;
+    AdConfig(AdConfig&&) = delete;
+    AdConfig& operator=(AdConfig&&) = delete;
 };
 
 AdConfig *ADCONFIG();

--- a/src/admc/ad_interface.cpp
+++ b/src/admc/ad_interface.cpp
@@ -160,8 +160,6 @@ bool AdInterface::connect() {
         }
         smbc_set_context(smbc);
 
-        emit connected();
-
         return true;
     } else {
         error_status_message(tr("Failed to connect"), tr("Authentication failed"));

--- a/src/admc/ad_interface.cpp
+++ b/src/admc/ad_interface.cpp
@@ -145,7 +145,8 @@ bool AdInterface::connect() {
     const bool success = ad_connect(cstr(uri), &ld);
 
     if (success) {
-        m_config = new AdConfig(this);
+        // TODO: check for adconfig load failure
+        ADCONFIG()->load();
 
         // TODO: can this context expire, for example from a disconnect?
         // NOTE: this doesn't leak memory. False positive.
@@ -167,10 +168,6 @@ bool AdInterface::connect() {
 
         return false;
     }
-}
-
-AdConfig *AdInterface::config() const {
-    return m_config;
 }
 
 QString AdInterface::domain() const {

--- a/src/admc/ad_interface.h
+++ b/src/admc/ad_interface.h
@@ -41,7 +41,6 @@ enum SearchScope {
 class QString;
 class QByteArray;
 class QDateTime;
-class AdConfig;
 class AdObject;
 template <typename T> class QList;
 typedef struct ldap LDAP;
@@ -64,7 +63,6 @@ public:
 
     bool connect();
 
-    AdConfig *config() const;
     QString domain() const;
     QString domain_head() const;
     QString host() const;
@@ -122,7 +120,6 @@ signals:
 private:
     LDAP *ld;
     SMBCCTX *smbc;
-    AdConfig *m_config;
     QString m_domain;
     QString m_domain_head;
     QString m_configuration_dn;

--- a/src/admc/ad_interface.h
+++ b/src/admc/ad_interface.h
@@ -109,9 +109,6 @@ public:
     void stop_search();
 
 signals:
-    // Emitted when connected successfully to a server
-    void connected();
-
     // These signals are for ObjectModel
     void object_added(const QString &dn);
     void object_deleted(const QString &dn);

--- a/src/admc/main_window.cpp
+++ b/src/admc/main_window.cpp
@@ -107,5 +107,6 @@ void MainWindow::connect_to_server() {
 
     if (connect_success) {
         init();
+        menubar->go_online();
     }
 }

--- a/src/admc/main_window.cpp
+++ b/src/admc/main_window.cpp
@@ -62,20 +62,15 @@ MainWindow::MainWindow()
     setCentralWidget(dummy_widget);
 
     connect(
-        AD(), &AdInterface::connected,
-        this, &MainWindow::on_connected);
-
-    STATUS()->start_error_log();
-
-    AD()->connect();
-
-    STATUS()->end_error_log(this);
+        menubar->connect_action, &QAction::triggered,
+        this, &MainWindow::connect_to_server);
+    connect_to_server();
 }
 
 // NOTE: need to finish creating widgets after connection
 // because some widgets require text strings that need to be
 // obtained from the server
-void MainWindow::on_connected() {
+void MainWindow::init() {
     STATUS()->status_bar->showMessage(tr("Ready"));
     SETTINGS()->connect_toggle_widget(STATUS()->status_log, BoolSetting_ShowStatusLog);
 
@@ -98,4 +93,19 @@ void MainWindow::closeEvent(QCloseEvent *event) {
     SETTINGS()->save_geometry(this, VariantSetting_MainWindowGeometry);
 
     QApplication::quit();
+}
+
+void MainWindow::connect_to_server() {
+    STATUS()->start_error_log();
+
+    const bool connect_success = AD()->connect();
+
+    // TODO: check for load failure
+    ADCONFIG()->load();
+
+    STATUS()->end_error_log(this);
+
+    if (connect_success) {
+        init();
+    }
 }

--- a/src/admc/main_window.h
+++ b/src/admc/main_window.h
@@ -36,11 +36,11 @@ public:
 protected:
     void closeEvent(QCloseEvent *event);
 
-private slots:
-    void on_connected();
-
 private:
     MenuBar *menubar;
+
+    void init();
+    void connect_to_server();
 };
 
 #endif /* MAIN_WINDOW_H */

--- a/src/admc/menubar.cpp
+++ b/src/admc/menubar.cpp
@@ -39,14 +39,9 @@
 
 MenuBar::MenuBar()
 : QMenuBar() {
-    QMenu *file_menu = addMenu(tr("&File"));
+    file_menu = addMenu(tr("&File"));
 
-    auto connect_action = file_menu->addAction(tr("&Connect"),
-        [this]() {
-            STATUS()->start_error_log();
-            AD()->connect();
-            STATUS()->end_error_log(this);
-        });
+    connect_action = file_menu->addAction(tr("&Connect"));
 
     auto quit_action = file_menu->addAction(tr("&Quit"),
         []() {
@@ -141,20 +136,18 @@ MenuBar::MenuBar()
         action->setEnabled(true);
     }
 
-    // Once connected, everything is enabled and connect is removed
-    connect(
-        AD(), &AdInterface::connected,
-        [this, file_menu, connect_action]() {
-            enable_actions(true);
-            file_menu->removeAction(connect_action);
-        });
-
     connect(
         toggle_widgets_action, &QAction::triggered,
         [this]() {
             auto dialog = new ToggleWidgetsDialog(this);
             dialog->open();
         });
+}
+
+// Once connected, everything is enabled and connect is removed
+void MenuBar::go_online() {
+    enable_actions(true);
+    file_menu->removeAction(connect_action);
 }
 
 void MenuBar::manual() {

--- a/src/admc/menubar.h
+++ b/src/admc/menubar.h
@@ -24,12 +24,12 @@
 
 class QAction;
 class QMenu;
-class ObjectMenu;
 
 class MenuBar final : public QMenuBar {
 Q_OBJECT
 
 public:
+    QAction *connect_action;
     QAction *filter_action;
     QAction *up_one_level_action;
     QAction *back_action;
@@ -37,6 +37,8 @@ public:
     QMenu *action_menu;
 
     MenuBar();
+
+    void go_online();
 
 signals:
     void filter_contents_dialog();
@@ -47,6 +49,8 @@ private slots:
 
 private:
     void enable_actions(const bool enabled);
+
+    QMenu *file_menu;
 };
 
 #endif /* MENUBAR_H */


### PR DESCRIPTION
This is preparation for changing how adinterface is used, which will require making adinterface not a singleton. Therefore, adconfig has to become a separate singleton.