### PR TITLE
improve drag impl flexilibty

### DIFF
--- a/src/admc/console.h
+++ b/src/admc/console.h
@@ -43,6 +43,8 @@ class AdObject;
 class QLabel;
 class QSortFilterProxyModel;
 class AdInterface;
+class QMimeData;
+class ConsoleDragModel;
 template <typename T> class QList;
 
 class Console final : public QWidget {
@@ -76,10 +78,12 @@ private slots:
     void on_result_item_double_clicked(const QModelIndex &index);
     void open_filter();
 
+    void on_drop(const QMimeData *mimedata, const QModelIndex &parent);
+
 private:
     QTreeView *scope_view;
     QTreeView *results_view;
-    QStandardItemModel *scope_model;
+    ConsoleDragModel *scope_model;
     QTreeView *focused_view;
     QWidget *results_header;
     QLabel *results_header_label;
@@ -106,6 +110,7 @@ private:
     void update_navigation_actions();
     QModelIndex get_scope_node_from_id(const int id) const;
     void update_results_header();
+    void setup_drag_model(ConsoleDragModel *model);
 };
 
 #endif /* CONSOLE_H */

--- a/src/admc/console_drag_model.cpp
+++ b/src/admc/console_drag_model.cpp
@@ -19,53 +19,38 @@
 
 #include "console_drag_model.h"
 
-#include "ad_interface.h"
-#include "ad_object.h"
-#include "status.h"
-#include "object_model.h"
-#include "object_drag.h"
-
+#include <QDebug>
 #include <QMimeData>
-#include <QString>
-
-// TODO: dragging queries and query folders
-
-const QString MIME_TYPE_OBJECT = "MIME_TYPE_OBJECT";
 
 QModelIndex prev_parent = QModelIndex();
 
-QList<AdObject> mimedata_to_object_list(const QMimeData *data);
+void ConsoleDragModel::set_fun_mime_data(FunMimeData fun) {
+    fun_mime_data = fun;
+}
 
-QMimeData *ConsoleDragModel::mimeData(const QModelIndexList &indexes) const {
-    auto data = new QMimeData();
+void ConsoleDragModel::set_fun_can_drop(FunCanDrop fun) {
+    fun_can_drop = fun;
+}
 
-    // Get adobject's from item data and convert the list to
-    // a variant
-    const QList<QVariant> objects =
-    [=]() {
-        QList<QVariant> out;
-        for (const QModelIndex index : indexes) {
-            if (index.column() == 0) {
-                const QVariant object_variant = index.data(ObjectRole_AdObject);
-                out.append(object_variant);
-            }
-        }
+QMimeData *ConsoleDragModel::mimeData(const QList<QModelIndex> &indexes) const {
+    if (fun_mime_data != nullptr) {
+        auto data = fun_mime_data(indexes);
 
-        return out;
-    }();
-    const QVariant objects_as_variant(objects);
-
-    // Convert objects variant to bytes
-    QByteArray objects_as_bytes;
-    QDataStream stream(&objects_as_bytes, QIODevice::WriteOnly);
-    stream << objects_as_variant;
-    
-    data->setData(MIME_TYPE_OBJECT, objects_as_bytes);
-
-    return data;
+        return data;
+    } else {
+        qDebug() << "ConsoleDragModel::mimeData() f-n ptr is unset";
+        
+        return new QMimeData();
+    }
 }
 
 bool ConsoleDragModel::canDropMimeData(const QMimeData *data, Qt::DropAction, int, int, const QModelIndex &parent) const {
+    if (fun_can_drop == nullptr) {
+        qDebug() << "ConsoleDragModel::canDropMimeData() f-n ptr is unset";
+
+        return false;
+    }
+
     // NOTE: this is a bandaid for a Qt bug. The bug causes
     // canDropMimeData() to stop being called for a given
     // view if canDropMimeData() returns false for the first
@@ -82,59 +67,13 @@ bool ConsoleDragModel::canDropMimeData(const QMimeData *data, Qt::DropAction, in
         return true;
     }
 
-    if (!data->hasFormat(MIME_TYPE_OBJECT)) {
-        return false;
-    }
+    const bool can_drop = fun_can_drop(data, parent);
 
-    const QList<AdObject> dropped_list = mimedata_to_object_list(data);
-    const AdObject target = parent.siblingAtColumn(0).data(ObjectRole_AdObject).value<AdObject>();
-
-    // NOTE: only check if object can be dropped if dropping a single object, because when dropping multiple objects it is ok for some objects to successfully drop and some to fail. For example, if you drop users together with OU's onto a group, users will be added to that group while OU will fail to drop.
-    if (dropped_list.size() == 1) {
-        const AdObject dropped = dropped_list[0];
-
-        return object_can_drop(dropped, target);
-    } else {
-        return true;
-    }
+    return can_drop;
 }
 
 bool ConsoleDragModel::dropMimeData(const QMimeData *data, Qt::DropAction action, int, int, const QModelIndex &parent) {
-    if (!data->hasFormat(MIME_TYPE_OBJECT)) {
-        return true;
-    }
-
-    const QList<AdObject> dropped_list = mimedata_to_object_list(data);
-    const AdObject target = parent.siblingAtColumn(0).data(ObjectRole_AdObject).value<AdObject>();
-
-    AdInterface ad;
-    if (ad_connected(ad)) {
-        for (const AdObject &dropped : dropped_list) {
-            object_drop(ad, dropped, target);
-        }
-
-        STATUS()->display_ad_messages(ad, nullptr);
-    }
+    emit drop(data, parent);
 
     return true;
-}
-
-QList<AdObject> mimedata_to_object_list(const QMimeData *data) {
-    // Convert from bytes to variant
-    QByteArray objects_as_bytes = data->data(MIME_TYPE_OBJECT);
-    QDataStream stream(&objects_as_bytes, QIODevice::ReadOnly);
-    QVariant objects_as_variant;
-    stream >> objects_as_variant;
-
-    // Convert from variant to list of objects
-    const QList<QVariant> objects_as_variant_list = objects_as_variant.toList();
-
-    QList<AdObject> out;
-
-    for (const QVariant &e : objects_as_variant_list) {
-        const AdObject object = e.value<AdObject>();
-        out.append(object);
-    }
-
-    return out;
 }

--- a/src/admc/console_drag_model.h
+++ b/src/admc/console_drag_model.h
@@ -20,14 +20,17 @@
 #ifndef CONSOLE_DRAG_MODEL_H
 #define CONSOLE_DRAG_MODEL_H
 
+/**
+ * This model doesn't implement specific drag drop behavior
+ * but instead allows the user of the model to implement.
+ * User of the model should set the drop functions as well
+ * as connect to the drop() signal.
+ */
+
 #include <QStandardItemModel>
 
-class QMimeData;
-class QModelIndex;
-
-/**
- * Implements drag and drop behavior for objects.
- */
+typedef QMimeData *(*FunMimeData)(const QList<QModelIndex> &indexes);
+typedef bool (*FunCanDrop)(const QMimeData *data, const QModelIndex &parent);
 
 class ConsoleDragModel : public QStandardItemModel {
 Q_OBJECT
@@ -35,9 +38,26 @@ Q_OBJECT
 public:
     using QStandardItemModel::QStandardItemModel;
 
-    QMimeData *mimeData(const QModelIndexList &indexes) const override;
+    // This function should construct the mimedata from
+    // model indexes
+    void set_fun_mime_data(FunMimeData fun);
+
+    // This function should return whether given mimedata
+    // can be dropped on given model index
+    void set_fun_can_drop(FunCanDrop fun);
+
+    QMimeData *mimeData(const QList<QModelIndex> &indexes) const override;
     bool dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent) override;
     bool canDropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent) const override;
+
+signals:
+    // Connect to this slot and perform the drop operation
+    // in the slot (if it's possible)
+    void drop(const QMimeData *data, const QModelIndex &parent);
+
+private:
+    FunMimeData fun_mime_data = nullptr; 
+    FunCanDrop fun_can_drop = nullptr; 
 };
 
 #endif /* CONSOLE_DRAG_MODEL_H */

--- a/src/admc/object_drag.cpp
+++ b/src/admc/object_drag.cpp
@@ -22,6 +22,9 @@
 #include "ad_interface.h"
 #include "ad_config.h"
 #include "ad_object.h"
+#include "object_model.h"
+
+#include <QMimeData>
 
 enum DropType {
     DropType_Move,
@@ -73,16 +76,6 @@ DropType get_drop_type(const AdObject &dropped, const AdObject &target) {
     }
 }
 
-bool object_can_drop(const AdObject &dropped, const AdObject &target) {
-    const DropType drop_type = get_drop_type(dropped, target);
-
-    if (drop_type == DropType_None) {
-        return false;
-    } else {
-        return true;
-    }
-}
-
 // General "drop" operation that can either move, link or change membership depending on which types of objects are involved
 void object_drop(AdInterface &ad, const AdObject &dropped, const AdObject &target) {
     DropType drop_type = get_drop_type(dropped, target);
@@ -100,4 +93,73 @@ void object_drop(AdInterface &ad, const AdObject &dropped, const AdObject &targe
             break;
         }
     }
+}
+
+QMimeData *object_mime_data(const QList<QModelIndex> &indexes) {
+    auto data = new QMimeData();
+
+    // Get adobject's from item data and convert the list to
+    // a variant
+    const QList<QVariant> objects =
+    [=]() {
+        QList<QVariant> out;
+        for (const QModelIndex index : indexes) {
+            if (index.column() == 0) {
+                const QVariant object_variant = index.data(ObjectRole_AdObject);
+                out.append(object_variant);
+            }
+        }
+
+        return out;
+    }();
+    const QVariant objects_as_variant(objects);
+
+    // Convert objects variant to bytes
+    QByteArray objects_as_bytes;
+    QDataStream stream(&objects_as_bytes, QIODevice::WriteOnly);
+    stream << objects_as_variant;
+    
+    data->setData(MIME_TYPE_OBJECT, objects_as_bytes);
+
+    return data;
+}
+
+bool object_can_drop(const QMimeData *data, const QModelIndex &parent) {
+    if (!data->hasFormat(MIME_TYPE_OBJECT)) {
+        return false;
+    }
+
+    const QList<AdObject> dropped_list = mimedata_to_object_list(data);
+    const AdObject target = parent.siblingAtColumn(0).data(ObjectRole_AdObject).value<AdObject>();
+
+    // NOTE: only check if object can be dropped if dropping a single object, because when dropping multiple objects it is ok for some objects to successfully drop and some to fail. For example, if you drop users together with OU's onto a group, users will be added to that group while OU will fail to drop.
+    if (dropped_list.size() == 1) {
+        const AdObject dropped = dropped_list[0];
+        const DropType drop_type = get_drop_type(dropped, target);
+        const bool can_drop = (drop_type != DropType_None);
+
+        return can_drop;
+    } else {
+        return true;
+    }
+}
+
+QList<AdObject> mimedata_to_object_list(const QMimeData *data) {
+    // Convert from bytes to variant
+    QByteArray objects_as_bytes = data->data(MIME_TYPE_OBJECT);
+    QDataStream stream(&objects_as_bytes, QIODevice::ReadOnly);
+    QVariant objects_as_variant;
+    stream >> objects_as_variant;
+
+    // Convert from variant to list of objects
+    const QList<QVariant> objects_as_variant_list = objects_as_variant.toList();
+
+    QList<AdObject> out;
+
+    for (const QVariant &e : objects_as_variant_list) {
+        const AdObject object = e.value<AdObject>();
+        out.append(object);
+    }
+
+    return out;
 }

--- a/src/admc/object_drag.h
+++ b/src/admc/object_drag.h
@@ -22,8 +22,15 @@
 
 class AdInterface;
 class AdObject;
+class QMimeData;
+class QModelIndex;
+template <typename T> class QList;
 
-bool object_can_drop(const AdObject &dropped, const AdObject &target);
+#define MIME_TYPE_OBJECT "MIME_TYPE_OBJECT"
+
 void object_drop(AdInterface &ad, const AdObject &dropped, const AdObject &target);
+QMimeData *object_mime_data(const QList<QModelIndex> &indexes);
+bool object_can_drop(const QMimeData *data, const QModelIndex &parent);
+QList<AdObject> mimedata_to_object_list(const QMimeData *data);
 
 #endif /* OBJECT_DRAG_H */


### PR DESCRIPTION
Qt's way of doing drag model where you have to subclass the model and then implement the 3 f-ns (mimeData, canDropMimeData and dropMimeData) is very inflexible. What I did was basically turn that inside out where now the user of the model implements those functions and "gives" them to the model. 2 of the functions are given directly as f-n ptrs while dropMimeData() has to be done as a signal/slot so that user of model can modify it's members inside it.

Flexibility is required because of the planned re implementation of Console as a shared library between ADMC and GPGUI. With the old scheme it would be hard or impossible for ADMC/GPGUI to implement their own custom drag drop behavior. With this sceme both ADMC and GPGUI can just give their drag drop implementation to the Console library.

Secondly, this is also needed for things like modifying contents of scope/results after a drag drop operation. With drag drop implementation located in the model, the model can only modify itself. For drag operations when an object is dragged from scope to results (or vice verse) it's needed to modify both scope and results (remove from scope, add to results). Since implementation can now be in Console (or user of Console), scope and results can be easily modified.