### PR TITLE
Fix primary group

### DIFF
--- a/src/admc/tabs/membership_tab.cpp
+++ b/src/admc/tabs/membership_tab.cpp
@@ -354,7 +354,7 @@ void MembershipTab::on_remove_button() {
 
     const bool any_selected_are_primary =
     [this, removed_values]() {
-        for (const QString dn : removed_values) {
+        for (const QString &dn : removed_values) {
             if (current_primary_values.contains(dn)) {
                 return true;
             }

--- a/src/admc/tabs/membership_tab.cpp
+++ b/src/admc/tabs/membership_tab.cpp
@@ -251,15 +251,6 @@ void MembershipTab::apply(AdInterface &ad, const QString &target) {
                 }
             }
 
-            if (current_primary_values != original_primary_values) {
-                const QString group_dn = current_primary_values.values()[0];
-                
-                const bool success = ad.user_set_primary_group(group_dn, target);
-                if (success) {
-                    original_primary_values = {group_dn};
-                }
-            }
-
             // Add user to groups that were added
             for (auto group : current_values) {
                 // When group stops being primary, normal membership state is updated by server, so don't have to add ourselves
@@ -274,6 +265,16 @@ void MembershipTab::apply(AdInterface &ad, const QString &target) {
                     if (success) {
                         new_original_values.insert(group);
                     }
+                }
+            }
+
+            // NOTE: must change primary stuff after remove/add operations because setting primary group causes server to perform some add/remove operations on it's end. Groups that stopped being primary are added to normal membership. Groups that become primary are removed from normal membership.
+            if (current_primary_values != original_primary_values) {
+                const QString group_dn = current_primary_values.values()[0];
+                
+                const bool success = ad.user_set_primary_group(group_dn, target);
+                if (success) {
+                    original_primary_values = {group_dn};
                 }
             }
 

--- a/src/admc/tabs/membership_tab.cpp
+++ b/src/admc/tabs/membership_tab.cpp
@@ -34,6 +34,8 @@
 #include <QMenu>
 #include <QPushButton>
 #include <QDebug>
+#include <QFormLayout>
+#include <QLabel>
 
 // Store members in a set
 // Generate model from current members list
@@ -106,6 +108,17 @@ MembershipTab::MembershipTab(const MembershipTabType type_arg) {
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(0);
     layout->addWidget(view);
+
+    // Add primary group label to layout
+    if (type == MembershipTabType_MemberOf) {
+        primary_group_label = new QLabel();
+
+        auto primary_group_layout = new QFormLayout();
+        primary_group_layout->addRow(tr("Primary group: "), primary_group_label);
+
+        layout->addLayout(primary_group_layout);
+    }
+
     layout->addLayout(button_layout);
 
     enable_widget_on_selection(remove_button, view);
@@ -380,6 +393,23 @@ void MembershipTab::enable_primary_button_on_valid_selection() {
 }
 
 void MembershipTab::reload_model() {
+    // Load primary group name into label
+    if (type == MembershipTabType_MemberOf) {
+        const QString primary_group_label_text =
+        [this]() {
+            if (!current_primary_values.isEmpty()) {
+                const QString primary_group_dn = current_primary_values.values()[0];
+                const QString primary_group_name = dn_get_name(primary_group_dn);
+
+                return primary_group_name;
+            } else {
+                return QString();
+            }
+        }();
+
+        primary_group_label->setText(primary_group_label_text);
+    }
+
     model->removeRows(0, model->rowCount());
 
     const QSet<QString> all_values = current_values + current_primary_values;

--- a/src/admc/tabs/membership_tab.h
+++ b/src/admc/tabs/membership_tab.h
@@ -28,6 +28,7 @@
 class QTreeView;
 class QStandardItemModel;
 class QPushButton;
+class QLabel;
 
 // Displays and edits membership info which can go both ways
 // 1. users that are members of group
@@ -61,6 +62,7 @@ private:
     QStandardItemModel *model;
     QTreeView *view;
     QPushButton *primary_button;
+    QLabel *primary_group_label;
 
     QSet<QString> original_values;
     QSet<QString> original_primary_values;


### PR DESCRIPTION
Closes #168
Closes #165 (didn't need separate edit widget, only a separate display widget)

This alters the "MemberOf" version of membership tab that is displayed for user objects.

Add primary group label that displays "Primary group: some group" below normal groups list. This replaces the "Primary" column (will remove in future) and is better because it's always visible.

Warn about trying to remove primary group/user. Before primary objects weren't selectable but that's confusing to user. Now they are selectable but if selection contains anything primary and remove button is pressed, the warning is opened (and remove is not performed).

Fix conflicts between changing primary group and adding/removing groups in apply(). Conflicts happened due to previously unknown fact that the server performs some add/remove operations on it's end when changing primary group. Server adds old primary group (that stopped being primary) to normal membership. Server also removes new primary group (that became primary) to normal membership. Therefore we have to update the state cache of membership according to what the server does. We also have to perform primary changes before add/remove. And finally, we have to ignore groups that became or stopped being primary in add/remove loops since server already added/removed them.
