### PR TITLE
improve drag

### DIFF
--- a/src/admc/console.h
+++ b/src/admc/console.h
@@ -44,7 +44,6 @@ class QLabel;
 class QSortFilterProxyModel;
 class AdInterface;
 class ConsoleDragModel;
-class QMimeData;
 template <typename T> class QList;
 
 class Console final : public QWidget {
@@ -78,8 +77,9 @@ private slots:
     void on_result_item_double_clicked(const QModelIndex &index);
     void open_filter();
 
-    void on_can_drop(const QMimeData *mimedata, const QModelIndex &parent, bool *ok);
-    void on_drop(const QMimeData *mimedata, const QModelIndex &parent);
+    void on_start_drag(const QList<QModelIndex> &dropped);
+    void on_can_drop(const QModelIndex &target, bool *ok);
+    void on_drop(const QModelIndex &target);
 
 private:
     QTreeView *scope_view;
@@ -94,6 +94,7 @@ private:
     QAction *navigate_back_action;
     QAction *navigate_forward_action;
     QAction *open_filter_action;
+    QList<QModelIndex> dropped;
 
     // NOTE: store target history as scope node id's
     // Last is closest to current

--- a/src/admc/console_drag_model.cpp
+++ b/src/admc/console_drag_model.cpp
@@ -19,15 +19,9 @@
 
 #include "console_drag_model.h"
 
-#include "ad_interface.h"
-#include "ad_object.h"
-#include "status.h"
-#include "object_model.h"
-
 #include <QMimeData>
-#include <QString>
 
-// TODO: dragging queries and query folders
+#define MIME_TYPE_CONSOLE "MIME_TYPE_CONSOLE"
 
 QModelIndex prev_parent = QModelIndex();
 
@@ -36,35 +30,24 @@ QModelIndex prev_parent = QModelIndex();
 // mimedata so that objects can be obtained directly from
 // models
 QMimeData *ConsoleDragModel::mimeData(const QModelIndexList &indexes) const {
+    emit start_drag(indexes);
+
     auto data = new QMimeData();
 
-    // Get adobject's from item data and convert the list to
-    // a variant
-    const QList<QVariant> objects =
-    [=]() {
-        QList<QVariant> out;
-        for (const QModelIndex index : indexes) {
-            if (index.column() == 0) {
-                const QVariant object_variant = index.data(ObjectRole_AdObject);
-                out.append(object_variant);
-            }
-        }
-
-        return out;
-    }();
-    const QVariant objects_as_variant(objects);
-
-    // Convert objects variant to bytes
-    QByteArray objects_as_bytes;
-    QDataStream stream(&objects_as_bytes, QIODevice::WriteOnly);
-    stream << objects_as_variant;
-    
-    data->setData(MIME_TYPE_OBJECT, objects_as_bytes);
+    // NOTE: even though we don't store any data in
+    // mimedata, set empty data with our type so that we can
+    // reject any mimedata not created in console drag model
+    // by checking if mimedata has our mime type.
+    data->setData(MIME_TYPE_CONSOLE, QByteArray());
 
     return data;
 }
 
 bool ConsoleDragModel::canDropMimeData(const QMimeData *data, Qt::DropAction, int, int, const QModelIndex &parent) const {
+    if (!data->hasFormat(MIME_TYPE_CONSOLE)) {
+        return false;
+    }
+
     // NOTE: this is a bandaid for a Qt bug. The bug causes
     // canDropMimeData() to stop being called for a given
     // view if canDropMimeData() returns false for the first
@@ -81,34 +64,26 @@ bool ConsoleDragModel::canDropMimeData(const QMimeData *data, Qt::DropAction, in
         return true;
     }
 
+    // NOTE: using index at 0th column because that column
+    // has the item roles
+    const QModelIndex target = parent.siblingAtColumn(0);
+
     bool ok;
-    emit can_drop(data, parent, &ok);
+    emit can_drop(target, &ok);
 
     return ok;
 }
 
 bool ConsoleDragModel::dropMimeData(const QMimeData *data, Qt::DropAction action, int, int, const QModelIndex &parent) {
-    emit drop(data, parent);
-
-    return true;
-}
-
-QList<AdObject> mimedata_to_object_list(const QMimeData *data) {
-    // Convert from bytes to variant
-    QByteArray objects_as_bytes = data->data(MIME_TYPE_OBJECT);
-    QDataStream stream(&objects_as_bytes, QIODevice::ReadOnly);
-    QVariant objects_as_variant;
-    stream >> objects_as_variant;
-
-    // Convert from variant to list of objects
-    const QList<QVariant> objects_as_variant_list = objects_as_variant.toList();
-
-    QList<AdObject> out;
-
-    for (const QVariant &e : objects_as_variant_list) {
-        const AdObject object = e.value<AdObject>();
-        out.append(object);
+    if (!data->hasFormat(MIME_TYPE_CONSOLE)) {
+        return false;
     }
 
-    return out;
+    // NOTE: using index at 0th column because that column
+    // has the item roles
+    const QModelIndex target = parent.siblingAtColumn(0);
+
+    emit drop(target);
+
+    return true;
 }

--- a/src/admc/console_drag_model.h
+++ b/src/admc/console_drag_model.h
@@ -22,15 +22,11 @@
 
 #include <QStandardItemModel>
 
-class QMimeData;
-class QModelIndex;
-class AdObject;
-
 /**
- * Implements drag and drop behavior for objects.
+ * Implements drag and drop. Note that this only implements
+ * the framework for drag and drop. The actual logic is
+ * implemented by console widget.
  */
-
-#define MIME_TYPE_OBJECT "MIME_TYPE_OBJECT"
 
 class ConsoleDragModel : public QStandardItemModel {
 Q_OBJECT
@@ -43,13 +39,14 @@ public:
     bool canDropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent) const override;
 
 signals:
+    // Save these indexes when drag is started
+    void start_drag(const QList<QModelIndex> &dropped) const;
+
     // Set "ok" to true if can drop and false if can't drop
     // NOTE: "ok" is supposed to be set only once
-    void can_drop(const QMimeData *data, const QModelIndex &parent, bool *ok) const;
+    void can_drop(const QModelIndex &target, bool *ok) const;
 
-    void drop(const QMimeData *data, const QModelIndex &parent);
+    void drop(const QModelIndex &target);
 };
-
-QList<AdObject> mimedata_to_object_list(const QMimeData *data);
 
 #endif /* CONSOLE_DRAG_MODEL_H */


### PR DESCRIPTION
more prep for console widget

Reworked drag more. Figured out that we don't have to stick to how qt models implement drag so don't have to store objects/indexes in mimedata but can store it in console at start of drag. Note that currently this looks like internals are leaking but it will be fine when console widget is there, since it will contain the "leakage".

Add start_drag() signal to console drag model. The user of model (console now, console widget in future) saves dropped indexes at this point.

Other signals now only pass the target index.

Mimedata only stores empty data with type. This is so that we can reject mimedata with other types (dragged from other models/apps).