### PR TITLE
Improve filter dialog

### DIFF
--- a/src/adldap/ad_config.cpp
+++ b/src/adldap/ad_config.cpp
@@ -528,6 +528,18 @@ bool AdConfig::get_attribute_is_constructed(const QString &attribute) const {
     return bit_is_set(system_flags, FLAG_ATTR_IS_CONSTRUCTED);   
 }
 
+// (noncontainer classes) = (all classes) - (container classes)
+QList<QString> AdConfig::get_noncontainer_classes() {
+    QList<QString> out = filter_classes;
+
+    const QList<QString> container_classes = get_filter_containers();
+    for (const QString &container_class : container_classes) {
+        out.removeAll(container_class);
+    }
+
+    return out;
+}
+
 QList<QString> AdConfigPrivate::add_auxiliary_classes(const QList<QString> &object_classes) const {
     QList<QString> out;
 

--- a/src/adldap/ad_config.h
+++ b/src/adldap/ad_config.h
@@ -80,6 +80,8 @@ public:
 
     void limit_edit(QLineEdit *edit, const QString &attribute);
 
+    QList<QString> get_noncontainer_classes();
+
 private:
     AdConfigPrivate *d;
 };

--- a/src/admc/CMakeLists.txt
+++ b/src/admc/CMakeLists.txt
@@ -50,6 +50,7 @@ set(ADMC_SOURCES
     settings.cpp
     policy_results_widget.cpp
     gplink.cpp
+    filter_classes_widget.cpp
     
     console_types/console_object.cpp
     console_types/console_policy.cpp

--- a/src/admc/CMakeLists.txt
+++ b/src/admc/CMakeLists.txt
@@ -39,6 +39,7 @@ set(ADMC_SOURCES
     password_dialog.cpp
     find_results.cpp
     filter_dialog.cpp
+    filter_custom_dialog.cpp
     find_widget.cpp
     tab_widget.cpp
     central_widget.cpp

--- a/src/admc/central_widget.cpp
+++ b/src/admc/central_widget.cpp
@@ -697,7 +697,12 @@ void CentralWidget::update_description_bar() {
 
         if (type == ItemType_Object) {
             const int results_count = console->get_current_results_count();
-            const QString out = tr("%n object(s)", "", results_count);
+            QString out = tr("%n object(s)", "", results_count);
+
+            const bool filtering_ON = filter_dialog->filtering_ON();
+            if (filtering_ON) {
+                out += tr(" [Filtering results]");
+            }
 
             return out;
         } else {

--- a/src/admc/console_types/console_object.cpp
+++ b/src/admc/console_types/console_object.cpp
@@ -26,7 +26,6 @@
 #include "status.h"
 #include "central_widget.h"
 #include "filter_dialog.h"
-#include "filter_widget/filter_widget.h"
 #include "console_actions.h"
 #include "select_object_dialog.h"
 #include "console_types/console_policy.h"
@@ -339,7 +338,7 @@ void console_object_fetch(ConsoleWidget *console, FilterDialog *filter_dialog, c
     //
     const QString filter =
     [=]() {
-        const QString user_filter = filter_dialog->filter_widget->get_filter();
+        const QString user_filter = filter_dialog->get_filter();
 
         const QString is_container = is_container_filter();
 

--- a/src/admc/filter_classes_widget.cpp
+++ b/src/admc/filter_classes_widget.cpp
@@ -29,18 +29,7 @@
 FilterClassesWidget::FilterClassesWidget()
 : QWidget()
 {   
-    // = all classes - container classes
-    const QList<QString> noncontainer_classes =
-    []() {
-        QList<QString> out = filter_classes;
-
-        const QList<QString> container_classes = g_adconfig->get_filter_containers();
-        for (const QString &container_class : container_classes) {
-            out.removeAll(container_class);
-        }
-
-        return out;
-    }();
+    const QList<QString> noncontainer_classes = g_adconfig->get_noncontainer_classes();   
 
     for (const QString &object_class : noncontainer_classes) {
         const QString class_string = g_adconfig->get_class_display_name(object_class);

--- a/src/admc/filter_classes_widget.cpp
+++ b/src/admc/filter_classes_widget.cpp
@@ -1,0 +1,70 @@
+/*
+ * ADMC - AD Management Center
+ *
+ * Copyright (C) 2020 BaseALT Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "filter_classes_widget.h"
+
+#include "adldap.h"
+#include "globals.h"
+
+#include <QVBoxLayout>
+#include <QScrollArea>
+#include <QCheckBox>
+
+FilterClassesWidget::FilterClassesWidget()
+: QWidget()
+{   
+    // = all classes - container classes
+    const QList<QString> noncontainer_classes =
+    []() {
+        QList<QString> out = filter_classes;
+
+        const QList<QString> container_classes = g_adconfig->get_filter_containers();
+        for (const QString &container_class : container_classes) {
+            out.removeAll(container_class);
+        }
+
+        return out;
+    }();
+
+    for (const QString &object_class : noncontainer_classes) {
+        const QString class_string = g_adconfig->get_class_display_name(object_class);
+        auto checkbox = new QCheckBox(class_string);
+
+        checkbox_map[object_class] = checkbox;
+    }
+
+    auto classes_widget = new QWidget();
+
+    auto classes_layout = new QVBoxLayout();
+    classes_widget->setLayout(classes_layout);
+
+    for (const QString &object_class : noncontainer_classes) {
+        QCheckBox *checkbox = checkbox_map[object_class];
+        classes_layout->addWidget(checkbox);
+    }
+
+    auto scroll_area = new QScrollArea();
+    scroll_area->setWidget(classes_widget);
+
+    auto layout = new QVBoxLayout();
+    setLayout(layout);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(0);
+    layout->addWidget(scroll_area);
+}

--- a/src/admc/filter_classes_widget.cpp
+++ b/src/admc/filter_classes_widget.cpp
@@ -26,14 +26,13 @@
 #include <QScrollArea>
 #include <QCheckBox>
 
-FilterClassesWidget::FilterClassesWidget()
+FilterClassesWidget::FilterClassesWidget(const QList<QString> &class_list)
 : QWidget()
 {   
-    const QList<QString> noncontainer_classes = g_adconfig->get_noncontainer_classes();   
-
-    for (const QString &object_class : noncontainer_classes) {
+    for (const QString &object_class : class_list) {
         const QString class_string = g_adconfig->get_class_display_name(object_class);
         auto checkbox = new QCheckBox(class_string);
+        checkbox->setChecked(true);
 
         checkbox_map[object_class] = checkbox;
     }
@@ -43,7 +42,7 @@ FilterClassesWidget::FilterClassesWidget()
     auto classes_layout = new QVBoxLayout();
     classes_widget->setLayout(classes_layout);
 
-    for (const QString &object_class : noncontainer_classes) {
+    for (const QString &object_class : class_list) {
         QCheckBox *checkbox = checkbox_map[object_class];
         classes_layout->addWidget(checkbox);
     }
@@ -78,4 +77,18 @@ QString FilterClassesWidget::get_filter() const {
     const QString filter = filter_OR(class_filter_list);
 
     return filter;
+}
+
+QList<QString> FilterClassesWidget::get_selected_classes() const {
+    QList<QString> out;
+
+    for (const QString &object_class : checkbox_map.keys()) {
+        const QCheckBox *check = checkbox_map[object_class];
+
+        if (check->isChecked()) {
+            out.append(object_class);
+        }
+    }
+
+    return out;
 }

--- a/src/admc/filter_classes_widget.cpp
+++ b/src/admc/filter_classes_widget.cpp
@@ -68,3 +68,25 @@ FilterClassesWidget::FilterClassesWidget()
     layout->setSpacing(0);
     layout->addWidget(scroll_area);
 }
+
+QString FilterClassesWidget::get_filter() const {
+    const QList<QString> class_filter_list =
+    [&] {
+        QList<QString> out;
+
+        for (const QString &object_class : checkbox_map.keys()) {
+            QCheckBox *checkbox = checkbox_map[object_class];
+
+            if (checkbox->isChecked()) {
+                const QString class_filter = filter_CONDITION(Condition_Equals, ATTRIBUTE_OBJECT_CLASS, object_class);
+                out.append(class_filter);
+            }
+        }
+
+        return out;
+    }();
+
+    const QString filter = filter_OR(class_filter_list);
+
+    return filter;
+}

--- a/src/admc/filter_classes_widget.h
+++ b/src/admc/filter_classes_widget.h
@@ -35,6 +35,8 @@ Q_OBJECT
 public:
     FilterClassesWidget();
 
+    QString get_filter() const;
+
 private:
     QHash<QString, QCheckBox *> checkbox_map;
 };

--- a/src/admc/filter_classes_widget.h
+++ b/src/admc/filter_classes_widget.h
@@ -21,6 +21,9 @@
 #define FILTER_CLASSES_WIDGET_H
 
 /**
+ * This widget is embedded in FilterDialog. Contains
+ * checkboxes of object classes. get_filter() returns a
+ * filter which will filter out unselected classes.
  */
 
 #include <QWidget>

--- a/src/admc/filter_classes_widget.h
+++ b/src/admc/filter_classes_widget.h
@@ -36,9 +36,10 @@ class FilterClassesWidget final : public QWidget {
 Q_OBJECT
     
 public:
-    FilterClassesWidget();
+    FilterClassesWidget(const QList<QString> &class_list);
 
     QString get_filter() const;
+    QList<QString> get_selected_classes() const;
 
 private:
     QHash<QString, QCheckBox *> checkbox_map;

--- a/src/admc/filter_classes_widget.h
+++ b/src/admc/filter_classes_widget.h
@@ -17,40 +17,26 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef FILTER_DIALOG_H
-#define FILTER_DIALOG_H
+#ifndef FILTER_CLASSES_WIDGET_H
+#define FILTER_CLASSES_WIDGET_H
 
 /**
- * Contains FilterWidget. When a filter is entered and
- * dialog is accepted, emits filter_changed() signal. Used
- * for filtering ObjectModel.
  */
 
-#include <QDialog>
+#include <QWidget>
+#include <QHash>
+#include <QString>
 
-class FilterWidget;
-class FilterCustomDialog;
-class QRadioButton;
-class QPushButton;
-class FilterClassesWidget;
+class QCheckBox;
 
-class FilterDialog final : public QDialog {
+class FilterClassesWidget final : public QWidget {
 Q_OBJECT
-
-public:
-    FilterWidget *filter_widget;
     
-    FilterDialog(QWidget *parent);
+public:
+    FilterClassesWidget();
 
 private:
-    FilterCustomDialog *custom_dialog;
-    QRadioButton *custom_button;
-    QRadioButton *classes_button;
-    QPushButton *custom_dialog_button;
-    FilterClassesWidget *filter_classes_widget;
-
-    void on_custom_button();
-    void on_classes_button();
+    QHash<QString, QCheckBox *> checkbox_map;
 };
 
-#endif /* FILTER_DIALOG_H */
+#endif /* FILTER_CLASSES_WIDGET_H */

--- a/src/admc/filter_custom_dialog.cpp
+++ b/src/admc/filter_custom_dialog.cpp
@@ -17,30 +17,27 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "filter_dialog.h"
+#include "filter_custom_dialog.h"
 
 #include "adldap.h"
 #include "globals.h"
+
 #include "filter_widget/filter_widget.h"
-#include "filter_custom_dialog.h"
 
 #include <QDialogButtonBox>
 #include <QVBoxLayout>
-#include <QHBoxLayout>
-#include <QRadioButton>
-#include <QPushButton>
-#include <QFrame>
 
 // TODO: implement canceling. Need to be able to load/unload
 // filter widget state though. For example, one way to
 // implement would be to save old state on open, then reload
 // it when cancel is pressed.
 
-FilterDialog::FilterDialog(QWidget *parent)
+FilterCustomDialog::FilterCustomDialog(QWidget *parent)
 : QDialog(parent)
 {   
-    setWindowTitle(tr("Filter contents"));
+    setWindowTitle(tr("Custom filter"));
 
+    // NOTE: Can't filter out container objects, because otherwise the whole tree can't be displayed, so only allow filtering by non-container classes.
     // = all classes - container classes
     const QList<QString> noncontainer_classes =
     []() {
@@ -56,53 +53,15 @@ FilterDialog::FilterDialog(QWidget *parent)
 
     filter_widget = new FilterWidget(noncontainer_classes);
 
-    custom_dialog = new FilterCustomDialog(this);
-
-    auto all_button = new QRadioButton(tr("Show all"));
-    auto classes_button = new QRadioButton(tr("Show only these types"));
-    custom_button = new QRadioButton(tr("Create custom"));
-
-    all_button->setChecked(true);
-
-    custom_dialog_button = new QPushButton(tr("Custom"));
-
     auto buttonbox = new QDialogButtonBox();
     buttonbox->addButton(QDialogButtonBox::Ok);
 
-    auto radio_buttons_frame = new QFrame();
-    radio_buttons_frame->setFrameStyle(QFrame::Raised);
-    radio_buttons_frame->setFrameShape(QFrame::Box);
-
-    auto custom_row_layout = new QHBoxLayout();
-    custom_row_layout->addWidget(custom_button);
-    custom_row_layout->addWidget(custom_dialog_button);
-
-    auto radio_layout = new QVBoxLayout();
-    radio_buttons_frame->setLayout(radio_layout);
-    radio_layout->addWidget(all_button);
-    radio_layout->addWidget(classes_button);
-    radio_layout->addLayout(custom_row_layout);
-
     auto layout = new QVBoxLayout();
     setLayout(layout);
-    layout->addWidget(radio_buttons_frame);
+    layout->addWidget(filter_widget);
     layout->addWidget(buttonbox);
 
     connect(
         buttonbox, &QDialogButtonBox::accepted,
         this, &QDialog::accept);
-    connect(
-        custom_dialog_button, &QPushButton::clicked,
-        custom_dialog, &QDialog::open);
-
-    connect(
-        custom_button, &QAbstractButton::toggled,
-        this, &FilterDialog::on_custom_button);
-    on_custom_button();
-}
-
-void FilterDialog::on_custom_button() {
-    const bool checked = custom_button->isChecked();
-
-    custom_dialog_button->setEnabled(checked);
 }

--- a/src/admc/filter_custom_dialog.cpp
+++ b/src/admc/filter_custom_dialog.cpp
@@ -37,19 +37,10 @@ FilterCustomDialog::FilterCustomDialog(QWidget *parent)
 {   
     setWindowTitle(tr("Custom filter"));
 
-    // NOTE: Can't filter out container objects, because otherwise the whole tree can't be displayed, so only allow filtering by non-container classes.
-    // = all classes - container classes
-    const QList<QString> noncontainer_classes =
-    []() {
-        QList<QString> out = filter_classes;
-
-        const QList<QString> container_classes = g_adconfig->get_filter_containers();
-        for (const QString &container_class : container_classes) {
-            out.removeAll(container_class);
-        }
-
-        return out;
-    }();
+    // NOTE: Can't filter out container objects, because
+    // otherwise the whole tree can't be displayed, so only
+    // allow filtering by non-container classes
+    const QList<QString> noncontainer_classes = g_adconfig->get_noncontainer_classes();   
 
     filter_widget = new FilterWidget(noncontainer_classes);
 

--- a/src/admc/filter_custom_dialog.h
+++ b/src/admc/filter_custom_dialog.h
@@ -22,7 +22,8 @@
 
 /**
  * Dialog that's opened when "Custom" button is pressed in
- * filter dialog.
+ * filter dialog. Contains a filter widget which is used to
+ * create a filter.
  */
 
 #include <QDialog>

--- a/src/admc/filter_custom_dialog.h
+++ b/src/admc/filter_custom_dialog.h
@@ -17,36 +17,26 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef FILTER_DIALOG_H
-#define FILTER_DIALOG_H
+#ifndef FILTER_CUSTOM_DIALOG_H
+#define FILTER_CUSTOM_DIALOG_H
 
 /**
- * Contains FilterWidget. When a filter is entered and
- * dialog is accepted, emits filter_changed() signal. Used
- * for filtering ObjectModel.
+ * Dialog that's opened when "Custom" button is pressed in
+ * filter dialog.
  */
 
 #include <QDialog>
 
 class FilterWidget;
-class FilterCustomDialog;
-class QRadioButton;
-class QPushButton;
 
-class FilterDialog final : public QDialog {
+class FilterCustomDialog final : public QDialog {
 Q_OBJECT
 
 public:
     FilterWidget *filter_widget;
     
-    FilterDialog(QWidget *parent);
+    FilterCustomDialog(QWidget *parent);
 
-private:
-    FilterCustomDialog *custom_dialog;
-    QRadioButton *custom_button;
-    QPushButton *custom_dialog_button;
-
-    void on_custom_button();
 };
 
-#endif /* FILTER_DIALOG_H */
+#endif /* FILTER_CUSTOM_DIALOG_H */

--- a/src/admc/filter_dialog.cpp
+++ b/src/admc/filter_dialog.cpp
@@ -60,7 +60,7 @@ FilterDialog::FilterDialog(QWidget *parent)
 
     custom_dialog_button = new QPushButton(tr("Custom"));
 
-    filter_classes_widget = new FilterClassesWidget();
+    filter_classes_widget = new FilterClassesWidget(noncontainer_classes);
 
     auto buttonbox = new QDialogButtonBox();
     buttonbox->addButton(QDialogButtonBox::Ok);

--- a/src/admc/filter_dialog.cpp
+++ b/src/admc/filter_dialog.cpp
@@ -117,6 +117,10 @@ FilterDialog::FilterDialog(QWidget *parent)
     on_classes_button();
 }
 
+bool FilterDialog::filtering_ON() const {
+    return !all_button->isChecked();
+}
+
 QString FilterDialog::get_filter() const {
     if (all_button->isChecked()) {
         return "(objectClass=*)";

--- a/src/admc/filter_dialog.cpp
+++ b/src/admc/filter_dialog.cpp
@@ -23,6 +23,7 @@
 #include "globals.h"
 #include "filter_widget/filter_widget.h"
 #include "filter_custom_dialog.h"
+#include "filter_classes_widget.h"
 
 #include <QDialogButtonBox>
 #include <QVBoxLayout>
@@ -30,6 +31,8 @@
 #include <QRadioButton>
 #include <QPushButton>
 #include <QFrame>
+#include <QScrollArea>
+#include <QCheckBox>
 
 // TODO: implement canceling. Need to be able to load/unload
 // filter widget state though. For example, one way to
@@ -40,6 +43,7 @@ FilterDialog::FilterDialog(QWidget *parent)
 : QDialog(parent)
 {   
     setWindowTitle(tr("Filter contents"));
+    resize(400, 400);
 
     // = all classes - container classes
     const QList<QString> noncontainer_classes =
@@ -59,12 +63,14 @@ FilterDialog::FilterDialog(QWidget *parent)
     custom_dialog = new FilterCustomDialog(this);
 
     auto all_button = new QRadioButton(tr("Show all"));
-    auto classes_button = new QRadioButton(tr("Show only these types"));
+    classes_button = new QRadioButton(tr("Show only these types"));
     custom_button = new QRadioButton(tr("Create custom"));
 
     all_button->setChecked(true);
 
     custom_dialog_button = new QPushButton(tr("Custom"));
+
+    filter_classes_widget = new FilterClassesWidget();
 
     auto buttonbox = new QDialogButtonBox();
     buttonbox->addButton(QDialogButtonBox::Ok);
@@ -73,6 +79,10 @@ FilterDialog::FilterDialog(QWidget *parent)
     radio_buttons_frame->setFrameStyle(QFrame::Raised);
     radio_buttons_frame->setFrameShape(QFrame::Box);
 
+    auto classes_row_layout = new QVBoxLayout();
+    classes_row_layout->addWidget(classes_button);
+    classes_row_layout->addWidget(filter_classes_widget);
+
     auto custom_row_layout = new QHBoxLayout();
     custom_row_layout->addWidget(custom_button);
     custom_row_layout->addWidget(custom_dialog_button);
@@ -80,7 +90,7 @@ FilterDialog::FilterDialog(QWidget *parent)
     auto radio_layout = new QVBoxLayout();
     radio_buttons_frame->setLayout(radio_layout);
     radio_layout->addWidget(all_button);
-    radio_layout->addWidget(classes_button);
+    radio_layout->addLayout(classes_row_layout);
     radio_layout->addLayout(custom_row_layout);
 
     auto layout = new QVBoxLayout();
@@ -99,10 +109,21 @@ FilterDialog::FilterDialog(QWidget *parent)
         custom_button, &QAbstractButton::toggled,
         this, &FilterDialog::on_custom_button);
     on_custom_button();
+
+    connect(
+        classes_button, &QAbstractButton::toggled,
+        this, &FilterDialog::on_classes_button);
+    on_classes_button();
 }
 
 void FilterDialog::on_custom_button() {
     const bool checked = custom_button->isChecked();
 
     custom_dialog_button->setEnabled(checked);
+}
+
+void FilterDialog::on_classes_button() {
+    const bool checked = classes_button->isChecked();
+
+    filter_classes_widget->setEnabled(checked);
 }

--- a/src/admc/filter_dialog.cpp
+++ b/src/admc/filter_dialog.cpp
@@ -33,6 +33,7 @@
 #include <QFrame>
 #include <QScrollArea>
 #include <QCheckBox>
+#include <QDebug>
 
 // TODO: implement canceling. Need to be able to load/unload
 // filter widget state though. For example, one way to
@@ -62,7 +63,7 @@ FilterDialog::FilterDialog(QWidget *parent)
 
     custom_dialog = new FilterCustomDialog(this);
 
-    auto all_button = new QRadioButton(tr("Show all"));
+    all_button = new QRadioButton(tr("Show all"));
     classes_button = new QRadioButton(tr("Show only these types"));
     custom_button = new QRadioButton(tr("Create custom"));
 
@@ -114,6 +115,18 @@ FilterDialog::FilterDialog(QWidget *parent)
         classes_button, &QAbstractButton::toggled,
         this, &FilterDialog::on_classes_button);
     on_classes_button();
+}
+
+QString FilterDialog::get_filter() const {
+    if (all_button->isChecked()) {
+        return "(objectClass=*)";
+    } else if (classes_button->isChecked()) {
+        return filter_classes_widget->get_filter();
+    } else if (custom_button->isChecked()) {
+        return custom_dialog->filter_widget->get_filter();
+    }
+    
+    return QString();
 }
 
 void FilterDialog::on_custom_button() {

--- a/src/admc/filter_dialog.cpp
+++ b/src/admc/filter_dialog.cpp
@@ -46,18 +46,7 @@ FilterDialog::FilterDialog(QWidget *parent)
     setWindowTitle(tr("Filter contents"));
     resize(400, 400);
 
-    // = all classes - container classes
-    const QList<QString> noncontainer_classes =
-    []() {
-        QList<QString> out = filter_classes;
-
-        const QList<QString> container_classes = g_adconfig->get_filter_containers();
-        for (const QString &container_class : container_classes) {
-            out.removeAll(container_class);
-        }
-
-        return out;
-    }();
+    const QList<QString> noncontainer_classes = g_adconfig->get_noncontainer_classes();   
 
     filter_widget = new FilterWidget(noncontainer_classes);
 

--- a/src/admc/filter_dialog.h
+++ b/src/admc/filter_dialog.h
@@ -41,6 +41,7 @@ public:
     FilterDialog(QWidget *parent);
 
     QString get_filter() const;
+    bool filtering_ON() const;
 
 private:
     FilterCustomDialog *custom_dialog;

--- a/src/admc/filter_dialog.h
+++ b/src/admc/filter_dialog.h
@@ -21,9 +21,9 @@
 #define FILTER_DIALOG_H
 
 /**
- * Contains FilterWidget. When a filter is entered and
- * dialog is accepted, emits filter_changed() signal. Used
- * for filtering ObjectModel.
+ * Dialog used to enter a filter that is applied to objects
+ * in the console. Allows showing all objects, objects of
+ * certain type or entering a custom filter.
  */
 
 #include <QDialog>

--- a/src/admc/filter_dialog.h
+++ b/src/admc/filter_dialog.h
@@ -38,16 +38,18 @@ class FilterDialog final : public QDialog {
 Q_OBJECT
 
 public:
-    FilterWidget *filter_widget;
-    
     FilterDialog(QWidget *parent);
+
+    QString get_filter() const;
 
 private:
     FilterCustomDialog *custom_dialog;
+    QRadioButton *all_button;
     QRadioButton *custom_button;
     QRadioButton *classes_button;
     QPushButton *custom_dialog_button;
     FilterClassesWidget *filter_classes_widget;
+    FilterWidget *filter_widget;
 
     void on_custom_button();
     void on_classes_button();

--- a/src/admc/filter_widget/select_classes_widget.h
+++ b/src/admc/filter_widget/select_classes_widget.h
@@ -21,41 +21,31 @@
 #define SELECT_CLASSES_WIDGET_H
 
 /**
- * Select classes for filtering.
+ * Widget embedded in find widget for selecting classes to
+ * filter for. Displays currently selected classes in line
+ * edit, with a button next to it which opens a dialog in
+ * which classes can be selected.
  */
 
 #include <QWidget>
-#include <QHash>
 
 class QLineEdit;
-class QDialog;
-class QCheckBox;
-class QPushButton;
-class QString;
+class FilterClassesWidget;
 
 class SelectClassesWidget final : public QWidget {
 Q_OBJECT
     
 public:
-    SelectClassesWidget(const QList<QString> classes);
+    SelectClassesWidget(const QList<QString> class_list);
 
-    // Return a filter that accepts only selected classes
     QString get_filter() const;
 
 private slots:
     void on_dialog_accepted();
-    void select_all();
-    void clear_selection();
-    void on_check_changed();
 
 private:
     QLineEdit *classes_display;
-    QDialog *dialog;
-    QHash<QString, QCheckBox *> dialog_checks;
-    QPushButton *ok_button;
-    QList<QString> class_list;
-
-    QList<QString> get_selected_classes() const;
+    FilterClassesWidget *filter_classes_widget;
 };
 
 #endif /* SELECT_CLASSES_WIDGET_H */


### PR DESCRIPTION
Split filter dialog's content into 3 areas (2 are new). First one is showing all objects, i.e. no filter. Second one is selecting classes to filter for. Last one is a custom filter.

Display special text "[Filtering results]" in console's description bar when a filter is activated.

Class selection dialog in find dialog now uses the same widget as the one used in filter dialog. Because of this, "select all", "deselect all" and "cancel" buttons were removed. Also removed previous behavior where selecting all classes changes filter to accept ALL classes (those outside of listed classes as well). That feature conflicted with stuff like selecting groups (only groups were listed).

Closes #182 