### PR TITLE
Single console model

### DIFF
--- a/src/admc/central_widget.cpp
+++ b/src/admc/central_widget.cpp
@@ -703,7 +703,7 @@ void CentralWidget::on_object_properties_applied() {
         const QList<QModelIndex> index_list = console->search_items(console_object_head()->index(), ObjectRole_DN, target, ItemType_Object);
         for (const QModelIndex &index : index_list) {
             const QList<QStandardItem *> row = console->get_row(index);
-            console_object_results_load(row, object);
+            console_object_load(row, object);
         }
     }
 

--- a/src/admc/central_widget.cpp
+++ b/src/admc/central_widget.cpp
@@ -351,7 +351,7 @@ void CentralWidget::object_create_helper(const QString &object_class) {
 
             show_busy_indicator();
 
-            const QList<QModelIndex> search_parent = console->search_scope_by_role(ObjectRole_DN, parent_dn, ItemType_Object);
+            const QList<QModelIndex> search_parent = console->search_items(ObjectRole_DN, parent_dn, ItemType_Object);
 
             if (search_parent.isEmpty()) {
                 hide_busy_indicator();
@@ -705,7 +705,7 @@ void CentralWidget::on_object_properties_applied() {
     for (const QString &target : target_list) {
         const AdObject object = ad.search_object(target);
 
-        const QList<QModelIndex> results_indexes = console->search_results_by_role(ObjectRole_DN, target, ItemType_Object);
+        const QList<QModelIndex> results_indexes = console->search_items(ObjectRole_DN, target, ItemType_Object);
         for (const QModelIndex &index : results_indexes) {
             const QList<QStandardItem *> results_row = console->get_results_row(index);
             console_object_results_load(results_row, object);
@@ -797,13 +797,13 @@ void CentralWidget::enable_disable_helper(const bool disabled) {
     }
 
     for (const QString &dn : changed_objects) {
-        const QList<QModelIndex> scope_indexes = console->search_scope_by_role(ObjectRole_DN, dn, ItemType_Object);
+        const QList<QModelIndex> scope_indexes = console->search_items(ObjectRole_DN, dn, ItemType_Object);
         for (const QModelIndex &index : scope_indexes) {
             QStandardItem *scope_item = console->get_scope_item(index);
             scope_item->setData(disabled, ObjectRole_AccountDisabled);
         }
 
-        const QList<QModelIndex> results_indexes = console->search_results_by_role(ObjectRole_DN, dn, ItemType_Object);
+        const QList<QModelIndex> results_indexes = console->search_items(ObjectRole_DN, dn, ItemType_Object);
         for (const QModelIndex &index : results_indexes) {
             const QList<QStandardItem *> results_row = console->get_results_row(index);
             results_row[0]->setData(disabled, ObjectRole_AccountDisabled);

--- a/src/admc/central_widget.cpp
+++ b/src/admc/central_widget.cpp
@@ -232,7 +232,7 @@ CentralWidget::CentralWidget()
         console, &ConsoleWidget::properties_requested,
         this, &CentralWidget::object_properties);
     connect(
-        console, &ConsoleWidget::selection_changed,
+        console, &ConsoleWidget::actions_changed,
         this, &CentralWidget::update_actions_visibility);
     connect(
         console, &ConsoleWidget::context_menu,

--- a/src/admc/central_widget.cpp
+++ b/src/admc/central_widget.cpp
@@ -705,12 +705,6 @@ void CentralWidget::on_object_properties_applied() {
     for (const QString &target : target_list) {
         const AdObject object = ad.search_object(target);
 
-        const QList<QModelIndex> scope_indexes = console->search_scope_by_role(ObjectRole_DN, target, ItemType_Object);
-        for (const QModelIndex &index : scope_indexes) {
-            QStandardItem *scope_item = console->get_scope_item(index);
-            console_object_scope_load(scope_item, object);
-        }
-
         const QList<QModelIndex> results_indexes = console->search_results_by_role(ObjectRole_DN, target, ItemType_Object);
         for (const QModelIndex &index : results_indexes) {
             const QList<QStandardItem *> results_row = console->get_results_row(index);

--- a/src/admc/central_widget.cpp
+++ b/src/admc/central_widget.cpp
@@ -601,11 +601,8 @@ void CentralWidget::query_paste() {
 
 void CentralWidget::on_items_can_drop(const QList<QPersistentModelIndex> &dropped_list, const QPersistentModelIndex &target, bool *ok) {
     const bool dropped_contains_target = [&]() {
-        const QModelIndex target_scope = console_item_convert_to_scope_index(target);
-
         for (const QPersistentModelIndex &dropped : dropped_list) {
-            const QModelIndex dropped_scope = console_item_convert_to_scope_index(dropped);
-            if (dropped_scope == target_scope) {
+            if (dropped == target) {
                 return true;
             }
         }

--- a/src/admc/central_widget.cpp
+++ b/src/admc/central_widget.cpp
@@ -705,10 +705,10 @@ void CentralWidget::on_object_properties_applied() {
     for (const QString &target : target_list) {
         const AdObject object = ad.search_object(target);
 
-        const QList<QModelIndex> results_indexes = console->search_items(ObjectRole_DN, target, ItemType_Object);
-        for (const QModelIndex &index : results_indexes) {
-            const QList<QStandardItem *> results_row = console->get_results_row(index);
-            console_object_results_load(results_row, object);
+        const QList<QModelIndex> index_list = console->search_items(ObjectRole_DN, target, ItemType_Object);
+        for (const QModelIndex &index : index_list) {
+            const QList<QStandardItem *> row = console->get_row(index);
+            console_object_results_load(row, object);
         }
     }
 
@@ -797,16 +797,10 @@ void CentralWidget::enable_disable_helper(const bool disabled) {
     }
 
     for (const QString &dn : changed_objects) {
-        const QList<QModelIndex> scope_indexes = console->search_items(ObjectRole_DN, dn, ItemType_Object);
-        for (const QModelIndex &index : scope_indexes) {
-            QStandardItem *scope_item = console->get_scope_item(index);
-            scope_item->setData(disabled, ObjectRole_AccountDisabled);
-        }
-
-        const QList<QModelIndex> results_indexes = console->search_items(ObjectRole_DN, dn, ItemType_Object);
-        for (const QModelIndex &index : results_indexes) {
-            const QList<QStandardItem *> results_row = console->get_results_row(index);
-            results_row[0]->setData(disabled, ObjectRole_AccountDisabled);
+        const QList<QModelIndex> index_list = console->search_items(ObjectRole_DN, dn, ItemType_Object);
+        for (const QModelIndex &index : index_list) {
+            QStandardItem *item = console->get_item(index);
+            item->setData(disabled, ObjectRole_AccountDisabled);
         }
     }
 

--- a/src/admc/central_widget.cpp
+++ b/src/admc/central_widget.cpp
@@ -256,11 +256,11 @@ void CentralWidget::go_online(AdInterface &ad) {
     auto object_results = new ResultsView(this);
     console_object_results_id = console->register_results(object_results, console_object_header_labels(), console_object_default_columns());
 
-    object_tree_head = console_object_tree_init(console, ad);
+    console_object_tree_init(console, ad);
     console_policy_tree_init(console, ad);
     console_query_tree_init(console);
 
-    console->set_current_scope(object_tree_head->index());
+    console->set_current_scope(console_object_head()->index());
 }
 
 void CentralWidget::open_filter() {
@@ -350,7 +350,7 @@ void CentralWidget::object_create_helper(const QString &object_class) {
 
             show_busy_indicator();
 
-            const QList<QModelIndex> search_parent = console->search_items(ObjectRole_DN, parent_dn, ItemType_Object);
+            const QList<QModelIndex> search_parent = console->search_items(console_object_head()->index(), ObjectRole_DN, parent_dn, ItemType_Object);
 
             if (search_parent.isEmpty()) {
                 hide_busy_indicator();
@@ -467,7 +467,7 @@ void CentralWidget::object_edit_upn_suffixes() {
 }
 
 void CentralWidget::object_change_dc() {
-    auto change_dc_dialog = new ChangeDCDialog(object_tree_head, this);
+    auto change_dc_dialog = new ChangeDCDialog(console_object_head(), this);
     change_dc_dialog->open();
 }
 
@@ -700,7 +700,7 @@ void CentralWidget::on_object_properties_applied() {
     for (const QString &target : target_list) {
         const AdObject object = ad.search_object(target);
 
-        const QList<QModelIndex> index_list = console->search_items(ObjectRole_DN, target, ItemType_Object);
+        const QList<QModelIndex> index_list = console->search_items(console_object_head()->index(), ObjectRole_DN, target, ItemType_Object);
         for (const QModelIndex &index : index_list) {
             const QList<QStandardItem *> row = console->get_row(index);
             console_object_results_load(row, object);
@@ -715,7 +715,7 @@ void CentralWidget::on_object_properties_applied() {
 void CentralWidget::refresh_head() {
     show_busy_indicator();
 
-    console->refresh_scope(object_tree_head->index());
+    console->refresh_scope(console_object_head()->index());
 
     hide_busy_indicator();
 }
@@ -792,7 +792,7 @@ void CentralWidget::enable_disable_helper(const bool disabled) {
     }
 
     for (const QString &dn : changed_objects) {
-        const QList<QModelIndex> index_list = console->search_items(ObjectRole_DN, dn, ItemType_Object);
+        const QList<QModelIndex> index_list = console->search_items(console_object_head()->index(), ObjectRole_DN, dn, ItemType_Object);
         for (const QModelIndex &index : index_list) {
             QStandardItem *item = console->get_item(index);
             item->setData(disabled, ObjectRole_AccountDisabled);

--- a/src/admc/central_widget.cpp
+++ b/src/admc/central_widget.cpp
@@ -260,7 +260,6 @@ void CentralWidget::go_online(AdInterface &ad) {
     console_policy_tree_init(console, ad);
     console_query_tree_init(console);
 
-    console->sort_scope();
     console->set_current_scope(object_tree_head->index());
 }
 
@@ -362,8 +361,6 @@ void CentralWidget::object_create_helper(const QString &object_class) {
             const QString created_dn = dialog->get_created_dn();
             console_object_create(console, ad, {created_dn}, scope_parent_index);
 
-            console->sort_scope();
-
             hide_busy_indicator();
         });
 }
@@ -385,8 +382,6 @@ void CentralWidget::object_move() {
             const QList<QString> old_dn_list = dialog->get_moved_objects();
             const QString new_parent_dn = dialog->get_selected();
             console_object_move(console, ad, old_dn_list, new_parent_dn);
-
-            console->sort_scope();
         });
 }
 

--- a/src/admc/central_widget.h
+++ b/src/admc/central_widget.h
@@ -26,7 +26,6 @@
  * browse and manipulate objects. Wraps ConsoleWidget inside it.
  */
 
-#include <QPersistentModelIndex>
 #include <QWidget>
 
 class QAbstractItemView;
@@ -112,7 +111,6 @@ private slots:
 
 private:
     ConsoleWidget *console;
-    QStandardItem *object_tree_head;
     FilterDialog *filter_dialog;
     PolicyResultsWidget *policy_results_widget;
 

--- a/src/admc/console_types/console_object.cpp
+++ b/src/admc/console_types/console_object.cpp
@@ -187,10 +187,10 @@ void console_object_delete(ConsoleWidget *console, const QList<QString> &dn_list
             // NOTE: don't touch query tree indexes, they
             // stay around and just go out of date
             const bool index_is_in_query_tree = [=]() {
-                const QModelIndex scope_parent = console->get_scope_parent(index);
-                const ItemType scope_parent_type = (ItemType) scope_parent.data(ConsoleRole_Type).toInt();
+                const QModelIndex parent = index.parent();
+                const ItemType parent_type = (ItemType) parent.data(ConsoleRole_Type).toInt();
 
-                return (scope_parent_type == ItemType_QueryItem);
+                return (parent_type == ItemType_QueryItem);
             }();
 
             if (index_is_in_query_tree && ignore_query_tree) {

--- a/src/admc/console_types/console_object.cpp
+++ b/src/admc/console_types/console_object.cpp
@@ -163,15 +163,8 @@ void disable_drag_if_object_cant_be_moved(const QList<QStandardItem *> &items, c
 // index because can delete objects from query tree
 void console_object_delete(ConsoleWidget *console, const QList<QString> &dn_list, const bool ignore_query_tree) {
     for (const QString &dn : dn_list) {
-        // Delete in scope
-        const QList<QPersistentModelIndex> scope_indexes = persistent_index_list(console->search_items(ObjectRole_DN, dn, ItemType_Object));
-        for (const QPersistentModelIndex &index : scope_indexes) {
-            console->delete_item(index);
-        }
-
-        // Delete in results
-        const QList<QPersistentModelIndex> results_indexes = persistent_index_list(console->search_items(ObjectRole_DN, dn, ItemType_Object));
-        for (const QPersistentModelIndex &index : results_indexes) {
+        const QList<QPersistentModelIndex> index_list = persistent_index_list(console->search_items(ObjectRole_DN, dn, ItemType_Object));
+        for (const QPersistentModelIndex &index : index_list) {
             // NOTE: don't touch query tree indexes, they
             // stay around and just go out of date
             const bool index_is_in_query_tree = [=]() {

--- a/src/admc/console_types/console_object.cpp
+++ b/src/admc/console_types/console_object.cpp
@@ -304,7 +304,7 @@ void console_object_create(ConsoleWidget *console, const QList<AdObject> &object
 void console_object_search(ConsoleWidget *console, const QModelIndex &index, const QString &base, const SearchScope scope, const QString &filter, const QList<QString> &attributes) {
     // Save original icon and switch to a different icon
     // that will indicate that this item is being fetched.
-    QStandardItem *item = console->get_scope_item(index);
+    QStandardItem *item = console->get_item(index);
     const QIcon original_icon = item->icon();
     item->setIcon(QIcon::fromTheme("system-search"));
 
@@ -351,11 +351,11 @@ void console_object_search(ConsoleWidget *console, const QModelIndex &index, con
                 return;
             }
 
-            QStandardItem *scope_item = console->get_scope_item(persistent_index);
-            scope_item->setIcon(original_icon);
+            QStandardItem *item_now = console->get_item(persistent_index);
+            item_now->setIcon(original_icon);
 
-            console->set_item_fetching(scope_item->index(), false);
-            scope_item->setDragEnabled(true);
+            console->set_item_fetching(item_now->index(), false);
+            item_now->setDragEnabled(true);
         },
         Qt::QueuedConnection);
 

--- a/src/admc/console_types/console_object.cpp
+++ b/src/admc/console_types/console_object.cpp
@@ -229,8 +229,6 @@ void console_object_move(ConsoleWidget *console, AdInterface &ad, const QList<QS
 
     console_object_create(console, ad, new_dn_list, new_parent_index);
     console_object_delete(console, old_dn_list, true);
-
-    console->sort_scope();
 }
 
 void console_object_move(ConsoleWidget *console, AdInterface &ad, const QList<QString> &old_dn_list, const QString &new_parent_dn) {
@@ -340,7 +338,6 @@ void console_object_search(ConsoleWidget *console, const QModelIndex &index, con
             }
 
             console_object_create(console, results.values(), persistent_index);
-            console->sort_scope();
         },
         Qt::QueuedConnection);
     QObject::connect(
@@ -401,7 +398,6 @@ void console_object_fetch(ConsoleWidget *console, FilterDialog *filter_dialog, c
             dev_mode_search_results(results, ad, base);
 
             console_object_create(console, results.values(), index);
-            console->sort_scope();
         }
     }
 
@@ -742,8 +738,6 @@ void console_object_drop_objects(ConsoleWidget *console, const QList<QPersistent
             }
         }
     }
-
-    console->sort_scope();
 
     hide_busy_indicator();
 

--- a/src/admc/console_types/console_object.cpp
+++ b/src/admc/console_types/console_object.cpp
@@ -164,13 +164,13 @@ void disable_drag_if_object_cant_be_moved(const QList<QStandardItem *> &items, c
 void console_object_delete(ConsoleWidget *console, const QList<QString> &dn_list, const bool ignore_query_tree) {
     for (const QString &dn : dn_list) {
         // Delete in scope
-        const QList<QPersistentModelIndex> scope_indexes = persistent_index_list(console->search_scope_by_role(ObjectRole_DN, dn, ItemType_Object));
+        const QList<QPersistentModelIndex> scope_indexes = persistent_index_list(console->search_items(ObjectRole_DN, dn, ItemType_Object));
         for (const QPersistentModelIndex &index : scope_indexes) {
             console->delete_item(index);
         }
 
         // Delete in results
-        const QList<QPersistentModelIndex> results_indexes = persistent_index_list(console->search_results_by_role(ObjectRole_DN, dn, ItemType_Object));
+        const QList<QPersistentModelIndex> results_indexes = persistent_index_list(console->search_items(ObjectRole_DN, dn, ItemType_Object));
         for (const QPersistentModelIndex &index : results_indexes) {
             // NOTE: don't touch query tree indexes, they
             // stay around and just go out of date
@@ -218,7 +218,7 @@ void console_object_move(ConsoleWidget *console, AdInterface &ad, const QList<QS
     // loads new object. End result is that new object is
     // duplicated.
     const QModelIndex new_parent_index = [=]() {
-        const QList<QModelIndex> results = console->search_scope_by_role(ObjectRole_DN, new_parent_dn, ItemType_Object);
+        const QList<QModelIndex> results = console->search_items(ObjectRole_DN, new_parent_dn, ItemType_Object);
 
         if (results.size() == 1) {
             return results[0];

--- a/src/admc/console_types/console_object.cpp
+++ b/src/admc/console_types/console_object.cpp
@@ -51,11 +51,11 @@ QStandardItem *object_tree_head = nullptr;
 void console_object_item_data_load(QStandardItem *item, const AdObject &object);
 DropType console_object_get_drop_type(const QModelIndex &dropped, const QModelIndex &target);
 void disable_drag_if_object_cant_be_moved(const QList<QStandardItem *> &items, const AdObject &object);
-bool console_object_scope_and_results_add_check(ConsoleWidget *console, const QModelIndex &parent);
+bool console_object_create_check(ConsoleWidget *console, const QModelIndex &parent);
 void console_object_drop_objects(ConsoleWidget *console, const QList<QPersistentModelIndex> &dropped_list, const QPersistentModelIndex &target);
 void console_object_drop_policies(ConsoleWidget *console, const QList<QPersistentModelIndex> &dropped_list, const QPersistentModelIndex &target, PolicyResultsWidget *policy_results_widget);
 
-void console_object_results_load(const QList<QStandardItem *> row, const AdObject &object) {
+void console_object_load(const QList<QStandardItem *> row, const AdObject &object) {
     // Load attribute columns
     for (int i = 0; i < g_adconfig->get_columns().count(); i++) {
         const QString attribute = g_adconfig->get_columns()[i];
@@ -182,7 +182,7 @@ void console_object_delete(ConsoleWidget *console, const QList<QString> &dn_list
 }
 
 void console_object_create(ConsoleWidget *console, AdInterface &ad, const QList<QString> &dn_list, const QModelIndex &parent) {
-    if (!console_object_scope_and_results_add_check(console, parent)) {
+    if (!console_object_create_check(console, parent)) {
         return;
     }
 
@@ -238,7 +238,7 @@ void console_object_move(ConsoleWidget *console, AdInterface &ad, const QList<QS
 }
 
 // Check parent index before adding objects to console
-bool console_object_scope_and_results_add_check(ConsoleWidget *console, const QModelIndex &parent) {
+bool console_object_create_check(ConsoleWidget *console, const QModelIndex &parent) {
     if (!parent.isValid()) {
         return false;
     }
@@ -255,7 +255,7 @@ bool console_object_scope_and_results_add_check(ConsoleWidget *console, const QM
 }
 
 void console_object_create(ConsoleWidget *console, const QList<AdObject> &object_list, const QModelIndex &parent) {
-    if (!console_object_scope_and_results_add_check(console, parent)) {
+    if (!console_object_create_check(console, parent)) {
         return;
     }
 
@@ -286,7 +286,7 @@ void console_object_create(ConsoleWidget *console, const QList<AdObject> &object
             }
         }();
 
-        console_object_results_load(row, object);
+        console_object_load(row, object);
     }
 }
 

--- a/src/admc/console_types/console_object.h
+++ b/src/admc/console_types/console_object.h
@@ -53,7 +53,6 @@ enum ObjectRole {
 
 extern int console_object_results_id;
 
-void console_object_scope_load(QStandardItem *item, const AdObject &object);
 void console_object_results_load(const QList<QStandardItem *> row, const AdObject &object);
 QList<QString> console_object_header_labels();
 QList<int> console_object_default_columns();

--- a/src/admc/console_types/console_object.h
+++ b/src/admc/console_types/console_object.h
@@ -57,7 +57,7 @@ void console_object_results_load(const QList<QStandardItem *> row, const AdObjec
 QList<QString> console_object_header_labels();
 QList<int> console_object_default_columns();
 QList<QString> console_object_search_attributes();
-void console_object_delete(ConsoleWidget *console, const QList<QString> &dn_list);
+void console_object_delete(ConsoleWidget *console, const QList<QString> &dn_list, const bool delete_in_query_tree = true);
 void console_object_move(ConsoleWidget *console, AdInterface &ad, const QList<QString> &old_dn_list, const QList<QString> &new_dn_list, const QString &new_parent_dn);
 void console_object_move(ConsoleWidget *console, AdInterface &ad, const QList<QString> &old_dn_list, const QString &new_parent_dn);
 void console_object_create(ConsoleWidget *console, const QList<AdObject> &object_list, const QModelIndex &parent);

--- a/src/admc/console_types/console_object.h
+++ b/src/admc/console_types/console_object.h
@@ -53,7 +53,7 @@ enum ObjectRole {
 
 extern int console_object_results_id;
 
-void console_object_results_load(const QList<QStandardItem *> row, const AdObject &object);
+void console_object_load(const QList<QStandardItem *> row, const AdObject &object);
 QList<QString> console_object_header_labels();
 QList<int> console_object_default_columns();
 QList<QString> console_object_search_attributes();

--- a/src/admc/console_types/console_object.h
+++ b/src/admc/console_types/console_object.h
@@ -57,7 +57,7 @@ void console_object_results_load(const QList<QStandardItem *> row, const AdObjec
 QList<QString> console_object_header_labels();
 QList<int> console_object_default_columns();
 QList<QString> console_object_search_attributes();
-void console_object_delete(ConsoleWidget *console, const QList<QString> &dn_list, const bool ignore_query_tree = false);
+void console_object_delete(ConsoleWidget *console, const QList<QString> &dn_list);
 void console_object_move(ConsoleWidget *console, AdInterface &ad, const QList<QString> &old_dn_list, const QList<QString> &new_dn_list, const QString &new_parent_dn);
 void console_object_move(ConsoleWidget *console, AdInterface &ad, const QList<QString> &old_dn_list, const QString &new_parent_dn);
 void console_object_create(ConsoleWidget *console, const QList<AdObject> &object_list, const QModelIndex &parent);
@@ -78,5 +78,7 @@ void object_operation_add_to_group(const QList<QString> &targets, QWidget *paren
 
 bool console_object_is_ou(const QModelIndex &index);
 void console_object_load_domain_head_text(QStandardItem *item);
+
+QStandardItem *console_object_head();
 
 #endif /* CONSOLE_OBJECT_H */

--- a/src/admc/console_types/console_policy.cpp
+++ b/src/admc/console_types/console_policy.cpp
@@ -64,7 +64,7 @@ QList<QString> console_policy_search_attributes() {
 
 void console_policy_create(ConsoleWidget *console, const AdObject &object) {
     const QModelIndex policy_root_index = [&]() {
-        const QList<QModelIndex> results = console->search_scope_by_role(ConsoleRole_Type, ItemType_PolicyRoot);
+        const QList<QModelIndex> results = console->search_items(ConsoleRole_Type, ItemType_PolicyRoot);
 
         if (!results.isEmpty()) {
             return results[0];

--- a/src/admc/console_types/console_policy.cpp
+++ b/src/admc/console_types/console_policy.cpp
@@ -40,6 +40,8 @@
 int policy_container_results_id;
 int policy_results_id;
 
+QStandardItem *policy_tree_head = nullptr;
+
 void console_policy_results_load(const QList<QStandardItem *> &row, const AdObject &object) {
     QStandardItem *main_item = row[0];
     main_item->setIcon(QIcon::fromTheme("folder-templates"));
@@ -63,33 +65,17 @@ QList<QString> console_policy_search_attributes() {
 }
 
 void console_policy_create(ConsoleWidget *console, const AdObject &object) {
-    const QModelIndex policy_root_index = [&]() {
-        const QList<QModelIndex> results = console->search_items(ConsoleRole_Type, ItemType_PolicyRoot);
-
-        if (!results.isEmpty()) {
-            return results[0];
-        } else {
-            return QModelIndex();
-        }
-    }();
-
-    if (!policy_root_index.isValid()) {
-        qDebug() << "Failed to find policy root";
-
-        return;
-    }
-
-    const QList<QStandardItem *> results_row = console->add_scope_item(policy_results_id, ScopeNodeType_Static, policy_root_index);
+    const QList<QStandardItem *> results_row = console->add_scope_item(policy_results_id, ScopeNodeType_Static, policy_tree_head->index());
 
     console_policy_results_load(results_row, object);
 }
 
 void console_policy_tree_init(ConsoleWidget *console, AdInterface &ad) {
-    QStandardItem *top_item = console->add_top_item(policy_container_results_id, ScopeNodeType_Static);
-    top_item->setText(QCoreApplication::translate("policy", "Group Policy Objects"));
-    top_item->setDragEnabled(false);
-    top_item->setIcon(QIcon::fromTheme("folder"));
-    top_item->setData(ItemType_PolicyRoot, ConsoleRole_Type);
+    policy_tree_head = console->add_top_item(policy_container_results_id, ScopeNodeType_Static);
+    policy_tree_head->setText(QCoreApplication::translate("policy", "Group Policy Objects"));
+    policy_tree_head->setDragEnabled(false);
+    policy_tree_head->setIcon(QIcon::fromTheme("folder"));
+    policy_tree_head->setData(ItemType_PolicyRoot, ConsoleRole_Type);
 
     // Add children
     const QString base = g_adconfig->domain_head();

--- a/src/admc/console_types/console_policy.cpp
+++ b/src/admc/console_types/console_policy.cpp
@@ -40,29 +40,14 @@
 int policy_container_results_id;
 int policy_results_id;
 
-void setup_policy_item_data(QStandardItem *item, const AdObject &object);
-void console_policy_results_load(const QList<QStandardItem *> &row, const AdObject &object);
-
-void console_policy_scope_load(QStandardItem *item, const AdObject &object) {
-    const QString display_name = object.get_string(ATTRIBUTE_DISPLAY_NAME);
-
-    item->setText(display_name);
-
-    setup_policy_item_data(item, object);
-}
-
 void console_policy_results_load(const QList<QStandardItem *> &row, const AdObject &object) {
+    QStandardItem *main_item = row[0];
+    main_item->setIcon(QIcon::fromTheme("folder-templates"));
+    main_item->setData(ItemType_Policy, ConsoleRole_Type);
+    main_item->setData(object.get_dn(), PolicyRole_DN);
+    
     const QString display_name = object.get_string(ATTRIBUTE_DISPLAY_NAME);
-
     row[0]->setText(display_name);
-
-    setup_policy_item_data(row[0], object);
-}
-
-void setup_policy_item_data(QStandardItem *item, const AdObject &object) {
-    item->setIcon(QIcon::fromTheme("folder-templates"));
-    item->setData(ItemType_Policy, ConsoleRole_Type);
-    item->setData(object.get_dn(), PolicyRole_DN);
 }
 
 QList<QString> console_policy_header_labels() {
@@ -98,7 +83,6 @@ void console_policy_create(ConsoleWidget *console, const AdObject &object) {
     QList<QStandardItem *> results_row;
     console->add_buddy_scope_and_results(policy_results_id, ScopeNodeType_Static, policy_root_index, &scope_item, &results_row);
 
-    console_policy_scope_load(scope_item, object);
     console_policy_results_load(results_row, object);
 }
 

--- a/src/admc/console_types/console_policy.cpp
+++ b/src/admc/console_types/console_policy.cpp
@@ -79,20 +79,17 @@ void console_policy_create(ConsoleWidget *console, const AdObject &object) {
         return;
     }
 
-    QStandardItem *scope_item;
-    QList<QStandardItem *> results_row;
-    console->add_buddy_scope_and_results(policy_results_id, ScopeNodeType_Static, policy_root_index, &scope_item, &results_row);
+    const QList<QStandardItem *> results_row = console->add_scope_item(policy_results_id, ScopeNodeType_Static, policy_root_index);
 
     console_policy_results_load(results_row, object);
 }
 
 void console_policy_tree_init(ConsoleWidget *console, AdInterface &ad) {
-    // Add head item
-    QStandardItem *head_item = console->add_scope_item(policy_container_results_id, ScopeNodeType_Static, QModelIndex());
-    head_item->setText(QCoreApplication::translate("policy", "Group Policy Objects"));
-    head_item->setDragEnabled(false);
-    head_item->setIcon(QIcon::fromTheme("folder"));
-    head_item->setData(ItemType_PolicyRoot, ConsoleRole_Type);
+    QStandardItem *top_item = console->add_top_item(policy_container_results_id, ScopeNodeType_Static);
+    top_item->setText(QCoreApplication::translate("policy", "Group Policy Objects"));
+    top_item->setDragEnabled(false);
+    top_item->setIcon(QIcon::fromTheme("folder"));
+    top_item->setData(ItemType_PolicyRoot, ConsoleRole_Type);
 
     // Add children
     const QString base = g_adconfig->domain_head();

--- a/src/admc/console_types/console_policy.cpp
+++ b/src/admc/console_types/console_policy.cpp
@@ -42,7 +42,7 @@ int policy_results_id;
 
 QStandardItem *policy_tree_head = nullptr;
 
-void console_policy_results_load(const QList<QStandardItem *> &row, const AdObject &object) {
+void console_policy_load(const QList<QStandardItem *> &row, const AdObject &object) {
     QStandardItem *main_item = row[0];
     main_item->setIcon(QIcon::fromTheme("folder-templates"));
     main_item->setData(ItemType_Policy, ConsoleRole_Type);
@@ -65,9 +65,9 @@ QList<QString> console_policy_search_attributes() {
 }
 
 void console_policy_create(ConsoleWidget *console, const AdObject &object) {
-    const QList<QStandardItem *> results_row = console->add_scope_item(policy_results_id, ScopeNodeType_Static, policy_tree_head->index());
+    const QList<QStandardItem *> row = console->add_scope_item(policy_results_id, ScopeNodeType_Static, policy_tree_head->index());
 
-    console_policy_results_load(results_row, object);
+    console_policy_load(row, object);
 }
 
 void console_policy_tree_init(ConsoleWidget *console, AdInterface &ad) {

--- a/src/admc/console_types/console_policy.h
+++ b/src/admc/console_types/console_policy.h
@@ -46,7 +46,7 @@ enum PolicyRole {
 extern int policy_container_results_id;
 extern int policy_results_id;
 
-void console_policy_results_load(const QList<QStandardItem *> &row, const AdObject &object);
+void console_policy_load(const QList<QStandardItem *> &row, const AdObject &object);
 QList<QString> console_policy_header_labels();
 QList<int> console_policy_default_columns();
 QList<QString> console_policy_search_attributes();

--- a/src/admc/console_types/console_policy.h
+++ b/src/admc/console_types/console_policy.h
@@ -46,7 +46,6 @@ enum PolicyRole {
 extern int policy_container_results_id;
 extern int policy_results_id;
 
-void console_policy_scope_load(QStandardItem *item, const AdObject &object);
 void console_policy_results_load(const QList<QStandardItem *> &row, const AdObject &object);
 QList<QString> console_policy_header_labels();
 QList<int> console_policy_default_columns();

--- a/src/admc/console_types/console_query.cpp
+++ b/src/admc/console_types/console_query.cpp
@@ -386,7 +386,7 @@ void console_query_actions_get_state(const QModelIndex &index, const bool single
 }
 
 QModelIndex console_query_get_root_index(ConsoleWidget *console) {
-    const QList<QModelIndex> results = console->search_scope_by_role(ConsoleRole_Type, ItemType_QueryRoot);
+    const QList<QModelIndex> results = console->search_items(ConsoleRole_Type, ItemType_QueryRoot);
 
     if (!results.isEmpty()) {
         return results[0];

--- a/src/admc/console_types/console_query.cpp
+++ b/src/admc/console_types/console_query.cpp
@@ -126,12 +126,10 @@ void console_query_folder_load(const QList<QStandardItem *> &row, const QString 
 }
 
 QModelIndex console_query_folder_create(ConsoleWidget *console, const QString &name, const QString &description, const QModelIndex &parent) {
-    QStandardItem *scope_item;
-    QList<QStandardItem *> row;
-    console->add_buddy_scope_and_results(console_query_folder_results_id, ScopeNodeType_Static, parent, &scope_item, &row);
+    const QList<QStandardItem *> row = console->add_scope_item(console_query_folder_results_id, ScopeNodeType_Static, parent);
     console_query_folder_load(row, name, description);
 
-    return scope_item->index();
+    return row[0]->index();
 }
 
 void console_query_item_load(const QList<QStandardItem *> row, const QString &name, const QString &description, const QString &filter, const QByteArray &filter_state, const QString &base, const bool scope_is_children) {
@@ -149,9 +147,7 @@ void console_query_item_load(const QList<QStandardItem *> row, const QString &na
 }
 
 void console_query_item_create(ConsoleWidget *console, const QString &name, const QString &description, const QString &filter, const QByteArray &filter_state, const QString &base, const bool scope_is_children, const QModelIndex &parent) {
-    QStandardItem *scope_item;
-    QList<QStandardItem *> row;
-    console->add_buddy_scope_and_results(console_object_results_id, ScopeNodeType_Dynamic, parent, &scope_item, &row);
+    const QList<QStandardItem *> row = console->add_scope_item(console_object_results_id, ScopeNodeType_Dynamic, parent);
 
     console_query_item_load(row, name, description, filter, filter_state, base, scope_is_children);
 }
@@ -173,19 +169,18 @@ void console_query_item_fetch(ConsoleWidget *console, const QModelIndex &index) 
 }
 
 void console_query_tree_init(ConsoleWidget *console) {
-    // Add head item
-    QStandardItem *head_item = console->add_scope_item(console_query_folder_results_id, ScopeNodeType_Static, QModelIndex());
-    head_item->setText(QCoreApplication::translate("query", "Saved Queries"));
-    head_item->setIcon(QIcon::fromTheme("folder"));
-    head_item->setData(ItemType_QueryRoot, ConsoleRole_Type);
-    head_item->setDragEnabled(false);
+    QStandardItem *top_item = console->add_top_item(console_query_folder_results_id, ScopeNodeType_Static);
+    top_item->setText(QCoreApplication::translate("query", "Saved Queries"));
+    top_item->setIcon(QIcon::fromTheme("folder"));
+    top_item->setData(ItemType_QueryRoot, ConsoleRole_Type);
+    top_item->setDragEnabled(false);
 
     // Add rest of tree
     const QHash<QString, QVariant> folder_list = g_settings->get_variant(VariantSetting_QueryFolders).toHash();
     const QHash<QString, QVariant> item_list = g_settings->get_variant(VariantSetting_QueryItems).toHash();
 
     QStack<QPersistentModelIndex> folder_stack;
-    folder_stack.append(head_item->index());
+    folder_stack.append(top_item->index());
     while (!folder_stack.isEmpty()) {
         const QPersistentModelIndex folder_index = folder_stack.pop();
 

--- a/src/admc/console_types/console_query.cpp
+++ b/src/admc/console_types/console_query.cpp
@@ -381,18 +381,6 @@ void console_query_actions_get_state(const QModelIndex &index, const bool single
     }
 }
 
-QModelIndex console_query_get_root_index(ConsoleWidget *console) {
-    const QList<QModelIndex> results = console->search_items(query_tree_head->index(), ConsoleRole_Type, ItemType_QueryRoot);
-
-    if (!results.isEmpty()) {
-        return results[0];
-    } else {
-        qDebug() << "Failed to find query root";
-
-        return QModelIndex();
-    }
-}
-
 void console_query_can_drop(const QList<QPersistentModelIndex> &dropped_list, const QPersistentModelIndex &target, const QSet<ItemType> &dropped_types, bool *ok) {
     const bool dropped_are_query_item_or_folder = (dropped_types - QSet<ItemType>({ItemType_QueryItem, ItemType_QueryFolder})).isEmpty();
     if (!dropped_are_query_item_or_folder) {

--- a/src/admc/console_types/console_query.cpp
+++ b/src/admc/console_types/console_query.cpp
@@ -596,3 +596,7 @@ void console_query_item_load(ConsoleWidget *console, const QHash<QString, QVaria
 
     console_query_item_create(console, name, description, filter, filter_state, base, scope_is_children, parent_index);
 }
+
+QStandardItem *console_query_head() {
+    return query_tree_head;
+}

--- a/src/admc/console_types/console_query.cpp
+++ b/src/admc/console_types/console_query.cpp
@@ -204,9 +204,9 @@ void console_query_tree_init(ConsoleWidget *console) {
 
                 const QString name = data["name"].toString();
                 const QString description = data["description"].toString();
-                const QPersistentModelIndex child_scope_index = console_query_folder_create(console, name, description, folder_index);
+                const QPersistentModelIndex child_index = console_query_folder_create(console, name, description, folder_index);
 
-                folder_stack.append(child_scope_index);
+                folder_stack.append(child_index);
             }
         }
     }

--- a/src/admc/console_types/console_query.cpp
+++ b/src/admc/console_types/console_query.cpp
@@ -512,7 +512,7 @@ void console_query_move(ConsoleWidget *console, const QList<QPersistentModelInde
 }
 
 void console_query_export(ConsoleWidget *console) {
-    const QModelIndex index = get_selected_scope_index(console);
+    const QModelIndex index = console->get_selected_item();
 
     const QString file_path = [&]() {
         const QString query_name = index.data(Qt::DisplayRole).toString();
@@ -539,7 +539,7 @@ void console_query_export(ConsoleWidget *console) {
 }
 
 void console_query_import(ConsoleWidget *console) {
-    const QModelIndex parent_index = get_selected_scope_index(console);
+    const QModelIndex parent_index = console->get_selected_item();
 
     const QString file_path = [&]() {
         const QString caption = QCoreApplication::translate("console_query.cpp", "Import Query");
@@ -580,17 +580,17 @@ void console_query_import(ConsoleWidget *console) {
 }
 
 void console_query_cut(ConsoleWidget *console) {
-    copied_index = get_selected_scope_index(console);
+    copied_index = console->get_selected_item();
     copied_index_is_cut = true;
 }
 
 void console_query_copy(ConsoleWidget *console) {
-    copied_index = get_selected_scope_index(console);
+    copied_index = console->get_selected_item();
     copied_index_is_cut = false;
 }
 
 void console_query_paste(ConsoleWidget *console) {
-    const QModelIndex parent_index = get_selected_scope_index(console);
+    const QModelIndex parent_index = console->get_selected_item();
     const bool delete_old_branch = copied_index_is_cut;
     console_query_move(console, {copied_index}, parent_index, delete_old_branch);
 }

--- a/src/admc/console_types/console_query.cpp
+++ b/src/admc/console_types/console_query.cpp
@@ -48,6 +48,7 @@ enum QueryColumn {
 };
 
 int console_query_folder_results_id;
+QStandardItem *query_tree_head = nullptr;
 
 bool copied_index_is_cut = false;
 QPersistentModelIndex copied_index;
@@ -169,18 +170,18 @@ void console_query_item_fetch(ConsoleWidget *console, const QModelIndex &index) 
 }
 
 void console_query_tree_init(ConsoleWidget *console) {
-    QStandardItem *top_item = console->add_top_item(console_query_folder_results_id, ScopeNodeType_Static);
-    top_item->setText(QCoreApplication::translate("query", "Saved Queries"));
-    top_item->setIcon(QIcon::fromTheme("folder"));
-    top_item->setData(ItemType_QueryRoot, ConsoleRole_Type);
-    top_item->setDragEnabled(false);
+    query_tree_head = console->add_top_item(console_query_folder_results_id, ScopeNodeType_Static);
+    query_tree_head->setText(QCoreApplication::translate("query", "Saved Queries"));
+    query_tree_head->setIcon(QIcon::fromTheme("folder"));
+    query_tree_head->setData(ItemType_QueryRoot, ConsoleRole_Type);
+    query_tree_head->setDragEnabled(false);
 
     // Add rest of tree
     const QHash<QString, QVariant> folder_list = g_settings->get_variant(VariantSetting_QueryFolders).toHash();
     const QHash<QString, QVariant> item_list = g_settings->get_variant(VariantSetting_QueryItems).toHash();
 
     QStack<QPersistentModelIndex> folder_stack;
-    folder_stack.append(top_item->index());
+    folder_stack.append(query_tree_head->index());
     while (!folder_stack.isEmpty()) {
         const QPersistentModelIndex folder_index = folder_stack.pop();
 
@@ -218,15 +219,10 @@ void console_query_tree_save(ConsoleWidget *console) {
     QHash<QString, QVariant> folder_list;
     QHash<QString, QVariant> item_list;
 
-    const QModelIndex query_root_index = console_query_get_root_index(console);
-    if (!query_root_index.isValid()) {
-        return;
-    }
-
     QStack<QModelIndex> stack;
-    stack.append(query_root_index);
+    stack.append(query_tree_head->index());
 
-    const QAbstractItemModel *model = query_root_index.model();
+    const QAbstractItemModel *model = query_tree_head->model();
 
     while (!stack.isEmpty()) {
         const QModelIndex index = stack.pop();
@@ -386,7 +382,7 @@ void console_query_actions_get_state(const QModelIndex &index, const bool single
 }
 
 QModelIndex console_query_get_root_index(ConsoleWidget *console) {
-    const QList<QModelIndex> results = console->search_items(ConsoleRole_Type, ItemType_QueryRoot);
+    const QList<QModelIndex> results = console->search_items(query_tree_head->index(), ConsoleRole_Type, ItemType_QueryRoot);
 
     if (!results.isEmpty()) {
         return results[0];

--- a/src/admc/console_types/console_query.cpp
+++ b/src/admc/console_types/console_query.cpp
@@ -476,7 +476,6 @@ void console_query_move(ConsoleWidget *console, const QList<QPersistentModelInde
         }
     }
 
-    console->sort_scope();
     console_query_tree_save(console);
 }
 

--- a/src/admc/console_types/console_query.cpp
+++ b/src/admc/console_types/console_query.cpp
@@ -297,7 +297,7 @@ bool console_query_or_folder_name_is_good(ConsoleWidget *console, const QString 
     const QList<QString> sibling_names = [&]() {
         QList<QString> out;
 
-        QStandardItemModel *model = console->scope_model();
+        const QAbstractItemModel *model = parent_index.model();
 
         for (int row = 0; row < model->rowCount(parent_index); row++) {
             const QModelIndex sibling = model->index(row, 0, parent_index);

--- a/src/admc/console_types/console_query.cpp
+++ b/src/admc/console_types/console_query.cpp
@@ -115,59 +115,45 @@ QString console_query_folder_path(const QModelIndex &index) {
     return path;
 }
 
-void console_query_folder_load(QStandardItem *scope_item, const QList<QStandardItem *> &results_row, const QString &name, const QString &description) {
-    auto load_main_item = [&](QStandardItem *item) {
-        item->setData(description, QueryItemRole_Description);
-        item->setData(ItemType_QueryFolder, ConsoleRole_Type);
-        item->setIcon(QIcon::fromTheme("folder"));
-    };
+void console_query_folder_load(const QList<QStandardItem *> &row, const QString &name, const QString &description) {
+    QStandardItem *main_item = row[0];
+    main_item->setData(description, QueryItemRole_Description);
+    main_item->setData(ItemType_QueryFolder, ConsoleRole_Type);
+    main_item->setIcon(QIcon::fromTheme("folder"));
 
-    load_main_item(scope_item);
-    scope_item->setText(name);
-
-    load_main_item(results_row[0]);
-    results_row[QueryColumn_Name]->setText(name);
-    results_row[QueryColumn_Description]->setText(description);
+    row[QueryColumn_Name]->setText(name);
+    row[QueryColumn_Description]->setText(description);
 }
 
 QModelIndex console_query_folder_create(ConsoleWidget *console, const QString &name, const QString &description, const QModelIndex &parent) {
     QStandardItem *scope_item;
-    QList<QStandardItem *> results_row;
-    console->add_buddy_scope_and_results(console_query_folder_results_id, ScopeNodeType_Static, parent, &scope_item, &results_row);
-    console_query_folder_load(scope_item, results_row, name, description);
+    QList<QStandardItem *> row;
+    console->add_buddy_scope_and_results(console_query_folder_results_id, ScopeNodeType_Static, parent, &scope_item, &row);
+    console_query_folder_load(row, name, description);
 
     return scope_item->index();
 }
 
-void console_query_item_load(QStandardItem *scope_item, const QList<QStandardItem *> results_row, const QString &name, const QString &description, const QString &filter, const QByteArray &filter_state, const QString &base, const bool scope_is_children) {
-    auto load_main_item = [&](QStandardItem *item) {
-        item->setData(ItemType_QueryItem, ConsoleRole_Type);
-        item->setData(description, QueryItemRole_Description);
-        item->setData(filter, QueryItemRole_Filter);
-        item->setData(filter_state, QueryItemRole_FilterState);
-        item->setData(base, QueryItemRole_Base);
-        item->setData(scope_is_children, QueryItemRole_ScopeIsChildren);
-        item->setIcon(QIcon::fromTheme("emblem-system"));
-    };
+void console_query_item_load(const QList<QStandardItem *> row, const QString &name, const QString &description, const QString &filter, const QByteArray &filter_state, const QString &base, const bool scope_is_children) {
+    QStandardItem *main_item = row[0];
+    main_item->setData(ItemType_QueryItem, ConsoleRole_Type);
+    main_item->setData(description, QueryItemRole_Description);
+    main_item->setData(filter, QueryItemRole_Filter);
+    main_item->setData(filter_state, QueryItemRole_FilterState);
+    main_item->setData(base, QueryItemRole_Base);
+    main_item->setData(scope_is_children, QueryItemRole_ScopeIsChildren);
+    main_item->setIcon(QIcon::fromTheme("emblem-system"));
 
-    if (scope_item != nullptr) {
-        load_main_item(scope_item);
-        scope_item->setText(name);
-    }
-
-    if (!results_row.isEmpty()) {
-        load_main_item(results_row[0]);
-        results_row[QueryColumn_Name]->setText(name);
-        results_row[QueryColumn_Description]->setText(description);
-    }
+    row[QueryColumn_Name]->setText(name);
+    row[QueryColumn_Description]->setText(description);
 }
 
 void console_query_item_create(ConsoleWidget *console, const QString &name, const QString &description, const QString &filter, const QByteArray &filter_state, const QString &base, const bool scope_is_children, const QModelIndex &parent) {
     QStandardItem *scope_item;
-    QList<QStandardItem *> results_row;
-    console->add_buddy_scope_and_results(console_object_results_id, ScopeNodeType_Dynamic, parent, &scope_item, &results_row);
+    QList<QStandardItem *> row;
+    console->add_buddy_scope_and_results(console_object_results_id, ScopeNodeType_Dynamic, parent, &scope_item, &row);
 
-    console_query_item_load(scope_item, results_row, name, description, filter, filter_state, base, scope_is_children);
+    console_query_item_load(row, name, description, filter, filter_state, base, scope_is_children);
 }
 
 void console_query_item_fetch(ConsoleWidget *console, const QModelIndex &index) {

--- a/src/admc/console_types/console_query.h
+++ b/src/admc/console_types/console_query.h
@@ -48,10 +48,10 @@ extern int console_query_folder_results_id;
 
 QList<QString> console_query_folder_header_labels();
 QList<int> console_query_folder_default_columns();
-void console_query_folder_load(QStandardItem *scope_item, const QList<QStandardItem *> &results_row, const QString &name, const QString &description);
+void console_query_folder_load(const QList<QStandardItem *> &row, const QString &name, const QString &description);
 // Returns index of the scope item
 QModelIndex console_query_folder_create(ConsoleWidget *console, const QString &name, const QString &description, const QModelIndex &parent);
-void console_query_item_load(QStandardItem *scope_item, const QList<QStandardItem *> results_row, const QString &name, const QString &description, const QString &filter, const QByteArray &filter_state, const QString &base, const bool scope_is_children);
+void console_query_item_load(const QList<QStandardItem *> row, const QString &name, const QString &description, const QString &filter, const QByteArray &filter_state, const QString &base, const bool scope_is_children);
 void console_query_item_create(ConsoleWidget *console, const QString &name, const QString &description, const QString &filter, const QByteArray &filter_state, const QString &base, const bool scope_is_children, const QModelIndex &parent);
 void console_query_item_fetch(ConsoleWidget *console, const QModelIndex &index);
 void console_query_tree_init(ConsoleWidget *console);

--- a/src/admc/console_types/console_query.h
+++ b/src/admc/console_types/console_query.h
@@ -49,7 +49,6 @@ extern int console_query_folder_results_id;
 QList<QString> console_query_folder_header_labels();
 QList<int> console_query_folder_default_columns();
 void console_query_folder_load(const QList<QStandardItem *> &row, const QString &name, const QString &description);
-// Returns index of the scope item
 QModelIndex console_query_folder_create(ConsoleWidget *console, const QString &name, const QString &description, const QModelIndex &parent);
 void console_query_item_load(const QList<QStandardItem *> row, const QString &name, const QString &description, const QString &filter, const QByteArray &filter_state, const QString &base, const bool scope_is_children);
 void console_query_item_create(ConsoleWidget *console, const QString &name, const QString &description, const QString &filter, const QByteArray &filter_state, const QString &base, const bool scope_is_children, const QModelIndex &parent);

--- a/src/admc/console_types/console_query.h
+++ b/src/admc/console_types/console_query.h
@@ -56,7 +56,7 @@ void console_query_item_create(ConsoleWidget *console, const QString &name, cons
 void console_query_item_fetch(ConsoleWidget *console, const QModelIndex &index);
 void console_query_tree_init(ConsoleWidget *console);
 void console_query_tree_save(ConsoleWidget *console);
-bool console_query_or_folder_name_is_good(const QString &name, const QModelIndex &parent_index, QWidget *parent_widget, const QModelIndex &current_index);
+bool console_query_or_folder_name_is_good(ConsoleWidget *console, const QString &name, const QModelIndex &parent_index, QWidget *parent_widget, const QModelIndex &current_index);
 void console_query_actions_add_to_menu(ConsoleActions *actions, QMenu *menu);
 void console_query_actions_get_state(const QModelIndex &index, const bool single_selection, QSet<ConsoleAction> *visible_actions, QSet<ConsoleAction> *disabled_actions);
 QString console_query_folder_path(const QModelIndex &index);

--- a/src/admc/console_types/console_query.h
+++ b/src/admc/console_types/console_query.h
@@ -60,7 +60,6 @@ bool console_query_or_folder_name_is_good(ConsoleWidget *console, const QString 
 void console_query_actions_add_to_menu(ConsoleActions *actions, QMenu *menu);
 void console_query_actions_get_state(const QModelIndex &index, const bool single_selection, QSet<ConsoleAction> *visible_actions, QSet<ConsoleAction> *disabled_actions);
 QString console_query_folder_path(const QModelIndex &index);
-QModelIndex console_query_get_root_index(ConsoleWidget *console);
 void console_query_can_drop(const QList<QPersistentModelIndex> &dropped_list, const QPersistentModelIndex &target, const QSet<ItemType> &dropped_types, bool *ok);
 void console_query_drop(ConsoleWidget *console, const QList<QPersistentModelIndex> &dropped_list, const QPersistentModelIndex &target);
 void console_query_move(ConsoleWidget *console, const QList<QPersistentModelIndex> &index_list, const QModelIndex &new_parent_index, const bool delete_old_branch = true);

--- a/src/admc/console_types/console_query.h
+++ b/src/admc/console_types/console_query.h
@@ -69,5 +69,6 @@ void console_query_import(ConsoleWidget *console);
 void console_query_cut(ConsoleWidget *console);
 void console_query_copy(ConsoleWidget *console);
 void console_query_paste(ConsoleWidget *console);
+QStandardItem *console_query_head();
 
 #endif /* CONSOLE_QUERY_H */

--- a/src/admc/console_widget/console_widget.cpp
+++ b/src/admc/console_widget/console_widget.cpp
@@ -572,7 +572,7 @@ void ConsoleWidgetPrivate::on_selection_changed() {
         refresh_action->setEnabled(false);
     }
 
-    emit q->selection_changed();
+    emit q->actions_changed();
 }
 
 void ConsoleWidgetPrivate::on_context_menu(const QPoint pos) {

--- a/src/admc/console_widget/console_widget.cpp
+++ b/src/admc/console_widget/console_widget.cpp
@@ -450,6 +450,12 @@ QList<QModelIndex> ConsoleWidget::get_selected_items() const {
     }
 }
 
+QModelIndex ConsoleWidget::get_selected_item() const {
+    const QList<QModelIndex> selected_list = get_selected_items();
+
+    return selected_list[0];
+}
+
 QList<QModelIndex> ConsoleWidget::search_scope_by_role(int role, const QVariant &value, const int type) const {
     const QList<QModelIndex> all_matches = d->scope_model->match(d->scope_model->index(0, 0), role, value, -1, Qt::MatchFlags(Qt::MatchExactly | Qt::MatchRecursive));
 

--- a/src/admc/console_widget/console_widget.cpp
+++ b/src/admc/console_widget/console_widget.cpp
@@ -465,7 +465,7 @@ QStandardItem *ConsoleWidget::get_item(const QModelIndex &index) const {
 QList<QStandardItem *> ConsoleWidget::get_row(const QModelIndex &index) const {
     QList<QStandardItem *> row;
 
-    for (int col = 0; col < d->scope_model->columnCount(); col++) {
+    for (int col = 0; col < d->scope_model->columnCount(index.parent()); col++) {
         QStandardItem *item = d->scope_model->item(index.row(), col);
         row.append(item);
     }

--- a/src/admc/console_widget/console_widget.cpp
+++ b/src/admc/console_widget/console_widget.cpp
@@ -481,10 +481,6 @@ QWidget *ConsoleWidget::get_description_bar() const {
     return d->description_bar;
 }
 
-QStandardItemModel *ConsoleWidget::scope_model() const {
-    return d->scope_model;
-}
-
 void ConsoleWidgetPrivate::connect_to_drag_model(ConsoleDragModel *model) {
     connect(
         model, &ConsoleDragModel::start_drag,

--- a/src/admc/console_widget/console_widget.cpp
+++ b/src/admc/console_widget/console_widget.cpp
@@ -521,6 +521,10 @@ QWidget *ConsoleWidget::get_description_bar() const {
     return d->description_bar;
 }
 
+QStandardItemModel *ConsoleWidget::scope_model() const {
+    return d->scope_model;
+}
+
 void ConsoleWidgetPrivate::connect_to_drag_model(ConsoleDragModel *model) {
     connect(
         model, &ConsoleDragModel::start_drag,
@@ -963,15 +967,4 @@ QModelIndex console_item_get_buddy(const QModelIndex &index) {
     const QModelIndex buddy = index.data(ConsoleRole_Buddy).toModelIndex();
 
     return buddy;
-}
-
-// TODO: rename
-QModelIndex console_item_convert_to_scope_index(const QModelIndex &index) {
-    if (console_item_is_scope(index)) {
-        return index;
-    } else {
-        const QModelIndex buddy = console_item_get_buddy(index);
-
-        return buddy;
-    }
 }

--- a/src/admc/console_widget/console_widget.cpp
+++ b/src/admc/console_widget/console_widget.cpp
@@ -426,7 +426,7 @@ QList<QModelIndex> ConsoleWidget::get_selected_items() const {
     const QList<QModelIndex> scope_selected = [&]() {
         QList<QModelIndex> out;
 
-        const QList<QModelIndex> selected_proxy = d->scope_view->selectionModel()->selectedIndexes();
+        const QList<QModelIndex> selected_proxy = d->scope_view->selectionModel()->selectedRows();
         for (const QModelIndex &index : selected_proxy) {
             const QModelIndex source_index = d->scope_proxy_model->mapToSource(index);
             out.append(source_index);

--- a/src/admc/console_widget/console_widget.cpp
+++ b/src/admc/console_widget/console_widget.cpp
@@ -462,7 +462,8 @@ QList<QStandardItem *> ConsoleWidget::get_row(const QModelIndex &index) const {
     QList<QStandardItem *> row;
 
     for (int col = 0; col < d->scope_model->columnCount(index.parent()); col++) {
-        QStandardItem *item = d->scope_model->item(index.row(), col);
+        const QModelIndex sibling = index.siblingAtColumn(col);
+        QStandardItem *item = d->scope_model->itemFromIndex(sibling);
         row.append(item);
     }
 

--- a/src/admc/console_widget/console_widget.cpp
+++ b/src/admc/console_widget/console_widget.cpp
@@ -286,21 +286,7 @@ void ConsoleWidget::delete_item(const QModelIndex &index) {
         set_current_scope(index.parent());
     }
 
-    // NOTE: i *think* discarding const from model is fine.
-    // Qt's reason: "A const pointer to the model is
-    // returned because calls to non-const functions of the
-    // model might invalidate the model index and possibly
-    // crash your application.". Index becoming invalid is
-    // expected since we're deleting it from the model.
-
-    // Remove buddy item
-    const QModelIndex buddy = console_item_get_buddy(index);
-    if (buddy.isValid()) {
-        ((QAbstractItemModel *) buddy.model())->removeRows(buddy.row(), 1, buddy.parent());
-    }
-
-    // Remove item from it's own model
-    ((QAbstractItemModel *) index.model())->removeRows(index.row(), 1, index.parent());
+    d->scope_model->removeRows(index.row(), 1, index.parent());
 }
 
 void ConsoleWidget::set_current_scope(const QModelIndex &index) {
@@ -409,12 +395,9 @@ void ConsoleWidget::set_item_fetching(const QModelIndex &scope_index, const bool
 }
 
 bool console_get_item_fetching(const QModelIndex &index) {
-    const bool index_fetching = index.data(ConsoleRole_Fetching).toBool();
+    const bool is_fetching = index.data(ConsoleRole_Fetching).toBool();
 
-    const QModelIndex buddy = console_item_get_buddy(index);
-    const bool buddy_fetching = buddy.data(ConsoleRole_Fetching).toBool();
-
-    return (index_fetching || buddy_fetching);
+    return is_fetching;
 }
 
 QList<QModelIndex> ConsoleWidget::get_selected_items() const {
@@ -955,16 +938,4 @@ QList<QModelIndex> filter_indexes_by_type(const QList<QModelIndex> &indexes, con
     }
 
     return out;
-}
-
-bool console_item_is_scope(const QModelIndex &index) {
-    const bool is_scope = index.data(ConsoleRole_IsScope).toBool();
-
-    return is_scope;
-}
-
-QModelIndex console_item_get_buddy(const QModelIndex &index) {
-    const QModelIndex buddy = index.data(ConsoleRole_Buddy).toModelIndex();
-
-    return buddy;
 }

--- a/src/admc/console_widget/console_widget.cpp
+++ b/src/admc/console_widget/console_widget.cpp
@@ -429,7 +429,8 @@ QModelIndex ConsoleWidget::get_selected_item() const {
 }
 
 QList<QModelIndex> ConsoleWidget::search_items(const QModelIndex &parent, int role, const QVariant &value, const int type) const {
-    const QList<QModelIndex> all_matches = d->scope_model->match(parent, role, value, -1, Qt::MatchFlags(Qt::MatchExactly | Qt::MatchRecursive));
+    const QModelIndex start = get_item(parent)->child(0, 0)->index();
+    const QList<QModelIndex> all_matches = d->scope_model->match(start, role, value, -1, Qt::MatchFlags(Qt::MatchExactly | Qt::MatchRecursive));
 
     const QList<QModelIndex> matches = filter_indexes_by_type(all_matches, type);
 

--- a/src/admc/console_widget/console_widget.cpp
+++ b/src/admc/console_widget/console_widget.cpp
@@ -380,13 +380,8 @@ void ConsoleWidget::set_description_bar_text(const QString &text) {
 // NOTE: this role is done through setter/getter because we
 // need to call on_selection_changed() in setter() to update
 // actions
-void ConsoleWidget::set_item_fetching(const QModelIndex &scope_index, const bool enabled) {
-    QStandardItem *item = get_scope_item(scope_index);
-
-    if (item == nullptr) {
-        return;
-    }
-
+void ConsoleWidget::set_item_fetching(const QModelIndex &index, const bool enabled) {
+    QStandardItem *item = get_item(index);
     item->setData(enabled, ConsoleRole_Fetching);
 
     d->on_selection_changed();
@@ -463,13 +458,11 @@ int ConsoleWidget::get_current_results_count() const {
     return d->scope_model->rowCount(current_scope);
 }
 
-QStandardItem *ConsoleWidget::get_scope_item(const QModelIndex &scope_index) const {
-    QStandardItem *item = d->scope_model->itemFromIndex(scope_index);
-
-    return item;
+QStandardItem *ConsoleWidget::get_item(const QModelIndex &index) const {
+    return d->scope_model->itemFromIndex(index);
 }
 
-QList<QStandardItem *> ConsoleWidget::get_results_row(const QModelIndex &index) const {
+QList<QStandardItem *> ConsoleWidget::get_row(const QModelIndex &index) const {
     QList<QStandardItem *> row;
 
     for (int col = 0; col < d->scope_model->columnCount(); col++) {

--- a/src/admc/console_widget/console_widget.cpp
+++ b/src/admc/console_widget/console_widget.cpp
@@ -486,12 +486,6 @@ QList<QStandardItem *> ConsoleWidget::get_results_row(const QModelIndex &index) 
     return row;
 }
 
-QModelIndex ConsoleWidget::get_scope_parent(const QModelIndex &index) const {
-    const QModelIndex scope_parent = index.data(ConsoleRole_ScopeParent).toModelIndex();
-
-    return scope_parent;
-}
-
 bool ConsoleWidget::item_was_fetched(const QModelIndex &index) const {
     return index.data(ConsoleRole_WasFetched).toBool();
 }

--- a/src/admc/console_widget/console_widget.cpp
+++ b/src/admc/console_widget/console_widget.cpp
@@ -361,10 +361,6 @@ int ConsoleWidget::register_results(QWidget *widget, ResultsView *view, const QL
     return id;
 }
 
-void ConsoleWidget::sort_scope() {
-    d->scope_model->sort(0, Qt::AscendingOrder);
-}
-
 void ConsoleWidget::set_description_bar_text(const QString &text) {
     const QString scope_name = [this]() {
         const QModelIndex current_scope = get_current_scope_item();

--- a/src/admc/console_widget/console_widget.cpp
+++ b/src/admc/console_widget/console_widget.cpp
@@ -428,8 +428,8 @@ QModelIndex ConsoleWidget::get_selected_item() const {
     return selected_list[0];
 }
 
-QList<QModelIndex> ConsoleWidget::search_items(int role, const QVariant &value, const int type) const {
-    const QList<QModelIndex> all_matches = d->scope_model->match(d->scope_model->index(0, 0), role, value, -1, Qt::MatchFlags(Qt::MatchExactly | Qt::MatchRecursive));
+QList<QModelIndex> ConsoleWidget::search_items(const QModelIndex &parent, int role, const QVariant &value, const int type) const {
+    const QList<QModelIndex> all_matches = d->scope_model->match(parent, role, value, -1, Qt::MatchFlags(Qt::MatchExactly | Qt::MatchRecursive));
 
     const QList<QModelIndex> matches = filter_indexes_by_type(all_matches, type);
 

--- a/src/admc/console_widget/console_widget.cpp
+++ b/src/admc/console_widget/console_widget.cpp
@@ -437,16 +437,12 @@ QModelIndex ConsoleWidget::get_selected_item() const {
     return selected_list[0];
 }
 
-QList<QModelIndex> ConsoleWidget::search_scope_by_role(int role, const QVariant &value, const int type) const {
+QList<QModelIndex> ConsoleWidget::search_items(int role, const QVariant &value, const int type) const {
     const QList<QModelIndex> all_matches = d->scope_model->match(d->scope_model->index(0, 0), role, value, -1, Qt::MatchFlags(Qt::MatchExactly | Qt::MatchRecursive));
 
     const QList<QModelIndex> matches = filter_indexes_by_type(all_matches, type);
 
     return matches;
-}
-
-QList<QModelIndex> ConsoleWidget::search_results_by_role(int role, const QVariant &value, const int type) const {
-    return search_scope_by_role(role, value, type);
 }
 
 QModelIndex ConsoleWidget::get_current_scope_item() const {

--- a/src/admc/console_widget/console_widget.h
+++ b/src/admc/console_widget/console_widget.h
@@ -176,6 +176,12 @@ public:
     // selected items from scope are returned instead.
     QList<QModelIndex> get_selected_items() const;
 
+    // Get a single selected item. Use if you are sure that
+    // there's only one (dialog that uses one target item
+    // for example). Returns first item in list if there are
+    // multiple items selected.
+    QModelIndex get_selected_item() const;
+
     // NOTE: if no type is given, then items of all types
     // will be returned
     QList<QModelIndex> search_scope_by_role(int role, const QVariant &value, const int type = -1) const;

--- a/src/admc/console_widget/console_widget.h
+++ b/src/admc/console_widget/console_widget.h
@@ -168,7 +168,8 @@ public:
     void set_item_fetching(const QModelIndex &scope_index, const bool enabled);
 
     // Gets selected item(s) from currently focused view,
-    // which could be scope or results.
+    // which could be scope or results. Only the main (first
+    // column) item is returned for each selected row.
 
     // NOTE: there is always at least one selected item. If
     // results is currently focused but has no selection,

--- a/src/admc/console_widget/console_widget.h
+++ b/src/admc/console_widget/console_widget.h
@@ -152,6 +152,9 @@ public:
     int register_results(ResultsView *view, const QList<QString> &column_labels, const QList<int> &default_columns);
     int register_results(QWidget *widget, ResultsView *view, const QList<QString> &column_labels, const QList<int> &default_columns);
 
+    QList<QStandardItem *> add_item(const int results_id, const bool is_scope, const ScopeNodeType scope_type, const QModelIndex &parent);
+
+
     // Sorts scope items by name. Note that this can affect
     // performance negatively if overused. For example, when
     // adding multiple scope items, try to call this once

--- a/src/admc/console_widget/console_widget.h
+++ b/src/admc/console_widget/console_widget.h
@@ -33,17 +33,12 @@
  * "results". Scope pane contains a tree of items. Each
  * scope item has it's own "results" which are displayed in
  * the results pane when the scope item is selected. Results
- * can contain items that represent children of the scope
- * item in scope tree. Results can also contain items that
- * do not have an equivalent in the scope tree and are
- * associated to the scope item in some other way. For
- * example - a search query, where the scope item represents
- * the query and results represents the results of the
- * search. The way results are displayed can be customized
- * by registering certain types of results views and
- * assigning them to scope items. The user widget of the
- * console widget is responsible for loading scope items and
- * results, creating results views and other things.
+ * can contain children of the scope item. Results may also
+ * display a custom widget. The way results are displayed
+ * can be customized by registering certain types of results
+ * views and assigning them to scope items. The user widget
+ * of the console widget is responsible for loading items,
+ * creating results views and other things.
  */
 
 #include <QWidget>
@@ -83,24 +78,13 @@ class ConsoleWidget final : public QWidget {
 public:
     ConsoleWidget(QWidget *parent = nullptr);
 
-    // These f-ns are for adding items to console. There are
-    // two types of items "scope" and "results". Scope is
-    // composed of a single item, while results is a row of
-    // multiple items. Scope and results items can be
-    // "buddies". This is for cases where a results item
-    // also represents a scope item. Buddies are deleted
-    // together. If a scope item is deleted, it’s buddy in
-    // results is also deleted and vice versa. When a buddy
-    // in results is activated (double-click or
-    // select+enter), scope’s current item is changed to
-    // it’s scope buddy. If this is the first scope item
-    // added to console, then it is set as current scope by
-    // default. If you want another scope item at startup,
-    // use set_current_scope(). Items returned from these
-    // f-ns should be used to set text, icon and your custom
-    // data roles. Note that after adding and setting up the
-    // first scope item you should call set_current_scope()
-    // on it.
+    // These f-ns are for adding items to console. Items
+    // returned from these f-ns should be used to set text,
+    // icon and your custom data roles. add_top_item() adds
+    // top level items to the scope tree. add_scope_item()
+    // adds an item that is shown both in scope and results.
+    // add_results_item() adds an item that is shown only in
+    // results.
     //
     // Arguments:
     //
@@ -115,12 +99,6 @@ public:
     // scope item. Note that dynamic scope items can be
     // fetched again via the refresh_scope() f-n or
     // "Refresh" action of the item menu.
-    //
-    // "parent" - index of the scope item which will be the
-    // parent of created item. Note that results are also
-    // "parented" by a scope parent, even though they are
-    // not in the scope tree. Pass empty QModelIndex as
-    // parent to add a scope item as top level item.
     QStandardItem *add_top_item(const int results_id, const ScopeNodeType scope_type);
     QList<QStandardItem *> add_scope_item(const int results_id, const ScopeNodeType scope_type, const QModelIndex &parent);
     QList<QStandardItem *> add_results_item(const QModelIndex &parent);

--- a/src/admc/console_widget/console_widget.h
+++ b/src/admc/console_widget/console_widget.h
@@ -182,8 +182,7 @@ public:
 
     // NOTE: if no type is given, then items of all types
     // will be returned
-    QList<QModelIndex> search_scope_by_role(int role, const QVariant &value, const int type = -1) const;
-    QList<QModelIndex> search_results_by_role(int role, const QVariant &value, const int type = -1) const;
+    QList<QModelIndex> search_items(int role, const QVariant &value, const int type = -1) const;
 
     QModelIndex get_current_scope_item() const;
     int get_current_results_count() const;

--- a/src/admc/console_widget/console_widget.h
+++ b/src/admc/console_widget/console_widget.h
@@ -130,8 +130,7 @@ public:
     // dialog.
     void set_has_properties(const QModelIndex &index, const bool has_properties);
 
-    // Deletes a scope/results item. If this item has a
-    // buddy, that buddy is also deleted.
+    // Deletes an item and all of it's columns
     void delete_item(const QModelIndex &index);
 
     // Sets current scope item in the scope tree

--- a/src/admc/console_widget/console_widget.h
+++ b/src/admc/console_widget/console_widget.h
@@ -163,7 +163,7 @@ public:
 
     void set_description_bar_text(const QString &text);
 
-    void set_item_fetching(const QModelIndex &scope_index, const bool enabled);
+    void set_item_fetching(const QModelIndex &index, const bool enabled);
 
     // Gets selected item(s) from currently focused view,
     // which could be scope or results. Only the main (first
@@ -187,8 +187,8 @@ public:
     QModelIndex get_current_scope_item() const;
     int get_current_results_count() const;
 
-    QStandardItem *get_scope_item(const QModelIndex &scope_index) const;
-    QList<QStandardItem *> get_results_row(const QModelIndex &results_index) const;
+    QStandardItem *get_item(const QModelIndex &index) const;
+    QList<QStandardItem *> get_row(const QModelIndex &index) const;
 
     bool item_was_fetched(const QModelIndex &index) const;
 

--- a/src/admc/console_widget/console_widget.h
+++ b/src/admc/console_widget/console_widget.h
@@ -251,9 +251,6 @@ private:
     ConsoleWidgetPrivate *d;
 };
 
-bool console_item_is_scope(const QModelIndex &index);
-QModelIndex console_item_get_buddy(const QModelIndex &index);
-
 // Returns true if item or item's buddy is fetching
 bool console_get_item_fetching(const QModelIndex &index);
 

--- a/src/admc/console_widget/console_widget.h
+++ b/src/admc/console_widget/console_widget.h
@@ -192,8 +192,6 @@ public:
     QWidget *get_scope_view() const;
     QWidget *get_description_bar() const;
 
-    QStandardItemModel *scope_model() const;
-
 signals:
     // Emitted when a dynamic scope item is expanded or
     // selected for the first time. User of this widget

--- a/src/admc/console_widget/console_widget.h
+++ b/src/admc/console_widget/console_widget.h
@@ -53,6 +53,7 @@ class ResultsView;
 class QStandardItem;
 class QMenu;
 class QAbstractItemView;
+class QStandardItemModel;
 
 enum ConsoleRolePublic {
     ConsoleRole_HasProperties = Qt::UserRole + 18,
@@ -204,6 +205,8 @@ public:
     QWidget *get_scope_view() const;
     QWidget *get_description_bar() const;
 
+    QStandardItemModel *scope_model() const;
+
 signals:
     // Emitted when a dynamic scope item is expanded or
     // selected for the first time. User of this widget
@@ -250,9 +253,6 @@ private:
 
 bool console_item_is_scope(const QModelIndex &index);
 QModelIndex console_item_get_buddy(const QModelIndex &index);
-// If index is already scope, returns index, otherwise
-// returns scope buddy, if it exists
-QModelIndex console_item_convert_to_scope_index(const QModelIndex &index);
 
 // Returns true if item or item's buddy is fetching
 bool console_get_item_fetching(const QModelIndex &index);

--- a/src/admc/console_widget/console_widget.h
+++ b/src/admc/console_widget/console_widget.h
@@ -153,14 +153,6 @@ public:
     int register_results(ResultsView *view, const QList<QString> &column_labels, const QList<int> &default_columns);
     int register_results(QWidget *widget, ResultsView *view, const QList<QString> &column_labels, const QList<int> &default_columns);
 
-    // Sorts scope items by name. Note that this can affect
-    // performance negatively if overused. For example, when
-    // adding multiple scope items, try to call this once
-    // after all items are added. If you were to call this
-    // after each item is added the whole process would be
-    // slowed down.
-    void sort_scope();
-
     void set_description_bar_text(const QString &text);
 
     void set_item_fetching(const QModelIndex &index, const bool enabled);

--- a/src/admc/console_widget/console_widget.h
+++ b/src/admc/console_widget/console_widget.h
@@ -194,7 +194,6 @@ public:
     QStandardItem *get_scope_item(const QModelIndex &scope_index) const;
     QList<QStandardItem *> get_results_row(const QModelIndex &results_index) const;
 
-    QModelIndex get_scope_parent(const QModelIndex &index) const;
     bool item_was_fetched(const QModelIndex &index) const;
 
     void add_actions_to_action_menu(QMenu *menu);

--- a/src/admc/console_widget/console_widget.h
+++ b/src/admc/console_widget/console_widget.h
@@ -222,10 +222,9 @@ signals:
     // description bar.
     void results_count_changed();
 
-    // Emitted when selected items changes. Note that this
-    // is also emitted when focus changes between scope and
-    // results panes.
-    void selection_changed();
+    // Emitted when actions need to updated due to selection
+    // changing.
+    void actions_changed();
 
     // Emitted when a context menu is requested from a scope
     // or results view

--- a/src/admc/console_widget/console_widget.h
+++ b/src/admc/console_widget/console_widget.h
@@ -169,6 +169,10 @@ public:
 
     // Gets selected item(s) from currently focused view,
     // which could be scope or results.
+
+    // NOTE: there is always at least one selected item. If
+    // results is currently focused but has no selection,
+    // selected items from scope are returned instead.
     QList<QModelIndex> get_selected_items() const;
 
     // NOTE: if no type is given, then items of all types

--- a/src/admc/console_widget/console_widget.h
+++ b/src/admc/console_widget/console_widget.h
@@ -173,7 +173,7 @@ public:
 
     // NOTE: if no type is given, then items of all types
     // will be returned
-    QList<QModelIndex> search_items(int role, const QVariant &value, const int type = -1) const;
+    QList<QModelIndex> search_items(const QModelIndex &parent, int role, const QVariant &value, const int type = -1) const;
 
     QModelIndex get_current_scope_item() const;
     int get_current_results_count() const;

--- a/src/admc/console_widget/console_widget.h
+++ b/src/admc/console_widget/console_widget.h
@@ -121,9 +121,9 @@ public:
     // "parented" by a scope parent, even though they are
     // not in the scope tree. Pass empty QModelIndex as
     // parent to add a scope item as top level item.
-    QStandardItem *add_scope_item(const int results_id, const ScopeNodeType scope_type, const QModelIndex &parent);
-    QList<QStandardItem *> add_results_row(const QModelIndex &scope_parent);
-    void add_buddy_scope_and_results(const int results_id, const ScopeNodeType scope_type, const QModelIndex &scope_parent, QStandardItem **scope_arg, QList<QStandardItem *> *results_arg);
+    QStandardItem *add_top_item(const int results_id, const ScopeNodeType scope_type);
+    QList<QStandardItem *> add_scope_item(const int results_id, const ScopeNodeType scope_type, const QModelIndex &parent);
+    QList<QStandardItem *> add_results_item(const QModelIndex &parent);
 
     // Sets whether a given item should have "Properties"
     // action in it's menu, which opens the Properties
@@ -152,9 +152,6 @@ public:
     int register_results(QWidget *widget);
     int register_results(ResultsView *view, const QList<QString> &column_labels, const QList<int> &default_columns);
     int register_results(QWidget *widget, ResultsView *view, const QList<QString> &column_labels, const QList<int> &default_columns);
-
-    QList<QStandardItem *> add_item(const int results_id, const bool is_scope, const ScopeNodeType scope_type, const QModelIndex &parent);
-
 
     // Sorts scope items by name. Note that this can affect
     // performance negatively if overused. For example, when

--- a/src/admc/console_widget/console_widget_p.h
+++ b/src/admc/console_widget/console_widget_p.h
@@ -47,18 +47,12 @@ enum ConsoleRole {
     // this scope item. Doesn't apply to results items.
     ConsoleRole_ResultsId = Qt::UserRole + 2,
 
-    ConsoleRole_Buddy = Qt::UserRole + 3,
-
-    // Scope item parent of a results item. Doesn't apply
-    // to scope items.
-    ConsoleRole_ScopeParent = Qt::UserRole + 4,
-
-    ConsoleRole_IsScope = Qt::UserRole + 5,
+    ConsoleRole_IsScope = Qt::UserRole + 3,
 
     // Determines whether scope is dynamic.
-    ConsoleRole_ScopeIsDynamic = Qt::UserRole + 6,
+    ConsoleRole_ScopeIsDynamic = Qt::UserRole + 4,
 
-    ConsoleRole_Fetching = Qt::UserRole + 7,
+    ConsoleRole_Fetching = Qt::UserRole + 5,
 
     // NOTE: don't go above ConsoleRole_Type and
     // ConsoleRole_LAST (defined in public header)

--- a/src/admc/console_widget/console_widget_p.h
+++ b/src/admc/console_widget/console_widget_p.h
@@ -83,7 +83,6 @@ public:
     QAbstractItemView *focused_view;
     QStackedWidget *results_stacked_widget;
     QHash<int, ResultsDescription> results_descriptions;
-    QHash<QPersistentModelIndex, QStandardItemModel *> results_models;
 
     QAction *properties_action;
     QAction *refresh_action;
@@ -107,7 +106,6 @@ public:
 
     ConsoleWidgetPrivate(ConsoleWidget *q_arg);
 
-    QStandardItemModel *get_results_model_for_scope_item(const QModelIndex &index) const;
     void open_action_menu_as_context_menu(const QPoint pos);
     void connect_to_drag_model(ConsoleDragModel *model);
     void on_scope_expanded(const QModelIndex &index);

--- a/src/admc/console_widget/results_view.h
+++ b/src/admc/console_widget/results_view.h
@@ -54,6 +54,7 @@ public:
     ResultsView(QWidget *parent);
 
     void set_model(QAbstractItemModel *model);
+    void set_parent(const QModelIndex &source_index);
     void set_view_type(const ResultsViewType type);
     QAbstractItemView *current_view() const;
     ResultsViewType current_view_type() const;

--- a/src/admc/console_widget/scope_model.cpp
+++ b/src/admc/console_widget/scope_model.cpp
@@ -36,3 +36,11 @@ bool ScopeModel::hasChildren(const QModelIndex &parent) const {
         return QSortFilterProxyModel::hasChildren(parent);
     }
 }
+
+bool ScopeModel::filterAcceptsRow(int source_row, const QModelIndex &source_parent) const {
+    const QModelIndex source_index = sourceModel()->index(source_row, 0, source_parent);
+
+    const bool is_scope = source_index.data(ConsoleRole_IsScope).toBool();
+
+    return is_scope;   
+}

--- a/src/admc/console_widget/scope_model.h
+++ b/src/admc/console_widget/scope_model.h
@@ -34,6 +34,7 @@ public:
     using QSortFilterProxyModel::QSortFilterProxyModel;
 
     bool hasChildren(const QModelIndex &parent) const override;
+    bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const override;
 };
 
 #endif /* SCOPE_MODEL_H */

--- a/src/admc/create_query_folder_dialog.cpp
+++ b/src/admc/create_query_folder_dialog.cpp
@@ -73,7 +73,7 @@ void CreateQueryFolderDialog::accept() {
     const QString name = name_edit->text();
     const QString description = description_edit->text();
 
-    if (!console_query_or_folder_name_is_good(name, parent_index, this, QModelIndex())) {
+    if (!console_query_or_folder_name_is_good(console, name, parent_index, this, QModelIndex())) {
         return;
     }
 

--- a/src/admc/create_query_folder_dialog.cpp
+++ b/src/admc/create_query_folder_dialog.cpp
@@ -69,7 +69,7 @@ void CreateQueryFolderDialog::open() {
 }
 
 void CreateQueryFolderDialog::accept() {
-    const QModelIndex parent_index = get_selected_scope_index(console);
+    const QModelIndex parent_index = console->get_selected_item();
     const QString name = name_edit->text();
     const QString description = description_edit->text();
 

--- a/src/admc/create_query_item_dialog.cpp
+++ b/src/admc/create_query_item_dialog.cpp
@@ -61,7 +61,7 @@ void CreateQueryItemDialog::accept() {
     bool scope_is_children;
     edit_query_widget->save(name, description, filter, base, scope_is_children, filter_state);
 
-    const QModelIndex parent_index = get_selected_scope_index(console);
+    const QModelIndex parent_index = console->get_selected_item();
 
     if (!console_query_or_folder_name_is_good(name, parent_index, this, QModelIndex())) {
         return;

--- a/src/admc/create_query_item_dialog.cpp
+++ b/src/admc/create_query_item_dialog.cpp
@@ -63,7 +63,7 @@ void CreateQueryItemDialog::accept() {
 
     const QModelIndex parent_index = console->get_selected_item();
 
-    if (!console_query_or_folder_name_is_good(name, parent_index, this, QModelIndex())) {
+    if (!console_query_or_folder_name_is_good(console, name, parent_index, this, QModelIndex())) {
         return;
     }
 

--- a/src/admc/edit_query_folder_dialog.cpp
+++ b/src/admc/edit_query_folder_dialog.cpp
@@ -61,7 +61,7 @@ EditQueryFolderDialog::EditQueryFolderDialog(ConsoleWidget *console_arg)
 }
 
 void EditQueryFolderDialog::open() {
-    const QModelIndex scope_index = get_selected_scope_index(console);
+    const QModelIndex scope_index = console->get_selected_item();
     const QString current_name = scope_index.data(Qt::DisplayRole).toString();
     const QString current_description = scope_index.data(QueryItemRole_Description).toString();
 
@@ -72,7 +72,7 @@ void EditQueryFolderDialog::open() {
 }
 
 void EditQueryFolderDialog::accept() {
-    const QModelIndex scope_index = get_selected_scope_index(console);
+    const QModelIndex scope_index = console->get_selected_item();
     const QModelIndex results_index = console_item_get_buddy(scope_index);
     const QString name = name_edit->text();
     const QString description = description_edit->text();

--- a/src/admc/edit_query_folder_dialog.cpp
+++ b/src/admc/edit_query_folder_dialog.cpp
@@ -80,7 +80,7 @@ void EditQueryFolderDialog::accept() {
         return;
     }
 
-    const QList<QStandardItem *> row = console->get_results_row(index);
+    const QList<QStandardItem *> row = console->get_row(index);
     console_query_folder_load(row, name, description);
 
     console_query_tree_save(console);

--- a/src/admc/edit_query_folder_dialog.cpp
+++ b/src/admc/edit_query_folder_dialog.cpp
@@ -61,9 +61,9 @@ EditQueryFolderDialog::EditQueryFolderDialog(ConsoleWidget *console_arg)
 }
 
 void EditQueryFolderDialog::open() {
-    const QModelIndex scope_index = console->get_selected_item();
-    const QString current_name = scope_index.data(Qt::DisplayRole).toString();
-    const QString current_description = scope_index.data(QueryItemRole_Description).toString();
+    const QModelIndex index = console->get_selected_item();
+    const QString current_name = index.data(Qt::DisplayRole).toString();
+    const QString current_description = index.data(QueryItemRole_Description).toString();
 
     name_edit->setText(current_name);
     description_edit->setText(current_description);

--- a/src/admc/edit_query_folder_dialog.cpp
+++ b/src/admc/edit_query_folder_dialog.cpp
@@ -77,7 +77,7 @@ void EditQueryFolderDialog::accept() {
     const QString name = name_edit->text();
     const QString description = description_edit->text();
 
-    if (!console_query_or_folder_name_is_good(name, scope_index.parent(), this, scope_index)) {
+    if (!console_query_or_folder_name_is_good(console, name, scope_index.parent(), this, scope_index)) {
         return;
     }
 

--- a/src/admc/edit_query_folder_dialog.cpp
+++ b/src/admc/edit_query_folder_dialog.cpp
@@ -72,18 +72,16 @@ void EditQueryFolderDialog::open() {
 }
 
 void EditQueryFolderDialog::accept() {
-    const QModelIndex scope_index = console->get_selected_item();
-    const QModelIndex results_index = console_item_get_buddy(scope_index);
+    const QModelIndex index = console->get_selected_item();
     const QString name = name_edit->text();
     const QString description = description_edit->text();
 
-    if (!console_query_or_folder_name_is_good(console, name, scope_index.parent(), this, scope_index)) {
+    if (!console_query_or_folder_name_is_good(console, name, index.parent(), this, index)) {
         return;
     }
 
-    QStandardItem *scope_item = console->get_scope_item(scope_index);
-    const QList<QStandardItem *> results_row = console->get_results_row(results_index);
-    console_query_folder_load(scope_item, results_row, name, description);
+    const QList<QStandardItem *> row = console->get_results_row(index);
+    console_query_folder_load(row, name, description);
 
     console_query_tree_save(console);
 

--- a/src/admc/edit_query_item_dialog.cpp
+++ b/src/admc/edit_query_item_dialog.cpp
@@ -48,13 +48,7 @@ EditQueryItemDialog::EditQueryItemDialog(ConsoleWidget *console_arg)
     layout->addWidget(edit_query_widget);
     layout->addWidget(buttonbox);
 
-    scope_index = get_selected_scope_index(console);
-
-    if (!scope_index.isValid()) {
-        close();
-
-        return;
-    }
+    const QModelIndex scope_index = console->get_selected_item();
 
     edit_query_widget->load(scope_index);
 
@@ -74,6 +68,8 @@ void EditQueryItemDialog::accept() {
     QByteArray filter_state;
     bool scope_is_children;
     edit_query_widget->save(name, description, filter, base, scope_is_children, filter_state);
+
+    const QModelIndex scope_index = console->get_selected_item();
 
     if (!console_query_or_folder_name_is_good(name, scope_index.parent(), this, scope_index)) {
         return;

--- a/src/admc/edit_query_item_dialog.cpp
+++ b/src/admc/edit_query_item_dialog.cpp
@@ -71,7 +71,7 @@ void EditQueryItemDialog::accept() {
 
     const QModelIndex scope_index = console->get_selected_item();
 
-    if (!console_query_or_folder_name_is_good(name, scope_index.parent(), this, scope_index)) {
+    if (!console_query_or_folder_name_is_good(console, name, scope_index.parent(), this, scope_index)) {
         return;
     }
 

--- a/src/admc/edit_query_item_dialog.cpp
+++ b/src/admc/edit_query_item_dialog.cpp
@@ -75,7 +75,7 @@ void EditQueryItemDialog::accept() {
         return;
     }
 
-    const QList<QStandardItem *> row = console->get_results_row(index);
+    const QList<QStandardItem *> row = console->get_row(index);
 
     console_query_item_load(row, name, description, filter, filter_state, base, scope_is_children);
 

--- a/src/admc/edit_query_item_dialog.cpp
+++ b/src/admc/edit_query_item_dialog.cpp
@@ -48,9 +48,9 @@ EditQueryItemDialog::EditQueryItemDialog(ConsoleWidget *console_arg)
     layout->addWidget(edit_query_widget);
     layout->addWidget(buttonbox);
 
-    const QModelIndex scope_index = console->get_selected_item();
+    const QModelIndex index = console->get_selected_item();
 
-    edit_query_widget->load(scope_index);
+    edit_query_widget->load(index);
 
     connect(
         buttonbox, &QDialogButtonBox::accepted,

--- a/src/admc/edit_query_item_dialog.cpp
+++ b/src/admc/edit_query_item_dialog.cpp
@@ -69,22 +69,19 @@ void EditQueryItemDialog::accept() {
     bool scope_is_children;
     edit_query_widget->save(name, description, filter, base, scope_is_children, filter_state);
 
-    const QModelIndex scope_index = console->get_selected_item();
+    const QModelIndex index = console->get_selected_item();
 
-    if (!console_query_or_folder_name_is_good(console, name, scope_index.parent(), this, scope_index)) {
+    if (!console_query_or_folder_name_is_good(console, name, index.parent(), this, index)) {
         return;
     }
 
-    QStandardItem *scope_item = console->get_scope_item(scope_index);
+    const QList<QStandardItem *> row = console->get_results_row(index);
 
-    const QModelIndex results_index = console_item_get_buddy(scope_index);
-    const QList<QStandardItem *> results_row = console->get_results_row(results_index);
-
-    console_query_item_load(scope_item, results_row, name, description, filter, filter_state, base, scope_is_children);
+    console_query_item_load(row, name, description, filter, filter_state, base, scope_is_children);
 
     console_query_tree_save(console);
 
-    console->refresh_scope(scope_index);
+    console->refresh_scope(index);
 
     QDialog::accept();
 }

--- a/src/admc/edit_query_item_dialog.h
+++ b/src/admc/edit_query_item_dialog.h
@@ -38,7 +38,6 @@ public:
 private:
     ConsoleWidget *console;
     EditQueryItemWidget *edit_query_widget;
-    QModelIndex scope_index;
 };
 
 #endif /* EDIT_QUERY_ITEM_DIALOG_H */

--- a/src/admc/find_results.cpp
+++ b/src/admc/find_results.cpp
@@ -145,7 +145,7 @@ void FindResults::load(const QHash<QString, AdObject> &results) {
     for (const AdObject &object : results) {
         const QList<QStandardItem *> row = make_item_row(g_adconfig->get_columns().count());
 
-        console_object_results_load(row, object);
+        console_object_load(row, object);
 
         model->appendRow(row);
     }

--- a/src/admc/policy_results_widget.cpp
+++ b/src/admc/policy_results_widget.cpp
@@ -109,8 +109,8 @@ PolicyResultsWidget::PolicyResultsWidget() {
         this, &PolicyResultsWidget::delete_link);
 }
 
-void PolicyResultsWidget::update(const QModelIndex &scope_index) {
-    const ItemType type = (ItemType) scope_index.data(ConsoleRole_Type).toInt();
+void PolicyResultsWidget::update(const QModelIndex &index) {
+    const ItemType type = (ItemType) index.data(ConsoleRole_Type).toInt();
     if (type != ItemType_Policy) {
         return;
     }
@@ -122,7 +122,7 @@ void PolicyResultsWidget::update(const QModelIndex &scope_index) {
 
     model->removeRows(0, model->rowCount());
 
-    gpo = scope_index.data(PolicyRole_DN).toString();
+    gpo = index.data(PolicyRole_DN).toString();
 
     const QString base = g_adconfig->domain_head();
     const SearchScope scope = SearchScope_All;

--- a/src/admc/policy_results_widget.h
+++ b/src/admc/policy_results_widget.h
@@ -43,7 +43,7 @@ public:
 
     // Loads links for this policy. Nothing is done if given
     // index is not a policy.
-    void update(const QModelIndex &scope_index);
+    void update(const QModelIndex &index);
 
 private:
     ResultsView *view;

--- a/src/admc/rename_policy_dialog.cpp
+++ b/src/admc/rename_policy_dialog.cpp
@@ -86,7 +86,7 @@ void RenamePolicyDialog::accept() {
         return;
     }
 
-    const QModelIndex scope_index = get_selected_scope_index(console);
+    const QModelIndex scope_index = console->get_selected_item();
     const QString old_name = scope_index.data(Qt::DisplayRole).toString();
 
     const QString new_name = name_edit->text();
@@ -126,7 +126,7 @@ void RenamePolicyDialog::reset() {
     }
 
     const QString name = [&]() {
-        const QModelIndex scope_index = get_selected_scope_index(console);
+        const QModelIndex scope_index = console->get_selected_item();
         const QString dn = scope_index.data(PolicyRole_DN).toString();
         const AdObject object = ad.search_object(dn);
 

--- a/src/admc/rename_policy_dialog.cpp
+++ b/src/admc/rename_policy_dialog.cpp
@@ -104,7 +104,7 @@ void RenamePolicyDialog::accept() {
     const QString dn = index.data(PolicyRole_DN).toString();
     const AdObject object = ad.search_object(dn);
 
-    const QList<QStandardItem *> row = console->get_results_row(index);
+    const QList<QStandardItem *> row = console->get_row(index);
     console_policy_results_load(row, object);
 
     console->sort_scope();

--- a/src/admc/rename_policy_dialog.cpp
+++ b/src/admc/rename_policy_dialog.cpp
@@ -106,8 +106,6 @@ void RenamePolicyDialog::accept() {
 
     const QList<QStandardItem *> row = console->get_row(index);
     console_policy_results_load(row, object);
-
-    console->sort_scope();
 }
 
 void RenamePolicyDialog::on_edited() {

--- a/src/admc/rename_policy_dialog.cpp
+++ b/src/admc/rename_policy_dialog.cpp
@@ -105,7 +105,7 @@ void RenamePolicyDialog::accept() {
     const AdObject object = ad.search_object(dn);
 
     const QList<QStandardItem *> row = console->get_row(index);
-    console_policy_results_load(row, object);
+    console_policy_load(row, object);
 }
 
 void RenamePolicyDialog::on_edited() {

--- a/src/admc/rename_policy_dialog.cpp
+++ b/src/admc/rename_policy_dialog.cpp
@@ -86,8 +86,8 @@ void RenamePolicyDialog::accept() {
         return;
     }
 
-    const QModelIndex scope_index = console->get_selected_item();
-    const QString old_name = scope_index.data(Qt::DisplayRole).toString();
+    const QModelIndex index = console->get_selected_item();
+    const QString old_name = index.data(Qt::DisplayRole).toString();
 
     const QString new_name = name_edit->text();
     const bool apply_success = ad.attribute_replace_string(target, ATTRIBUTE_DISPLAY_NAME, new_name);
@@ -101,15 +101,11 @@ void RenamePolicyDialog::accept() {
 
     g_status()->display_ad_messages(ad, this);
 
-    const QString dn = scope_index.data(PolicyRole_DN).toString();
+    const QString dn = index.data(PolicyRole_DN).toString();
     const AdObject object = ad.search_object(dn);
 
-    QStandardItem *scope_item = console->get_scope_item(scope_index);
-    console_policy_scope_load(scope_item, object);
-
-    const QModelIndex results_index = console_item_get_buddy(scope_index);
-    const QList<QStandardItem *> results_row = console->get_results_row(results_index);
-    console_policy_results_load(results_row, object);
+    const QList<QStandardItem *> row = console->get_results_row(index);
+    console_policy_results_load(row, object);
 
     console->sort_scope();
 }
@@ -126,8 +122,8 @@ void RenamePolicyDialog::reset() {
     }
 
     const QString name = [&]() {
-        const QModelIndex scope_index = console->get_selected_item();
-        const QString dn = scope_index.data(PolicyRole_DN).toString();
+        const QModelIndex index = console->get_selected_item();
+        const QString dn = index.data(PolicyRole_DN).toString();
         const AdObject object = ad.search_object(dn);
 
         return object.get_string(ATTRIBUTE_DISPLAY_NAME);

--- a/src/admc/select_policy_dialog.cpp
+++ b/src/admc/select_policy_dialog.cpp
@@ -71,11 +71,13 @@ SelectPolicyDialog::SelectPolicyDialog(QWidget *parent)
 
     const QHash<QString, AdObject> results = ad.search(base, scope, filter, attributes);
 
+    // TODO: assuming that policy row has 1 column, need to
+    // make it depend on some constant
     for (const AdObject &object : results.values()) {
-        auto item = new QStandardItem();
-        model->appendRow(item);
+        const QList<QStandardItem *> row = {new QStandardItem()};
+        model->appendRow(row);
 
-        console_policy_scope_load(item, object);
+        console_policy_results_load(row, object);
     }
 
     const auto top_layout = new QVBoxLayout();

--- a/src/admc/select_policy_dialog.cpp
+++ b/src/admc/select_policy_dialog.cpp
@@ -77,7 +77,7 @@ SelectPolicyDialog::SelectPolicyDialog(QWidget *parent)
         const QList<QStandardItem *> row = {new QStandardItem()};
         model->appendRow(row);
 
-        console_policy_results_load(row, object);
+        console_policy_load(row, object);
     }
 
     const auto top_layout = new QVBoxLayout();

--- a/src/admc/utils.cpp
+++ b/src/admc/utils.cpp
@@ -229,19 +229,6 @@ QList<QPersistentModelIndex> persistent_index_list(const QList<QModelIndex> &ind
     return out;
 }
 
-QModelIndex get_selected_scope_index(ConsoleWidget *console) {
-    const QList<QModelIndex> selected_indexes = console->get_selected_items();
-
-    if (selected_indexes.size() == 1) {
-        const QModelIndex index = selected_indexes[0];
-        const QModelIndex scope_index = console_item_convert_to_scope_index(index);
-
-        return scope_index;
-    } else {
-        return QModelIndex();
-    }
-}
-
 // Hide advanced view only" objects if advanced view setting
 // is off
 void advanced_features_filter(QString &filter) {

--- a/src/admc/utils.h
+++ b/src/admc/utils.h
@@ -94,10 +94,6 @@ QIcon get_object_icon(const AdObject &object);
 
 QList<QPersistentModelIndex> persistent_index_list(const QList<QModelIndex> &indexes);
 
-// Returns selected scope index. If selected item is in
-// results, returns it's scope buddy.
-QModelIndex get_selected_scope_index(ConsoleWidget *console);
-
 void advanced_features_filter(QString &filter);
 
 void dev_mode_filter(QString &filter);


### PR DESCRIPTION
Use one model for both scope and results in console widget. Results uses setRootIndex() (as it did a couple times before...).

Simplifies a lot of things:
- removes the need to convert between scope and results items
- removes buddies
- simplifies adding items to console
- don't need to do 2 searches, 1 is enough
- don't have to manage results models

One negative is that the scope tree now slows down a bit easier when working with many objects(1000's). Before it was snappier because scope tree used a separate model.