### PR TITLE
Messages in ad

### DIFF
--- a/src/admc/ad_interface.cpp
+++ b/src/admc/ad_interface.cpp
@@ -129,6 +129,10 @@ bool AdInterface::is_connected() const {
     return m_is_connected;
 }
 
+QList<AdMessage> AdInterface::messages() const {
+    return m_messages;
+}
+
 // Helper f-n for search()
 // NOTE: cookie is starts as NULL. Then after each while
 // loop, it is set to the value returned by
@@ -1092,7 +1096,7 @@ void AdInterface::success_status_message(const QString &msg, const DoStatusMsg d
     }
 
     const AdMessage message(msg, AdMessageType_Success);
-    messages.append(message);
+    m_messages.append(message);
 }
 
 void AdInterface::error_status_message(const QString &context, const QString &error, const DoStatusMsg do_msg) {
@@ -1106,7 +1110,7 @@ void AdInterface::error_status_message(const QString &context, const QString &er
     }
 
     const AdMessage message(msg, AdMessageType_Error);
-    messages.append(message);
+    m_messages.append(message);
 }
 
 QString AdInterface::default_error() const {

--- a/src/admc/ad_interface.cpp
+++ b/src/admc/ad_interface.cpp
@@ -133,6 +133,20 @@ QList<AdMessage> AdInterface::messages() const {
     return m_messages;
 }
 
+bool AdInterface::any_error_messages() const {
+    for (const auto &message : m_messages) {
+        if (message.type() == AdMessageType_Error) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void AdInterface::clear_messages() {
+    m_messages.clear();
+}
+
 // Helper f-n for search()
 // NOTE: cookie is starts as NULL. Then after each while
 // loop, it is set to the value returned by

--- a/src/admc/ad_interface.cpp
+++ b/src/admc/ad_interface.cpp
@@ -22,7 +22,6 @@
 #include "ad_utils.h"
 #include "ad_object.h"
 #include "attribute_display.h"
-#include "status.h"
 #include "utils.h"
 
 #include <ldap.h>
@@ -1092,7 +1091,8 @@ void AdInterface::success_status_message(const QString &msg, const DoStatusMsg d
         return;
     }
 
-    Status::instance()->message(msg, StatusType_Success);
+    const AdMessage message(msg, AdMessageType_Success);
+    messages.append(message);
 }
 
 void AdInterface::error_status_message(const QString &context, const QString &error, const DoStatusMsg do_msg) {
@@ -1105,7 +1105,8 @@ void AdInterface::error_status_message(const QString &context, const QString &er
         msg += QString(tr(". Error: \"%1\"")).arg(error);;
     }
 
-    Status::instance()->message(msg, StatusType_Error);
+    const AdMessage message(msg, AdMessageType_Error);
+    messages.append(message);
 }
 
 QString AdInterface::default_error() const {
@@ -1426,3 +1427,18 @@ bool AdCookie::more_pages() const {
 AdCookie::~AdCookie() {
     ber_bvfree(cookie);
 }
+
+AdMessage::AdMessage(const QString &text, const AdMessageType &type) {
+    m_text = text;
+    m_type = type;
+}
+
+QString AdMessage::text() const {
+    return m_text;
+}
+
+AdMessageType AdMessage::type() const {
+    return m_type;
+}
+
+

--- a/src/admc/ad_interface.h
+++ b/src/admc/ad_interface.h
@@ -119,6 +119,7 @@ public:
     ~AdInterface();
 
     bool is_connected() const;
+    QList<AdMessage> messages() const;
 
     // NOTE: If request attributes list is empty, all attributes are returned
 
@@ -175,7 +176,7 @@ private:
     QString domain;
     QString domain_head;
     QString host;
-    QList<AdMessage> messages;
+    QList<AdMessage> m_messages;
 
     void success_status_message(const QString &msg, const DoStatusMsg do_msg = DoStatusMsg_Yes);
     void error_status_message(const QString &context, const QString &error, const DoStatusMsg do_msg = DoStatusMsg_Yes);

--- a/src/admc/ad_interface.h
+++ b/src/admc/ad_interface.h
@@ -120,6 +120,8 @@ public:
 
     bool is_connected() const;
     QList<AdMessage> messages() const;
+    bool any_error_messages() const;
+    void clear_messages();
 
     // NOTE: If request attributes list is empty, all attributes are returned
 

--- a/src/admc/ad_interface.h
+++ b/src/admc/ad_interface.h
@@ -84,6 +84,24 @@ signals:
 
 AdSignals *ADSIGNALS();
 
+enum AdMessageType {
+    AdMessageType_Success,
+    AdMessageType_Error
+};
+
+class AdMessage {
+
+public:
+    AdMessage(const QString &text, const AdMessageType &type);
+
+    QString text() const;
+    AdMessageType type() const;
+
+private:
+    QString m_text;
+    AdMessageType m_type;
+};
+
 class AdInterface {
 Q_DECLARE_TR_FUNCTIONS(AdInterface)
 
@@ -157,6 +175,7 @@ private:
     QString domain;
     QString domain_head;
     QString host;
+    QList<AdMessage> messages;
 
     void success_status_message(const QString &msg, const DoStatusMsg do_msg = DoStatusMsg_Yes);
     void error_status_message(const QString &context, const QString &error, const DoStatusMsg do_msg = DoStatusMsg_Yes);

--- a/src/admc/console_drag_model.cpp
+++ b/src/admc/console_drag_model.cpp
@@ -109,13 +109,11 @@ bool ConsoleDragModel::dropMimeData(const QMimeData *data, Qt::DropAction action
 
     AdInterface ad;
     if (ad_connected(ad)) {
-        STATUS()->start_error_log();
-
         for (const AdObject &dropped : dropped_list) {
             object_drop(ad, dropped, target);
         }
 
-        STATUS()->end_error_log(nullptr);
+        STATUS()->display_ad_messages(ad, nullptr);
     }
 
     return true;

--- a/src/admc/create_dialog.cpp
+++ b/src/admc/create_dialog.cpp
@@ -232,6 +232,7 @@ void CreateDialog::accept() {
 
     const bool add_success = ad.object_add(dn, object_class);
 
+    bool final_success = false;
     if (add_success) {
         const bool apply_success =
         [this, &ad, dn]() {
@@ -248,20 +249,23 @@ void CreateDialog::accept() {
         }();
 
         if (apply_success) {
-            const QString message = QString(tr("Created object \"%1\"")).arg(name);
-
-            STATUS()->add_message(message, StatusType_Success);
+            final_success = true;
 
             QDialog::accept();
         } else {
             ad.object_delete(dn);
-            fail_msg();
         }
+    }
+
+    STATUS()->display_ad_messages(ad, this);
+    
+    if (final_success) {
+        const QString message = QString(tr("Created object \"%1\"")).arg(name);
+
+        STATUS()->add_message(message, StatusType_Success);
     } else {
         fail_msg();
     }
-    
-    STATUS()->display_ad_messages(ad, this);
 }
 
 // Enable/disable create button if all required edits filled

--- a/src/admc/create_dialog.cpp
+++ b/src/admc/create_dialog.cpp
@@ -224,8 +224,6 @@ void CreateDialog::accept() {
         return;
     }
 
-    STATUS()->start_error_log();
-
     auto fail_msg =
     [name]() {
         const QString message = QString(tr("Failed to create object \"%1\"")).arg(name);
@@ -263,7 +261,7 @@ void CreateDialog::accept() {
         fail_msg();
     }
     
-    STATUS()->end_error_log(this);
+    STATUS()->display_ad_messages(ad, this);
 }
 
 // Enable/disable create button if all required edits filled

--- a/src/admc/create_dialog.cpp
+++ b/src/admc/create_dialog.cpp
@@ -227,7 +227,7 @@ void CreateDialog::accept() {
     auto fail_msg =
     [name]() {
         const QString message = QString(tr("Failed to create object \"%1\"")).arg(name);
-        STATUS()->message(message, StatusType_Error);
+        STATUS()->add_message(message, StatusType_Error);
     };
 
     const bool add_success = ad.object_add(dn, object_class);
@@ -250,7 +250,7 @@ void CreateDialog::accept() {
         if (apply_success) {
             const QString message = QString(tr("Created object \"%1\"")).arg(name);
 
-            STATUS()->message(message, StatusType_Success);
+            STATUS()->add_message(message, StatusType_Success);
 
             QDialog::accept();
         } else {

--- a/src/admc/main_window.cpp
+++ b/src/admc/main_window.cpp
@@ -102,12 +102,10 @@ void MainWindow::closeEvent(QCloseEvent *event) {
 void MainWindow::connect_to_server() {
     AdInterface ad;
     if (ad_connected(ad)) {
-        STATUS()->start_error_log();
-
         // TODO: check for load failure
         ADCONFIG()->load(ad);
 
-        STATUS()->end_error_log(this);
+        STATUS()->display_ad_messages(ad, this);
 
         init();
     }

--- a/src/admc/object_menu.cpp
+++ b/src/admc/object_menu.cpp
@@ -285,13 +285,11 @@ void delete_object(const QList<QString> targets, QWidget *parent) {
         AdInterface ad;
 
         if (ad_connected(ad)) {
-            STATUS()->start_error_log();
-
             for (const QString &target : targets) {
                 ad.object_delete(target);
             }
 
-            STATUS()->end_error_log(parent);
+            STATUS()->display_ad_messages(ad, parent);
         }
     }
 }
@@ -309,13 +307,11 @@ void move(const QList<QString> targets, QWidget *parent) {
 
             AdInterface ad;
             if (ad_connected(ad)) {
-                STATUS()->start_error_log();
-
                 for (const QString &target : targets) {
                     ad.object_move(target, selected);
                 }
 
-                STATUS()->end_error_log(parent);
+                STATUS()->display_ad_messages(ad, parent);
             }
         });
 
@@ -336,15 +332,13 @@ void add_to_group(const QList<QString> targets, QWidget *parent) {
 
             AdInterface ad;
             if (ad_connected(ad)) {
-                STATUS()->start_error_log();
-
                 for (const QString &target : targets) {
                     for (auto group : selected) {
                         ad.group_add_member(group, target);
                     }
                 }
 
-                STATUS()->end_error_log(parent);
+                STATUS()->display_ad_messages(ad, parent);
             }
         });
 
@@ -369,26 +363,22 @@ void reset_password(const QString &target, QWidget *parent) {
 void enable_account(const QList<QString> targets, QWidget *parent) {
     AdInterface ad;
     if (ad_connected(ad)) {
-        STATUS()->start_error_log();
-
         for (const QString &target : targets) {
             ad.user_set_account_option(target, AccountOption_Disabled, false);
         }
 
-        STATUS()->end_error_log(parent);
+        STATUS()->display_ad_messages(ad, parent);
     }
 }
 
 void disable_account(const QList<QString> targets, QWidget *parent) {
     AdInterface ad;
     if (ad_connected(ad)) {
-        STATUS()->start_error_log();
-
         for (const QString &target : targets) {
             ad.user_set_account_option(target, AccountOption_Disabled, true);
         }
 
-        STATUS()->end_error_log(parent);
+        STATUS()->display_ad_messages(ad, parent);
     }
 }
 
@@ -420,14 +410,11 @@ void move_object(const QList<QString> targets, QWidget *parent) {
 
             AdInterface ad;
             if (ad_connected(ad)) {
-
-                STATUS()->start_error_log();
-
                 for (const QString &target : targets) {
                     ad.object_move(target, selected);
                 }
 
-                STATUS()->end_error_log(parent);
+                STATUS()->display_ad_messages(ad, parent);
             }
         });
 

--- a/src/admc/password_dialog.cpp
+++ b/src/admc/password_dialog.cpp
@@ -93,11 +93,9 @@ void PasswordDialog::accept() {
         return;
     }
 
-    STATUS()->start_error_log();
-
     edits_apply(ad, edits, target);
 
     QDialog::close();
 
-    STATUS()->end_error_log(this);
+    STATUS()->display_ad_messages(ad, this);
 }

--- a/src/admc/properties_dialog.cpp
+++ b/src/admc/properties_dialog.cpp
@@ -231,8 +231,6 @@ bool PropertiesDialog::apply() {
 
     show_busy_indicator();
 
-    STATUS()->start_error_log();
-
     bool total_apply_success = true;
     
     for (auto tab : tabs) {
@@ -242,7 +240,7 @@ bool PropertiesDialog::apply() {
         }
     }
 
-    STATUS()->end_error_log(this);
+    STATUS()->display_ad_messages(ad, this);
 
     if (total_apply_success) {
         apply_button->setEnabled(false);

--- a/src/admc/rename_dialog.cpp
+++ b/src/admc/rename_dialog.cpp
@@ -133,21 +133,25 @@ void RenameDialog::accept() {
     const QString new_name = name_edit->text();
     const bool rename_success = ad.object_rename(target, new_name);
 
+    bool final_success = false;
     if (rename_success) {
         const QString new_dn = dn_rename(target, new_name);
         const bool apply_success = edits_apply(ad, all_edits, new_dn);
 
         if (apply_success) {
-            success_msg(old_name);
+            final_success = true;
+
             QDialog::close();
-        } else {
-            fail_msg(old_name);
         }
-    } else {
-        fail_msg(old_name);
     }
 
     STATUS()->display_ad_messages(ad, this);
+
+    if (final_success) {
+        success_msg(old_name);
+    } else {
+        fail_msg(old_name);
+    }
 }
 
 void RenameDialog::on_edited() {

--- a/src/admc/rename_dialog.cpp
+++ b/src/admc/rename_dialog.cpp
@@ -108,12 +108,12 @@ RenameDialog::RenameDialog(const QString &target_arg, QWidget *parent)
 
 void RenameDialog::success_msg(const QString &old_name) {
     const QString message = QString(tr("Renamed object \"%1\"")).arg(old_name);
-    STATUS()->message(message, StatusType_Success);
+    STATUS()->add_message(message, StatusType_Success);
 }
 
 void RenameDialog::fail_msg(const QString &old_name) {
     const QString message = QString(tr("Failed to rename object \"%1\"")).arg(old_name);
-    STATUS()->message(message, StatusType_Error);
+    STATUS()->add_message(message, StatusType_Error);
 }
 
 void RenameDialog::accept() {

--- a/src/admc/rename_dialog.cpp
+++ b/src/admc/rename_dialog.cpp
@@ -130,8 +130,6 @@ void RenameDialog::accept() {
         return;
     }
 
-    STATUS()->start_error_log();
-
     const QString new_name = name_edit->text();
     const bool rename_success = ad.object_rename(target, new_name);
 
@@ -149,7 +147,7 @@ void RenameDialog::accept() {
         fail_msg(old_name);
     }
 
-    STATUS()->end_error_log(this);
+    STATUS()->display_ad_messages(ad, this);
 }
 
 void RenameDialog::on_edited() {

--- a/src/admc/rename_policy_dialog.cpp
+++ b/src/admc/rename_policy_dialog.cpp
@@ -98,8 +98,6 @@ void RenamePolicyDialog::accept() {
     const AdObject object = ad.search_object(target);
     const QString old_name = object.get_string(ATTRIBUTE_DISPLAY_NAME);
 
-    STATUS()->start_error_log();
-
     const QString new_name = name_edit->text();
     const bool apply_success = ad.attribute_replace_string(target, ATTRIBUTE_DISPLAY_NAME, new_name);
 
@@ -110,7 +108,7 @@ void RenamePolicyDialog::accept() {
         RenameDialog::fail_msg(old_name);
     }
 
-    STATUS()->end_error_log(this);
+    STATUS()->display_ad_messages(ad, this);
 }
 
 void RenamePolicyDialog::on_edited() {

--- a/src/admc/status.cpp
+++ b/src/admc/status.cpp
@@ -47,7 +47,7 @@ Status::Status() {
     status_log->setReadOnly(true);
 }
 
-void Status::message(const QString &msg, const StatusType &type) {
+void Status::add_message(const QString &msg, const StatusType &type) {
     status_bar->showMessage(msg);
     
     const QColor color =
@@ -90,31 +90,20 @@ void Status::display_ad_messages(const AdInterface &ad, QWidget *parent) {
     }
 
     //
-    // Display last message in status bar
-    //
-    const AdMessage last_message = messages.last();
-    status_bar->showMessage(last_message.text());
-
-    //
     // Display all messages in status log
     //
-    const QColor original_status_log_color = status_log->textColor();
-
     for (const auto &message : messages) {
-        const QColor color =
+        const StatusType status_type =
         [message]() {
             switch (message.type()) {
-                case AdMessageType_Success: return Qt::darkGreen;
-                case AdMessageType_Error: return Qt::red;
+                case AdMessageType_Success: return StatusType_Success;
+                case AdMessageType_Error: return StatusType_Error;
             }
-            return Qt::black;
+            return StatusType_Success;
         }();
 
-        status_log->setTextColor(color);
-        status_log->append(message.text());
+        add_message(message.text(), status_type);
     }
-
-    status_log->setTextColor(original_status_log_color);
 
     //
     // Display all error messages in error log

--- a/src/admc/status.cpp
+++ b/src/admc/status.cpp
@@ -48,10 +48,6 @@ Status::Status() {
 }
 
 void Status::message(const QString &msg, const StatusType &type) {
-    if (type == StatusType_Error) {
-        error_log.append(msg);
-    }
-
     status_bar->showMessage(msg);
     
     const QColor color =
@@ -88,38 +84,6 @@ void Status::message(const QString &msg, const StatusType &type) {
     if (print_errors && type == StatusType_Error) {
         qInfo() << msg;
     }
-}
-
-void Status::start_error_log() {
-    error_log.clear();
-}
-
-void Status::end_error_log(QWidget *parent) {
-    if (error_log.isEmpty()) {
-        return;
-    }
-
-    auto dialog = new QDialog(parent);
-    dialog->setWindowTitle(QCoreApplication::translate("Status", "Errors occured"));
-    dialog->setAttribute(Qt::WA_DeleteOnClose);
-    dialog->setMinimumWidth(600);
-
-    auto log = new QPlainTextEdit();
-    const QString text = error_log.join("\n");
-    log->setPlainText(text);
-
-    auto button_box = new QDialogButtonBox(QDialogButtonBox::Ok);
-
-    auto layout = new QVBoxLayout();
-    dialog->setLayout(layout);
-    layout->addWidget(log);
-    layout->addWidget(button_box);
-
-    QObject::connect(
-        button_box, &QDialogButtonBox::accepted,
-        dialog, &QDialog::accept);
-
-    dialog->open();
 }
 
 void Status::display_ad_messages(const AdInterface &ad, QWidget *parent) {

--- a/src/admc/status.cpp
+++ b/src/admc/status.cpp
@@ -80,10 +80,6 @@ void Status::message(const QString &msg, const StatusType &type) {
     QTextCursor end_cursor = status_log->textCursor();
     end_cursor.movePosition(QTextCursor::End);
     status_log->setTextCursor(end_cursor);
-
-    if (print_errors && type == StatusType_Error) {
-        qInfo() << msg;
-    }
 }
 
 void Status::display_ad_messages(const AdInterface &ad, QWidget *parent) {
@@ -123,18 +119,7 @@ void Status::display_ad_messages(const AdInterface &ad, QWidget *parent) {
     //
     // Display all error messages in error log
     //
-    const bool any_errors =
-    [messages]() {
-        for (const auto &message : messages) {
-            if (message.type() == AdMessageType_Error) {
-                return true;
-            }
-        }
-
-        return false;
-    }();
-
-    if (any_errors) {
+    if (ad.any_error_messages()) {
         auto dialog = new QDialog(parent);
         dialog->setWindowTitle(QCoreApplication::translate("Status", "Errors occured"));
         dialog->setAttribute(Qt::WA_DeleteOnClose);

--- a/src/admc/status.h
+++ b/src/admc/status.h
@@ -26,8 +26,6 @@
  * error messages in a dialog.
  */
 
-#include <QList>
-
 #include "utils.h"
 
 class QTextEdit;
@@ -52,21 +50,9 @@ public:
 
     void message(const QString &msg, const StatusType &type);
 
-    // To show an error log for operation(s) that result in
-    // Status messages, call start_error_log() before
-    // performing operation(s) and end_error_log(this) after. If
-    // any errors occured, error log will open when
-    // end_error_log(this) is called.
-    void start_error_log();
-    
-    // Returns true if there no errors happened
-    void end_error_log(QWidget *parent);
-
     void display_ad_messages(const AdInterface &ad, QWidget *parent);
 
 private:
-    QList<QString> error_log;
-
     Status();
     DISABLE_COPY_MOVE(Status);
 };

--- a/src/admc/status.h
+++ b/src/admc/status.h
@@ -42,7 +42,6 @@ enum StatusType {
 class Status {
 
 public:   
-    bool print_errors = false;
     QStatusBar *status_bar;
     QTextEdit *status_log;
 

--- a/src/admc/status.h
+++ b/src/admc/status.h
@@ -34,6 +34,7 @@ class QTextEdit;
 class QStatusBar;
 class QString;
 class QWidget;
+class AdInterface;
 
 enum StatusType {
     StatusType_Success,
@@ -60,6 +61,8 @@ public:
     
     // Returns true if there no errors happened
     void end_error_log(QWidget *parent);
+
+    void display_ad_messages(const AdInterface &ad, QWidget *parent);
 
 private:
     QList<QString> error_log;

--- a/src/admc/status.h
+++ b/src/admc/status.h
@@ -47,7 +47,7 @@ public:
 
     static Status *instance();
 
-    void message(const QString &msg, const StatusType &type);
+    void add_message(const QString &msg, const StatusType &type);
 
     void display_ad_messages(const AdInterface &ad, QWidget *parent);
 

--- a/tests/admc_test.cpp
+++ b/tests/admc_test.cpp
@@ -23,7 +23,6 @@
 #include "ad_utils.h"
 #include "ad_object.h"
 #include "ad_config.h"
-#include "status.h"
 #include "object_model.h"
 
 #include <QTest>
@@ -40,9 +39,6 @@ void ADMCTest::initTestCase() {
 
     // TODO: check for load failure
     ADCONFIG()->load(ad);
-
-    // NOTE: temporary band-aid until messages are routed correctly throgh AdInterface instance. This makes status error messages be printed to console. I think it's useful to understand why a test failed. When messages are collected in an AdInterface instances, can just print them here ourselves and avoid touching Status.
-    STATUS()->print_errors = true;
 
     // Cleanup before all tests in-case this test suite was
     // previously interrupted and a cleanup wasn't performed
@@ -63,6 +59,19 @@ void ADMCTest::init() {
 }
 
 void ADMCTest::cleanup() {
+    // Print AD error messages
+    if (ad.any_error_messages()) {
+        qInfo() << "AD errors:";
+
+        for (const auto &message : ad.messages()) {
+            if (message.type() == AdMessageType_Error) {
+                qInfo() << message.text();
+            }
+        }
+    }
+
+    ad.clear_messages();
+
     if (parent_widget != nullptr) {
         delete parent_widget;
         parent_widget = nullptr;

--- a/tests/admc_test_object_menu.cpp
+++ b/tests/admc_test_object_menu.cpp
@@ -409,6 +409,8 @@ void ADMCTestObjectMenu::object_menu_add_to_group() {
     const bool create_user_success = ad.object_add(user_dn, CLASS_USER);
     QVERIFY2(create_user_success, "Failed to create user");
     QVERIFY2(object_exists(user_dn), "Created user doesn't exist");
+    const bool create_user_success2 = ad.object_add(user_dn, CLASS_USER);
+    QVERIFY2(create_user_success2, "Failed to create user");
 
     // Create test group
     const bool create_group_success = ad.object_add(group_dn, CLASS_GROUP);

--- a/tests/admc_test_object_menu.cpp
+++ b/tests/admc_test_object_menu.cpp
@@ -409,8 +409,6 @@ void ADMCTestObjectMenu::object_menu_add_to_group() {
     const bool create_user_success = ad.object_add(user_dn, CLASS_USER);
     QVERIFY2(create_user_success, "Failed to create user");
     QVERIFY2(object_exists(user_dn), "Created user doesn't exist");
-    const bool create_user_success2 = ad.object_add(user_dn, CLASS_USER);
-    QVERIFY2(create_user_success2, "Failed to create user");
 
     // Create test group
     const bool create_group_success = ad.object_add(group_dn, CLASS_GROUP);


### PR DESCRIPTION
Rework how AD messages get to Status (status bar, status log and error log).

Previously AD instance directly used Status global instance to send it's messages to it using `Status::message()`. Status stored errors in an error log and errors were displayed with `start_error_log()` and `end_error_log()`.

Now AD collects all of it's messages. Then the code that uses this AD instance can display those messages by calling `Status::display_ad_messages(ad)`.

Basically the chain of communication changed from `App code -> AD -> Status` to `App code -> AD ||||| App code -> Status`. In addition, AD doesn't depend on Status.

Removed the print_errors flag used by tests to print AD errors, can now just do it without touching Status.