### PR TITLE
Bugfix/gplink case

### DIFF
--- a/src/admc/gplink.cpp
+++ b/src/admc/gplink.cpp
@@ -35,104 +35,168 @@ Gplink::Gplink(const QString &gplink_string) {
             continue;
         }
 
-        QString gpo_case = part_split[0];
-        gpo_case.replace(LDAP_PREFIX, "", Qt::CaseSensitive);
+        // "LDAP://cn={UUID},cn=something,DC=a,DC=b"
+        // =>
+        // "cn={uuid},cn=something,dc=a,dc=b"
+        const QString gpo = [&]() {
+            QString out;
 
-        const QString gpo = gpo_case.toLower();
+            out = part_split[0];
+            out.remove(LDAP_PREFIX);
+            out = out.toLower();
 
-        gpo_case_map[gpo] = gpo_case;
+            return out;
+        }();
 
-        const QString option_string = part_split[1];
-        const int option = option_string.toInt();
+        const int option = [&]() {
+            const QString option_string = part_split[1];
+            const int option_int = option_string.toInt();
 
-        gpos_in_order.append(gpo);
+            return option_int;
+        }();
+
+        gpo_list.append(gpo);
         options[gpo] = option;
     }
 }
 
+// Transform into gplink format. Have to uppercase some
+// parts of the output.
 QString Gplink::to_string() const {
-    QString gplink_string;
+    QList<QString> part_list;
 
-    for (auto gpo : gpos_in_order) {
-        const QString gpo_case = gpo_case_map[gpo];
+    for (auto gpo : gpo_list) {
+        // Convert gpo dn from lower case to gplink case
+        // format
+        const QString gpo_case = [&]() {            
+            const QList<QString> rdn_list = gpo.split(",");
+
+            QList<QString> rdn_list_case;
+
+            for (const QString &rdn : rdn_list) {
+                const QString rdn_case = [&]() {
+                    const QList<QString> attribute_value = rdn.split("=");
+                    
+                    // Do no processing if data is malformed
+                    if (attribute_value.size() != 2) {
+                        return rdn;
+                    }
+
+                    const QString attribute = attribute_value[0];
+                    const QString value = attribute_value[1];
+
+                    const QString attribute_case = [&]() {
+                        // "DC" attribute is upper-cased
+                        if (attribute == "dc") {
+                            return attribute.toUpper();
+                        } else {
+                            return attribute;
+                        }
+                    }();
+
+                    const QString value_case = [&]() {
+                        // uuid (the first rdn) is upper-cased
+                        if (rdn_list.indexOf(rdn) == 0) {
+                            return value.toUpper();
+                        } else {
+                            return value;
+                        }
+                    }();
+
+                    const QList<QString> attribute_value_case = {
+                        attribute_case,
+                        value_case,
+                    };
+
+                    const QString out = attribute_value_case.join("=");
+
+                    return out;
+                }();
+
+                rdn_list_case.append(rdn_case);
+            }
+
+            const QString out = rdn_list_case.join(",");
+
+            return out;
+        }();
         const int option = options[gpo];
         const QString option_string = QString::number(option);
 
         const QString part = QString("[%1%2;%3]").arg(LDAP_PREFIX, gpo_case, option_string);
 
-        gplink_string += part;
+        part_list.append(part);
     }
 
-    return gplink_string;
-}
-
-QList<QString> Gplink::get_gpos() const {
-    QList<QString> out;
-
-    for (const QString &gpo : gpos_in_order) {
-        const QString gpo_case = gpo_case_map[gpo];
-        out.append(gpo_case);
-    }
+    const QString out = part_list.join("");
 
     return out;
+}
+
+bool Gplink::contains(const QString &gpo_case) const {
+    const QString gpo = gpo_case.toLower();
+
+    return options.contains(gpo);
 }
 
 void Gplink::add(const QString &gpo_case) {
     const QString gpo = gpo_case.toLower();
 
-    const bool gpo_already_in_link = gpo_case_map.contains(gpo);
+    const bool gpo_already_in_link = contains(gpo);
     if (gpo_already_in_link) {
         return;
     }
 
-    gpos_in_order.append(gpo);
+    gpo_list.append(gpo);
     options[gpo] = 0;
-    gpo_case_map[gpo] = gpo_case;
 }
 
 void Gplink::remove(const QString &gpo_case) {
     const QString gpo = gpo_case.toLower();
-    if (!gpo_case_map.contains(gpo)) {
+
+    if (!contains(gpo)) {
         return;
     }
 
-    gpos_in_order.removeAll(gpo);
+    gpo_list.removeAll(gpo);
     options.remove(gpo);
-    gpo_case_map.remove(gpo);
 }
 
 void Gplink::move_up(const QString &gpo_case) {
     const QString gpo = gpo_case.toLower();
-    if (!gpo_case_map.contains(gpo)) {
+
+    if (!contains(gpo)) {
         return;
     }
 
-    const int current_index = gpos_in_order.indexOf(gpo);
+    const int current_index = gpo_list.indexOf(gpo);
 
     if (current_index > 0) {
         const int new_index = current_index - 1;
-        gpos_in_order.move(current_index, new_index);
+        gpo_list.move(current_index, new_index);
     }
 }
 
 void Gplink::move_down(const QString &gpo_case) {
     const QString gpo = gpo_case.toLower();
-    if (!gpo_case_map.contains(gpo)) {
+
+    if (!contains(gpo)) {
         return;
     }
 
-    const int current_index = gpos_in_order.indexOf(gpo);
+    const int current_index = gpo_list.indexOf(gpo);
 
-    if (current_index < gpos_in_order.size() - 1) {
+    if (current_index < gpo_list.size() - 1) {
         const int new_index = current_index + 1;
 
-        gpos_in_order.move(current_index, new_index);
+        gpo_list.move(current_index, new_index);
     }
 }
 
 bool Gplink::get_option(const QString &gpo_case, const GplinkOption option) const {
     const QString gpo = gpo_case.toLower();
-    if (!gpo_case_map.contains(gpo)) {
+    
+    if (!contains(gpo)) {
         return false;
     }
 
@@ -144,20 +208,14 @@ bool Gplink::get_option(const QString &gpo_case, const GplinkOption option) cons
 
 void Gplink::set_option(const QString &gpo_case, const GplinkOption option, const bool value) {
     const QString gpo = gpo_case.toLower();
-    if (!gpo_case_map.contains(gpo)) {
+    
+    if (!contains(gpo)) {
         return;
     }
 
     const int option_bits = options[gpo];
     const int option_bits_new = bit_set(option_bits, (int) option, value);
     options[gpo] = option_bits_new;
-}
-
-bool Gplink::equals(const QString &other_string) const {
-    const QString a = to_string().toLower();
-    const QString b = other_string.toLower();
-
-    return (a == b);
 }
 
 bool Gplink::equals(const Gplink &other) const {

--- a/src/admc/gplink.h
+++ b/src/admc/gplink.h
@@ -35,8 +35,7 @@ enum GplinkOption {
  * Gplink attribute primer: an ordered list of GPO container
  * DN's with each GPO being assigned an "option" value.
  * Options specify whether policy is disabled and/or
- * enforced. Internal handling of DN's is case insensitive,
- * but case is preserved for all output.
+ * enforced.
  */
 
 class Gplink {
@@ -45,7 +44,7 @@ public:
     Gplink(const QString &gplink_string);
 
     QString to_string() const;
-    QList<QString> get_gpos() const;
+    bool contains(const QString &gpo) const;
 
     void add(const QString &gpo);
     void remove(const QString &gpo);
@@ -55,15 +54,11 @@ public:
     bool get_option(const QString &gpo, const GplinkOption option) const;
     void set_option(const QString &gpo, const GplinkOption option, const bool value);
 
-    // NOTE: these must be used for comparison! Don't
-    // compare plain gplink strings!
-    bool equals(const QString &other_string) const;
     bool equals(const Gplink &other) const;
 
 private:
-    QList<QString> gpos_in_order;
+    QList<QString> gpo_list;
     QHash<QString, int> options;
-    QHash<QString, QString> gpo_case_map;
 };
 
 #endif /* GPLINK_H */

--- a/src/admc/tabs/group_policy_tab.cpp
+++ b/src/admc/tabs/group_policy_tab.cpp
@@ -253,20 +253,18 @@ void GroupPolicyTab::reload_gplink() {
     const QList<QString> attributes = {ATTRIBUTE_DISPLAY_NAME};
     const QHash<QString, AdObject> results = ad.search(base, scope, filter, attributes);
 
-    const QList<QString> gpos = gplink.get_gpos();
-
-    for (auto dn : results.keys()) {
-        if (!gpos.contains(dn)) {
+    for (auto gpo : results.keys()) {
+        if (!gplink.contains(gpo)) {
             continue;
         }
 
-        const AdObject object = results[dn];
+        const AdObject object = results[gpo];
 
         const QString display_name = object.get_string(ATTRIBUTE_DISPLAY_NAME);
 
         const QList<QStandardItem *> row = make_item_row(GplinkColumn_COUNT);
         row[GplinkColumn_Name]->setText(display_name);
-        set_data_for_row(row, dn, GplinkRole_DN);
+        set_data_for_row(row, gpo, GplinkRole_DN);
 
         for (const auto column : option_columns) {
             QStandardItem *item = row[column];
@@ -274,7 +272,7 @@ void GroupPolicyTab::reload_gplink() {
 
             const Qt::CheckState checkstate = [=]() {
                 const GplinkOption option = column_to_option[column];
-                const bool option_is_set = gplink.get_option(dn, option);
+                const bool option_is_set = gplink.get_option(gpo, option);
                 if (option_is_set) {
                     return Qt::Checked;
                 } else {

--- a/tests/admc_test_gplink.cpp
+++ b/tests/admc_test_gplink.cpp
@@ -22,6 +22,18 @@
 
 #include "gplink.h"
 
+Q_DECLARE_METATYPE(GplinkOption)
+
+const QString test_gplink_string = "[LDAP://cn={AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA},cn=policies,cn=system,DC=domain,DC=alt;0][LDAP://cn={BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB},cn=policies,cn=system,DC=domain,DC=alt;1][LDAP://cn={CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC},cn=policies,cn=system,DC=domain,DC=alt;2]";
+
+const QString dn_A = "CN={AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA},CN=Policies,CN=System,DC=domain,DC=alt";
+const QString dn_B = "CN={BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB},CN=Policies,CN=System,DC=domain,DC=alt";
+const QString dn_C = "CN={CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC},CN=Policies,CN=System,DC=domain,DC=alt";
+
+const QString gplink_A = "[LDAP://cn={AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA},cn=policies,cn=system,DC=domain,DC=alt;0]";
+const QString gplink_B = "[LDAP://cn={BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB},cn=policies,cn=system,DC=domain,DC=alt;1]";
+const QString gplink_C = "[LDAP://cn={CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC},cn=policies,cn=system,DC=domain,DC=alt;2]";
+
 void test_gplink_equality(const Gplink &a, const QString &b);
 
 void ADMCTestGplink::initTestCase() {
@@ -36,126 +48,187 @@ void ADMCTestGplink::init() {
 void ADMCTestGplink::cleanup() {
 }
 
-void ADMCTestGplink::test_to_string() {
-    const QString gplink_string = "[LDAP://a;0][LDAP://b;0][LDAP://c;0][LDAP://UPPER;0]";
-    Gplink gplink(gplink_string);
+void ADMCTestGplink::to_string() {
+    Gplink gplink(test_gplink_string);
 
-    QVERIFY((gplink.to_string() == gplink_string));
+    QCOMPARE(gplink.to_string(), test_gplink_string);
 }
 
-void ADMCTestGplink::test_get_gpos() {
-    const QString gplink_string = "[LDAP://a;0][LDAP://b;0][LDAP://c;0][LDAP://UPPER;0]";
-    Gplink gplink(gplink_string);
+void ADMCTestGplink::contains_data() {
+    QTest::addColumn<QString>("gpo");
+    QTest::addColumn<bool>("contains_value");
 
-    const QList<QString> gpos = gplink.get_gpos();
-    const QList<QString> correct_gpos = {"a", "b", "c", "UPPER"};
-
-    QVERIFY((gpos == correct_gpos));
+    QTest::newRow("a") << dn_A << true;
+    QTest::newRow("b") << dn_B << true;
+    QTest::newRow("c") << dn_C << true;
+    QTest::newRow("shouldn't contains") << "CN={00000000-016D-11D2-945F-00C04FB984F9},CN=Policies,CN=Dystem,DC=domain,DC=alt" << false;
 }
 
-void ADMCTestGplink::test_add() {
-    const QString gplink_string = "[LDAP://a;0][LDAP://b;0][LDAP://c;0][LDAP://UPPER;0]";
-    Gplink gplink(gplink_string);
+void ADMCTestGplink::contains() {
+    QFETCH(QString, gpo);
+    QFETCH(bool, contains_value);
+    
+    Gplink gplink(test_gplink_string);
 
-    // Simple add
-    gplink.add("added gpo");
-
-    // Test that case is preserved
-    gplink.add("added gpo UPPERCASE");
-
-    // Test that duplicates are ignored
-    gplink.add("a");
-
-    const QString correct_gplink_string = "[LDAP://a;0][LDAP://b;0][LDAP://c;0][LDAP://UPPER;0][LDAP://added gpo;0][LDAP://added gpo UPPERCASE;0]";
-
-    test_gplink_equality(gplink, correct_gplink_string);
+    QCOMPARE(gplink.contains(gpo), contains_value);
 }
 
-void ADMCTestGplink::test_remove() {
-    const QString gplink_string = "[LDAP://a;0][LDAP://b;0][LDAP://c;0][LDAP://UPPER;0]";
-    Gplink gplink(gplink_string);
+void ADMCTestGplink::add_data() {
+    QTest::addColumn<QString>("gplink_before");
+    QTest::addColumn<QList<QString>>("gpo_list");
+    QTest::addColumn<QString>("gplink_after");
 
-    gplink.remove("b");
-
-    gplink.remove("non existing gpo");
-
-    const QString correct_gplink_string = "[LDAP://a;0][LDAP://c;0][LDAP://UPPER;0]";
-
-    test_gplink_equality(gplink, correct_gplink_string);
+    QTest::newRow("add to empty") << "" << QList<QString>({dn_A}) << gplink_A;
+    QTest::newRow("add to non-empty") << gplink_B << QList<QString>({dn_A}) << (gplink_B + gplink_A);
+    QTest::newRow("add same one twice to empty") << "" << QList<QString>({dn_A, dn_A}) << gplink_A;
+    QTest::newRow("add already existing") << "gplink_A" << QList<QString>({dn_A}) << gplink_A;
 }
 
-void ADMCTestGplink::test_move_up() {
-    const QString gplink_string = "[LDAP://a;0][LDAP://b;0][LDAP://c;0][LDAP://UPPER;0]";
-    Gplink gplink(gplink_string);
+void ADMCTestGplink::add() {
+    QFETCH(QString, gplink_before);
+    QFETCH(QList<QString>, gpo_list);
+    QFETCH(QString, gplink_after);
 
-    gplink.move_up("b");
+    Gplink gplink(gplink_before);
 
-    gplink.move_up("non existing gpo");
+    for (const QString &gpo : gpo_list) {
+        gplink.add(gpo);
+    }
 
-    const QString correct_gplink_string = "[LDAP://b;0][LDAP://a;0][LDAP://c;0][LDAP://UPPER;0]";
-
-    test_gplink_equality(gplink, correct_gplink_string);
+    QCOMPARE(gplink.to_string(), gplink_after);
 }
 
-void ADMCTestGplink::test_move_down() {
-    const QString gplink_string = "[LDAP://a;0][LDAP://b;0][LDAP://c;0][LDAP://UPPER;0]";
-    Gplink gplink(gplink_string);
+void ADMCTestGplink::remove_data() {
+    QTest::addColumn<QString>("gplink_before");
+    QTest::addColumn<QList<QString>>("gpo_list");
+    QTest::addColumn<QString>("gplink_after");
 
-    gplink.move_down("b");
-
-    gplink.move_down("non existing gpo");
-
-    const QString correct_gplink_string = "[LDAP://a;0][LDAP://c;0][LDAP://b;0][LDAP://UPPER;0]";
-
-    test_gplink_equality(gplink, correct_gplink_string);
+    QTest::newRow("remove 1") << gplink_A << QList<QString>({dn_A}) << "";
+    QTest::newRow("remove from empty") << "" << QList<QString>({dn_A}) << "";
+    QTest::newRow("remove same one twice") << gplink_A << QList<QString>({dn_A, dn_A}) << "";
+    QTest::newRow("remove from multiple") << (gplink_A + gplink_B) << QList<QString>({dn_A}) << gplink_B;
 }
 
-void ADMCTestGplink::test_get_option() {
-    const QString gplink_string = "[LDAP://a;0][LDAP://b;0][LDAP://c;1][LDAP://UPPER;0]";
-    Gplink gplink(gplink_string);
+void ADMCTestGplink::remove() {
+    QFETCH(QString, gplink_before);
+    QFETCH(QList<QString>, gpo_list);
+    QFETCH(QString, gplink_after);
 
-    const bool b_option = gplink.get_option("b", GplinkOption_Disabled);
-    QVERIFY(b_option == false);
+    Gplink gplink(gplink_before);
 
-    const bool c_option = gplink.get_option("c", GplinkOption_Disabled);
-    QVERIFY(c_option == true);
+    for (const QString &gpo : gpo_list) {
+        gplink.remove(gpo);
+    }
 
-    // Should return for non-existing gpo
-    const bool non_existing_option = gplink.get_option("non_existing_option", GplinkOption_Disabled);
-    QVERIFY(non_existing_option == false);
+    QCOMPARE(gplink.to_string(), gplink_after);
 }
 
-void ADMCTestGplink::test_set_option() {
-    const QString gplink_string = "[LDAP://a;0][LDAP://b;0][LDAP://c;1][LDAP://UPPER;0]";
-    Gplink gplink(gplink_string);
+void ADMCTestGplink::move_up_data() {
+    QTest::addColumn<QString>("gplink_before");
+    QTest::addColumn<QList<QString>>("gpo_list");
+    QTest::addColumn<QString>("gplink_after");
 
-    gplink.set_option("b", GplinkOption_Disabled, true);
-    gplink.set_option("c", GplinkOption_Enforced, true);
-
-    const QString correct_gplink_string = "[LDAP://a;0][LDAP://b;1][LDAP://c;3][LDAP://UPPER;0]";
-
-    test_gplink_equality(gplink, correct_gplink_string);
+    QTest::newRow("move up empty") << "" << QList<QString>({dn_A}) << "";
+    QTest::newRow("move up single") << gplink_A << QList<QString>({dn_A}) << gplink_A;
+    QTest::newRow("move up non-existing") << gplink_A << QList<QString>({dn_B}) << gplink_A;
+    QTest::newRow("move up from [2] to [1]") << (gplink_A + gplink_B + gplink_C) << QList<QString>({dn_C}) << (gplink_A + gplink_C + gplink_B);
+    QTest::newRow("move up twice from [2] to [0]") << (gplink_A + gplink_B + gplink_C) << QList<QString>({dn_C, dn_C}) << (gplink_C + gplink_A + gplink_B);
 }
 
-void ADMCTestGplink::test_equals() {
-    const QString a_string = "[LDAP://a;0][LDAP://b;0][LDAP://c;1][LDAP://UPPER;0]";
-    Gplink a_gplink(a_string);
-    QVERIFY(a_gplink.equals(a_string));
+void ADMCTestGplink::move_up() {
+    QFETCH(QString, gplink_before);
+    QFETCH(QList<QString>, gpo_list);
+    QFETCH(QString, gplink_after);
 
-    const QString b_string = "[LDAP://a;0][LDAP://b;0]";
-    Gplink b_gplink(b_string);
-    QVERIFY(!b_gplink.equals(a_string));
+    Gplink gplink(gplink_before);
 
-    // Comparison should be case insensitive
-    const QString c_string = "[LDAP://a;0][LDAP://b;0]";
-    const QString d_string = "[LDAP://A;0][LDAP://B;0]";
-    Gplink c_gplink(c_string);
-    QVERIFY(c_gplink.equals(d_string));
+    for (const QString &gpo : gpo_list) {
+        gplink.move_up(gpo);
+    }
+
+    QCOMPARE(gplink.to_string(), gplink_after);
 }
 
-void test_gplink_equality(const Gplink &a, const QString &b) {
-    const QString fail_msg = QString("gplink test failed\nthis = \t  %1\ncorrect = %2").arg(a.to_string(), b);
-    QVERIFY2((a.to_string() == b), fail_msg.toUtf8().constData());
+void ADMCTestGplink::move_down_data() {
+    QTest::addColumn<QString>("gplink_before");
+    QTest::addColumn<QList<QString>>("gpo_list");
+    QTest::addColumn<QString>("gplink_after");
+
+    QTest::newRow("move down empty") << "" << QList<QString>({dn_A}) << "";
+    QTest::newRow("move down single") << gplink_A << QList<QString>({dn_A}) << gplink_A;
+    QTest::newRow("move down non-existing") << gplink_A << QList<QString>({dn_B}) << gplink_A;
+    QTest::newRow("move down from [1] to [2]") << (gplink_A + gplink_B + gplink_C) << QList<QString>({dn_B}) << (gplink_A + gplink_C + gplink_B);
+    QTest::newRow("move down twice from [0] to [2]") << (gplink_A + gplink_B + gplink_C) << QList<QString>({dn_A, dn_A}) << (gplink_B + gplink_C + gplink_A);
+}
+
+void ADMCTestGplink::move_down() {
+    QFETCH(QString, gplink_before);
+    QFETCH(QList<QString>, gpo_list);
+    QFETCH(QString, gplink_after);
+
+    Gplink gplink(gplink_before);
+
+    for (const QString &gpo : gpo_list) {
+        gplink.move_down(gpo);
+    }
+
+    QCOMPARE(gplink.to_string(), gplink_after);
+}
+
+void ADMCTestGplink::get_option_data() {
+    QTest::addColumn<QString>("gplink_before");
+    QTest::addColumn<QString>("gpo");
+    QTest::addColumn<GplinkOption>("option");
+    QTest::addColumn<bool>("option_value");
+
+    QTest::newRow("A disabled") << gplink_A << dn_A << GplinkOption_Disabled << false;
+    QTest::newRow("A enforced") << gplink_A << dn_A << GplinkOption_Enforced << false;
+
+    QTest::newRow("B disabled") << gplink_B << dn_B << GplinkOption_Disabled << true;
+    QTest::newRow("B enforced") << gplink_B << dn_B << GplinkOption_Enforced << false;
+
+    QTest::newRow("C disabled") << gplink_C << dn_C << GplinkOption_Disabled << false;
+    QTest::newRow("C enforced") << gplink_C << dn_C << GplinkOption_Enforced << true;
+}
+
+void ADMCTestGplink::get_option() {
+    QFETCH(QString, gplink_before);
+    QFETCH(QString, gpo);
+    QFETCH(GplinkOption, option);
+    QFETCH(bool, option_value);
+
+    Gplink gplink(gplink_before);
+
+    const bool actual_value = gplink.get_option(gpo, option);
+
+    QCOMPARE(actual_value, option_value);
+}
+
+void ADMCTestGplink::set_option_data() {
+    QTest::addColumn<QString>("gplink_before");
+    QTest::addColumn<QString>("gpo");
+    QTest::addColumn<GplinkOption>("option");
+    QTest::addColumn<bool>("option_value");
+    QTest::addColumn<QString>("gplink_after");
+
+    QTest::newRow("set disabled true") << "[LDAP://cn={AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA},cn=policies,cn=system,DC=domain,DC=alt;0]" << dn_A << GplinkOption_Disabled << true << "[LDAP://cn={AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA},cn=policies,cn=system,DC=domain,DC=alt;1]";
+    QTest::newRow("set enforced true") << "[LDAP://cn={AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA},cn=policies,cn=system,DC=domain,DC=alt;0]" << dn_A << GplinkOption_Enforced << true << "[LDAP://cn={AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA},cn=policies,cn=system,DC=domain,DC=alt;2]";
+    QTest::newRow("set disabled false") << "[LDAP://cn={AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA},cn=policies,cn=system,DC=domain,DC=alt;1]" << dn_A << GplinkOption_Disabled << false << "[LDAP://cn={AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA},cn=policies,cn=system,DC=domain,DC=alt;0]";
+    QTest::newRow("set enforced false") << "[LDAP://cn={AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA},cn=policies,cn=system,DC=domain,DC=alt;2]" << dn_A << GplinkOption_Enforced << false << "[LDAP://cn={AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA},cn=policies,cn=system,DC=domain,DC=alt;0]";
+}
+
+void ADMCTestGplink::set_option() {
+    QFETCH(QString, gplink_before);
+    QFETCH(QString, gpo);
+    QFETCH(GplinkOption, option);
+    QFETCH(bool, option_value);
+    QFETCH(QString, gplink_after);
+
+    Gplink gplink(gplink_before);
+
+    gplink.set_option(gpo, option, option_value);
+
+    QCOMPARE(gplink.to_string(), gplink_after);
 }
 
 QTEST_MAIN(ADMCTestGplink)

--- a/tests/admc_test_gplink.h
+++ b/tests/admc_test_gplink.h
@@ -35,15 +35,21 @@ public slots:
     void cleanup();
 
 private slots:
-    void test_to_string();
-    void test_get_gpos();
-    void test_add();
-    void test_remove();
-    void test_move_up();
-    void test_move_down();
-    void test_get_option();
-    void test_set_option();
-    void test_equals();
+    void to_string();
+    void contains_data();
+    void contains();
+    void add_data();
+    void add();
+    void remove_data();
+    void remove();
+    void move_up_data();
+    void move_up();
+    void move_down_data();
+    void move_down();
+    void get_option_data();
+    void get_option();
+    void set_option_data();
+    void set_option();
 };
 
 #endif /* ADMC_TEST_GPLINK_H */


### PR DESCRIPTION
Gplink handled case incorrectly and preserved incorrect case instead of converting it to correct case.

Change it so that gplink converts all input to lower case and internally uses lower-case everywhere.

When outputting through to_string(), convert to Windows style case.

closes #270 
closes #271 