### PR TITLE
do drag and drop using signals/slots

### DIFF
--- a/src/admc/console.cpp
+++ b/src/admc/console.cpp
@@ -251,6 +251,8 @@ void Console::on_can_drop(const QMimeData *mimedata, const QModelIndex &parent, 
         *ok = false;
     }
 
+    // NOTE: using sibling at 0th column because we store
+    // item roles in the first item (first column)
     const QList<AdObject> dropped_list = mimedata_to_object_list(mimedata);
     const AdObject target = parent.siblingAtColumn(0).data(ObjectRole_AdObject).value<AdObject>();
 
@@ -269,6 +271,8 @@ void Console::on_drop(const QMimeData *mimedata, const QModelIndex &parent) {
         return;
     }
 
+    // NOTE: using sibling at 0th column because we store
+    // item roles in the first item (first column)
     const QList<AdObject> dropped_list = mimedata_to_object_list(mimedata);
     const AdObject target = parent.siblingAtColumn(0).data(ObjectRole_AdObject).value<AdObject>();
 

--- a/src/admc/console.h
+++ b/src/admc/console.h
@@ -43,6 +43,8 @@ class AdObject;
 class QLabel;
 class QSortFilterProxyModel;
 class AdInterface;
+class ConsoleDragModel;
+class QMimeData;
 template <typename T> class QList;
 
 class Console final : public QWidget {
@@ -76,10 +78,13 @@ private slots:
     void on_result_item_double_clicked(const QModelIndex &index);
     void open_filter();
 
+    void on_can_drop(const QMimeData *mimedata, const QModelIndex &parent, bool *ok);
+    void on_drop(const QMimeData *mimedata, const QModelIndex &parent);
+
 private:
     QTreeView *scope_view;
     QTreeView *results_view;
-    QStandardItemModel *scope_model;
+    ConsoleDragModel *scope_model;
     QTreeView *focused_view;
     QWidget *results_header;
     QLabel *results_header_label;
@@ -106,6 +111,7 @@ private:
     void update_navigation_actions();
     QModelIndex get_scope_node_from_id(const int id) const;
     void update_results_header();
+    void connect_to_drag_model(ConsoleDragModel *model);
 };
 
 #endif /* CONSOLE_H */

--- a/src/admc/console_drag_model.h
+++ b/src/admc/console_drag_model.h
@@ -24,10 +24,13 @@
 
 class QMimeData;
 class QModelIndex;
+class AdObject;
 
 /**
  * Implements drag and drop behavior for objects.
  */
+
+#define MIME_TYPE_OBJECT "MIME_TYPE_OBJECT"
 
 class ConsoleDragModel : public QStandardItemModel {
 Q_OBJECT
@@ -38,6 +41,15 @@ public:
     QMimeData *mimeData(const QModelIndexList &indexes) const override;
     bool dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent) override;
     bool canDropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent) const override;
+
+signals:
+    // Set "ok" to true if can drop and false if can't drop
+    // NOTE: "ok" is supposed to be set only once
+    void can_drop(const QMimeData *data, const QModelIndex &parent, bool *ok) const;
+
+    void drop(const QMimeData *data, const QModelIndex &parent);
 };
+
+QList<AdObject> mimedata_to_object_list(const QMimeData *data);
 
 #endif /* CONSOLE_DRAG_MODEL_H */


### PR DESCRIPTION
This is preparation for shared console widget library. This change moves the implementation of drag logic outside the model class, so that users of the library can implement their own drag logic on their own types of items.

Currently this is slightly incomplete because in new console widget code model items have id's. Those id's will be stored in mimedata instead of adobject's but for now leaving old mimedata code in place.

Replaces #178 because that PR basically reimplements signals/slots. Should stick to standard Qt mechanisms if possible.