### PR TITLE
Policy results

### DIFF
--- a/src/admc/CMakeLists.txt
+++ b/src/admc/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(admc
     utils.cpp
     settings.cpp
     policy_model.cpp
+    policy_results_widget.cpp
 
     move_dialog.cpp
     rename_dialog.cpp

--- a/src/admc/central_widget.h
+++ b/src/admc/central_widget.h
@@ -43,6 +43,7 @@ class AdInterface;
 class ConsoleWidget;
 class ResultsView;
 class ObjectActions;
+class PolicyResultsWidget;
 template <typename T> class QList;
 
 enum ItemType {
@@ -97,12 +98,16 @@ private slots:
     void on_items_can_drop(const QList<QModelIndex> &dropped, const QModelIndex &target, bool *ok);
     void on_items_dropped(const QList<QModelIndex> &dropped, const QModelIndex &target);
 
+    void on_current_scope_changed();
+
 private:
     int object_results_id;
     int policies_results_id;
+    int policy_links_results_id;
     QPersistentModelIndex scope_head_index;
     QPersistentModelIndex policies_index;
     FilterDialog *filter_dialog;
+    PolicyResultsWidget *policy_results_widget;
 
     ObjectActions *object_actions;
 

--- a/src/admc/central_widget.h
+++ b/src/admc/central_widget.h
@@ -90,6 +90,7 @@ private slots:
     void edit_upn_suffixes();
 
     void create_policy();
+    void add_link();
     void rename_policy();
     void delete_policy();
 

--- a/src/admc/console_widget/console_widget.cpp
+++ b/src/admc/console_widget/console_widget.cpp
@@ -356,6 +356,9 @@ int ConsoleWidget::register_results(QWidget *widget, ResultsView *view, const QL
         connect(
             view, &ResultsView::context_menu,
             d, &ConsoleWidgetPrivate::on_context_menu);
+        connect(
+            view, &ResultsView::selection_changed,
+            d, &ConsoleWidgetPrivate::on_selection_changed);
 
         // Hide non-default results view columns. Note that
         // at creation, view header doesnt have any
@@ -373,10 +376,6 @@ int ConsoleWidget::register_results(QWidget *widget, ResultsView *view, const QL
                 }
             });
     }
-
-    connect(
-        view, &ResultsView::selection_changed,
-        d, &ConsoleWidgetPrivate::on_selection_changed);
 
     return id;
 }

--- a/src/admc/policy_results_widget.cpp
+++ b/src/admc/policy_results_widget.cpp
@@ -1,0 +1,30 @@
+/*
+ * ADMC - AD Management Center
+ *
+ * Copyright (C) 2020 BaseALT Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "policy_results_widget.h"
+
+#include <QModelIndex>
+
+PolicyResultsWidget::PolicyResultsWidget() {   
+
+}
+
+void PolicyResultsWidget::update(const QModelIndex &scope_index) {
+
+}

--- a/src/admc/policy_results_widget.cpp
+++ b/src/admc/policy_results_widget.cpp
@@ -35,6 +35,7 @@
 #include <QVBoxLayout>
 #include <QAction>
 #include <QMenu>
+#include <QHeaderView>
 
 enum PolicyResultsColumn {
     PolicyResultsColumn_Name,
@@ -86,6 +87,11 @@ PolicyResultsWidget::PolicyResultsWidget() {
     });
 
     view->setModel(model);
+
+    view->header()->resizeSection(0, 300);
+    view->header()->resizeSection(1, 100);
+    view->header()->resizeSection(2, 100);
+    view->header()->resizeSection(3, 500);
 
     const auto layout = new QVBoxLayout();
     setLayout(layout);

--- a/src/admc/policy_results_widget.cpp
+++ b/src/admc/policy_results_widget.cpp
@@ -170,7 +170,7 @@ void PolicyResultsWidget::on_item_changed(QStandardItem *item) {
     gplink.set_option(gpo, option, is_checked);
     const QString updated_gplink_string = gplink.to_string();
 
-    const bool gplink_didnt_change = (updated_gplink_string == gplink_string);
+    const bool gplink_didnt_change = gplink.equals(gplink_string);
     if (gplink_didnt_change) {
         return;
     }

--- a/src/admc/policy_results_widget.cpp
+++ b/src/admc/policy_results_widget.cpp
@@ -19,12 +19,186 @@
 
 #include "policy_results_widget.h"
 
+#include "adldap.h"
+#include "console_widget/console_widget.h"
+#include "central_widget.h"
+#include "policy_model.h"
+#include "utils.h"
+#include "gplink.h"
+#include "status.h"
+
 #include <QModelIndex>
+#include <QTreeView>
+#include <QDebug>
+#include <QTreeView>
+#include <QStandardItemModel>
+#include <QVBoxLayout>
+
+enum PolicyResultsColumn {
+    PolicyResultsColumn_Name,
+    PolicyResultsColumn_Enforced,
+    PolicyResultsColumn_Disabled,
+
+    PolicyResultsColumn_COUNT,
+};
+
+enum PolicyResultsRole {
+    PolicyResultsRole_DN = Qt::UserRole,
+    PolicyResultsRole_GplinkString = Qt::UserRole + 1,
+
+    PolicyResultsRole_COUNT,
+};
+
+const QSet<PolicyResultsColumn> option_columns = {
+    PolicyResultsColumn_Disabled,
+    PolicyResultsColumn_Enforced
+};
+
+const QHash<PolicyResultsColumn, GplinkOption> column_to_option = {
+    {PolicyResultsColumn_Disabled, GplinkOption_Disabled},
+    {PolicyResultsColumn_Enforced, GplinkOption_Enforced}
+};
+
+// TODO: need to sync this with changes done through group
+// policy tab (just call load after properties is closed?)
 
 PolicyResultsWidget::PolicyResultsWidget() {   
+    view = new QTreeView(this);
+    view->setContextMenuPolicy(Qt::CustomContextMenu);
+    view->setAllColumnsShowFocus(true);
+    view->setSortingEnabled(true);
 
+    model = new QStandardItemModel(0, PolicyResultsColumn_COUNT, this);
+    set_horizontal_header_labels_from_map(model, {
+        {PolicyResultsColumn_Name, tr("Location")},
+        {PolicyResultsColumn_Enforced, tr("Enforced")},
+        {PolicyResultsColumn_Disabled, tr("Disabled")},
+    });
+
+    view->setModel(model);
+
+    const auto layout = new QVBoxLayout();
+    setLayout(layout);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(0);
+    layout->addWidget(view);
+
+    connect(
+        model, &QStandardItemModel::itemChanged,
+        this, &PolicyResultsWidget::on_item_changed);
 }
 
 void PolicyResultsWidget::update(const QModelIndex &scope_index) {
+    const ItemType type = (ItemType) scope_index.data(ConsoleRole_Type).toInt();
+    if (type != ItemType_Policy) {
+        return;
+    }
 
+    AdInterface ad;
+    if (ad_failed(ad)) {
+        return;
+    }
+
+    model->removeRows(0, model->rowCount());
+
+    gpo = scope_index.data(PolicyRole_DN).toString();
+
+    const QList<QString> search_attributes = {ATTRIBUTE_NAME, ATTRIBUTE_GPLINK};
+    const QString filter = filter_CONDITION(Condition_Contains, ATTRIBUTE_GPLINK, gpo);
+    const QHash<QString, AdObject> search_results = ad.search(filter, search_attributes, SearchScope_All);
+
+    for (const AdObject &object : search_results.values()) {
+        const QList<QStandardItem *> row = make_item_row(PolicyResultsColumn_COUNT);
+        
+        const QString dn = object.get_dn();
+        const QString name = dn_get_name(dn);
+        row[PolicyResultsColumn_Name]->setText(name);
+
+        const QString gplink_string = object.get_string(ATTRIBUTE_GPLINK);
+        const Gplink gplink = Gplink(gplink_string);
+
+        const Qt::CheckState enforced_checkstate =
+        [&]() {
+            const bool is_enforced = gplink.get_option(dn, GplinkOption_Enforced);
+            if (is_enforced) {
+                return Qt::Checked;
+            } else {
+                return Qt::Unchecked;
+            }
+        }();
+        row[PolicyResultsColumn_Enforced]->setCheckable(true);
+        row[PolicyResultsColumn_Enforced]->setCheckState(enforced_checkstate);
+
+        for (const auto column : option_columns) {
+            QStandardItem *item = row[column];
+            item->setCheckable(true);
+
+            const Qt::CheckState checkstate =
+            [=]() {
+                const GplinkOption option = column_to_option[column];
+                const bool option_is_set = gplink.get_option(dn, option);
+                if (option_is_set) {
+                    return Qt::Checked;
+                } else {
+                    return Qt::Unchecked;
+                }
+            }();
+            item->setCheckState(checkstate);
+        }
+
+        row[0]->setData(dn, PolicyResultsRole_DN);
+        row[0]->setData(gplink_string, PolicyResultsRole_GplinkString);
+
+        model->appendRow(row);
+    }
+}
+
+void PolicyResultsWidget::on_item_changed(QStandardItem *item) {
+    const PolicyResultsColumn column = (PolicyResultsColumn) item->column();
+    if (!option_columns.contains(column)) {
+        return;
+    }
+
+    const QModelIndex this_index = item->index();
+    const QModelIndex index = this_index.siblingAtColumn(0);
+    const QString dn = index.data(PolicyResultsRole_DN).toString();
+    const GplinkOption option = column_to_option[column];
+    const bool is_checked = (item->checkState() == Qt::Checked);
+
+    const QString gplink_string = index.data(PolicyResultsRole_GplinkString).toString();
+    Gplink gplink = Gplink(gplink_string);
+    gplink.set_option(gpo, option, is_checked);
+    const QString updated_gplink_string = gplink.to_string();
+
+    const bool gplink_didnt_change = (updated_gplink_string == gplink_string);
+    if (gplink_didnt_change) {
+        return;
+    }
+
+    AdInterface ad;
+    if (ad_failed(ad)) {
+        return;
+    }
+
+    show_busy_indicator();
+
+    const bool success = ad.attribute_replace_string(dn, ATTRIBUTE_GPLINK, updated_gplink_string);
+
+    if (success) {
+        model->setData(index, updated_gplink_string, PolicyResultsRole_GplinkString);
+    } else {
+        const Qt::CheckState undo_check_state =
+        [&]() {
+            if (item->checkState() == Qt::Checked) {
+                return Qt::Unchecked;
+            } else {
+                return Qt::Checked;
+            }
+        }();
+        item->setCheckState(undo_check_state);
+    }
+
+    STATUS()->display_ad_messages(ad, this);
+
+    hide_busy_indicator();
 }

--- a/src/admc/policy_results_widget.cpp
+++ b/src/admc/policy_results_widget.cpp
@@ -40,6 +40,7 @@ enum PolicyResultsColumn {
     PolicyResultsColumn_Name,
     PolicyResultsColumn_Enforced,
     PolicyResultsColumn_Disabled,
+    PolicyResultsColumn_Path,
 
     PolicyResultsColumn_COUNT,
 };
@@ -81,6 +82,7 @@ PolicyResultsWidget::PolicyResultsWidget() {
         {PolicyResultsColumn_Name, tr("Location")},
         {PolicyResultsColumn_Enforced, tr("Enforced")},
         {PolicyResultsColumn_Disabled, tr("Disabled")},
+        {PolicyResultsColumn_Path, tr("Path")},
     });
 
     view->setModel(model);
@@ -127,6 +129,8 @@ void PolicyResultsWidget::update(const QModelIndex &scope_index) {
         const QString dn = object.get_dn();
         const QString name = dn_get_name(dn);
         row[PolicyResultsColumn_Name]->setText(name);
+        
+        row[PolicyResultsColumn_Path]->setText(dn_get_parent_canonical(dn));
 
         const QString gplink_string = object.get_string(ATTRIBUTE_GPLINK);
         const Gplink gplink = Gplink(gplink_string);

--- a/src/admc/policy_results_widget.h
+++ b/src/admc/policy_results_widget.h
@@ -25,8 +25,12 @@
  */
 
 #include <QWidget>
+#include <QString>
 
 class QModelIndex;
+class QTreeView;
+class QStandardItemModel;
+class QStandardItem;
 
 class PolicyResultsWidget final : public QWidget {
 Q_OBJECT
@@ -34,9 +38,16 @@ Q_OBJECT
 public:
     PolicyResultsWidget();
 
+    // Loads links for this policy. Nothing is done if given
+    // index is not a policy.
     void update(const QModelIndex &scope_index);
 
 private:
+    QTreeView *view;
+    QStandardItemModel *model;
+    QString gpo;
+
+    void on_item_changed(QStandardItem *item);
 
 };
 

--- a/src/admc/policy_results_widget.h
+++ b/src/admc/policy_results_widget.h
@@ -52,7 +52,6 @@ private:
     void on_item_changed(QStandardItem *item);
     void open_context_menu(const QPoint &pos);
     void delete_link();
-
 };
 
 #endif /* POLICY_RESULTS_WIDGET_H */

--- a/src/admc/policy_results_widget.h
+++ b/src/admc/policy_results_widget.h
@@ -31,6 +31,7 @@ class QModelIndex;
 class QTreeView;
 class QStandardItemModel;
 class QStandardItem;
+class QMenu;
 
 class PolicyResultsWidget final : public QWidget {
 Q_OBJECT
@@ -46,8 +47,11 @@ private:
     QTreeView *view;
     QStandardItemModel *model;
     QString gpo;
+    QMenu *context_menu;
 
     void on_item_changed(QStandardItem *item);
+    void open_context_menu(const QPoint &pos);
+    void delete_link();
 
 };
 

--- a/src/admc/policy_results_widget.h
+++ b/src/admc/policy_results_widget.h
@@ -1,0 +1,43 @@
+/*
+ * ADMC - AD Management Center
+ *
+ * Copyright (C) 2020 BaseALT Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef POLICY_RESULTS_WIDGET_H
+#define POLICY_RESULTS_WIDGET_H
+
+/**
+ * Displays OU's linked to currently selected policy.
+ */
+
+#include <QWidget>
+
+class QModelIndex;
+
+class PolicyResultsWidget final : public QWidget {
+Q_OBJECT
+
+public:
+    PolicyResultsWidget();
+
+    void update(const QModelIndex &scope_index);
+
+private:
+
+};
+
+#endif /* POLICY_RESULTS_WIDGET_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,6 +41,7 @@ set(TEST_SOURCES
     ${PROJECT_SOURCE_DIR}/src/admc/utils.cpp
     ${PROJECT_SOURCE_DIR}/src/admc/settings.cpp
     ${PROJECT_SOURCE_DIR}/src/admc/policy_model.cpp
+    ${PROJECT_SOURCE_DIR}/src/admc/policy_results_widget.cpp
 
     ${PROJECT_SOURCE_DIR}/src/admc/move_dialog.cpp
     ${PROJECT_SOURCE_DIR}/src/admc/rename_dialog.cpp


### PR DESCRIPTION
![1](https://user-images.githubusercontent.com/13269470/113853301-8ff16e00-97ae-11eb-94dd-4ee42d6875d0.png)

Added policy results. This is the thing you see in results pane when a policy is selected. Displays OU's to which this policy is linked. Allows deleting OU links (via context menu) and changing "enforced" and "disabled" link options.

Added "add link" to policy items in console. You select OU's and they get linked to selected policy.
