### PR TITLE
Feature/protect against deletion

### DIFF
--- a/.gear/admc.spec
+++ b/.gear/admc.spec
@@ -100,6 +100,7 @@ Tests for ADMC
 %_bindir/admc_test_delegation_edit
 %_bindir/admc_test_string_other_edit
 %_bindir/admc_test_account_option_edit
+%_bindir/admc_test_protect_deletion_edit
 %_bindir/admc_test_gpoptions_edit
 %_bindir/admc_test_octet_editor
 %_bindir/admc_test_bool_editor

--- a/src/adldap/ad_defines.h
+++ b/src/adldap/ad_defines.h
@@ -244,6 +244,8 @@ enum AcePermission {
     AcePermission_FullControl,
     AcePermission_Read,
     AcePermission_Write,
+    AcePermission_Delete,
+    AcePermission_DeleteSubtree,
     AcePermission_CreateChild,
     AcePermission_DeleteChild,
     AcePermission_AllowedToAuthenticate,

--- a/src/adldap/ad_security.h
+++ b/src/adldap/ad_security.h
@@ -53,6 +53,8 @@ QString ad_security_get_trustee_name(AdInterface &ad, const QByteArray &trustee)
 bool attribute_replace_security_descriptor(AdInterface *ad, const QString &dn, const QHash<QByteArray, QHash<AcePermission, PermissionState>> &descriptor_state_arg);
 QList<QByteArray> ad_security_get_trustee_list_from_object(const AdObject &object);
 QHash<QByteArray, QHash<AcePermission, PermissionState>> ad_security_get_state_from_sd(security_descriptor *sd, AdConfig *adconfig);
+bool ad_security_get_protected_against_deletion(const AdObject &object, AdConfig *config);
+bool ad_security_set_protected_against_deletion(AdInterface &ad, const QString dn, AdConfig *config, const bool enabled);
 
 // NOTE: have to talloc_free() returned sd
 security_descriptor *ad_security_get_sd(const AdObject &object);
@@ -60,5 +62,6 @@ security_descriptor *ad_security_get_sd(const AdObject &object);
 void ad_security_sort_dacl(security_descriptor *sd);
 
 QByteArray dom_sid_to_bytes(const dom_sid &sid);
+QByteArray dom_sid_string_to_bytes(const dom_sid &sid);
 
 #endif /* AD_SECURITY_H */

--- a/src/admc/CMakeLists.txt
+++ b/src/admc/CMakeLists.txt
@@ -144,6 +144,7 @@ set(ADMC_SOURCES
     edits/delegation_edit.cpp
     edits/logon_hours_edit.cpp
     edits/logon_computers_edit.cpp
+    edits/protect_deletion_edit.cpp
 
     console_widget/console_widget.cpp
     console_widget/scope_proxy_model.cpp

--- a/src/admc/create_object_dialog.cpp
+++ b/src/admc/create_object_dialog.cpp
@@ -27,6 +27,7 @@
 #include "edits/password_edit.h"
 #include "edits/string_edit.h"
 #include "edits/upn_edit.h"
+#include "edits/protect_deletion_edit.h"
 #include "globals.h"
 #include "settings.h"
 #include "status.h"
@@ -188,6 +189,9 @@ CreateObjectDialog::CreateObjectDialog(const QString &parent_dn_arg, const QStri
             });
     } else if (object_class == CLASS_OU) {
         edits_layout->addRow(tr("Name:"), name_edit);
+        
+        auto protect_deletion_edit = new ProtectDeletionEdit(&all_edits, this);
+        protect_deletion_edit->add_to_layout(edits_layout);
     } else {
         qWarning() << "Class" << object_class << "is unsupported by create dialog";
         return;

--- a/src/admc/create_object_dialog.cpp
+++ b/src/admc/create_object_dialog.cpp
@@ -191,6 +191,7 @@ CreateObjectDialog::CreateObjectDialog(const QString &parent_dn_arg, const QStri
         edits_layout->addRow(tr("Name:"), name_edit);
         
         auto protect_deletion_edit = new ProtectDeletionEdit(&all_edits, this);
+        protect_deletion_edit->set_enabled(true);
         protect_deletion_edit->add_to_layout(edits_layout);
     } else {
         qWarning() << "Class" << object_class << "is unsupported by create dialog";

--- a/src/admc/edits/protect_deletion_edit.cpp
+++ b/src/admc/edits/protect_deletion_edit.cpp
@@ -42,6 +42,10 @@ ProtectDeletionEdit::ProtectDeletionEdit(QList<AttributeEdit *> *edits_out, QObj
         });
 }
 
+void ProtectDeletionEdit::set_enabled(const bool enabled) {
+    check->setChecked(enabled);
+}
+
 void ProtectDeletionEdit::load_internal(AdInterface &ad, const AdObject &object) {
     const bool enabled = ad_security_get_protected_against_deletion(object, g_adconfig);
 

--- a/src/admc/edits/protect_deletion_edit.cpp
+++ b/src/admc/edits/protect_deletion_edit.cpp
@@ -1,0 +1,64 @@
+/*
+ * ADMC - AD Management Center
+ *
+ * Copyright (C) 2020-2021 BaseALT Ltd.
+ * Copyright (C) 2020-2021 Dmitry Degtyarev
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "edits/protect_deletion_edit.h"
+
+#include "adldap.h"
+#include "utils.h"
+#include "globals.h"
+
+#include <QCheckBox>
+#include <QFormLayout>
+
+// Object is protected from deletion if it denies
+// permissions for "delete" and "delete subtree" for
+// "WORLD"(everyone) trustee
+
+ProtectDeletionEdit::ProtectDeletionEdit(QList<AttributeEdit *> *edits_out, QObject *parent)
+: AttributeEdit(edits_out, parent) {
+    check = new QCheckBox(tr("Protect against deletion"));
+
+    connect(
+        check, &QCheckBox::stateChanged,
+        [this]() {
+            emit edited();
+        });
+}
+
+void ProtectDeletionEdit::load_internal(AdInterface &ad, const AdObject &object) {
+    const bool enabled = ad_security_get_protected_against_deletion(object, g_adconfig);
+
+    check->setChecked(enabled);
+}
+
+void ProtectDeletionEdit::set_read_only(const bool read_only) {
+    check->setDisabled(read_only);
+}
+
+void ProtectDeletionEdit::add_to_layout(QFormLayout *layout) {
+    layout->addRow(check);
+}
+
+bool ProtectDeletionEdit::apply(AdInterface &ad, const QString &dn) const {
+    const bool enabled = check->isChecked();
+    const bool apply_success = ad_security_set_protected_against_deletion(ad, dn, g_adconfig, enabled);
+
+    return apply_success;
+}

--- a/src/admc/edits/protect_deletion_edit.h
+++ b/src/admc/edits/protect_deletion_edit.h
@@ -1,0 +1,43 @@
+/*
+ * ADMC - AD Management Center
+ *
+ * Copyright (C) 2020-2021 BaseALT Ltd.
+ * Copyright (C) 2020-2021 Dmitry Degtyarev
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef PROTECT_DELETION_EDIT_H
+#define PROTECT_DELETION_EDIT_H
+
+/**
+ * Checkbox edit that modifies ACL to protect (or not)
+ * against deletion by denying/allowing deletion.
+ */
+
+#include "edits/attribute_edit.h"
+
+class QCheckBox;
+
+class ProtectDeletionEdit final : public AttributeEdit {
+    Q_OBJECT
+public:
+    ProtectDeletionEdit(QList<AttributeEdit *> *edits_out, QObject *parent);
+    DECL_ATTRIBUTE_EDIT_VIRTUALS();
+
+private:
+    QCheckBox *check;
+};
+
+#endif /* PROTECT_DELETION_EDIT_H */

--- a/src/admc/edits/protect_deletion_edit.h
+++ b/src/admc/edits/protect_deletion_edit.h
@@ -36,6 +36,8 @@ public:
     ProtectDeletionEdit(QList<AttributeEdit *> *edits_out, QObject *parent);
     DECL_ATTRIBUTE_EDIT_VIRTUALS();
 
+    void set_enabled(const bool enabled);
+
 private:
     QCheckBox *check;
 };

--- a/src/admc/tabs/object_tab.cpp
+++ b/src/admc/tabs/object_tab.cpp
@@ -23,6 +23,7 @@
 #include "adldap.h"
 #include "edits/datetime_edit.h"
 #include "edits/string_edit.h"
+#include "edits/protect_deletion_edit.h"
 
 #include <QFormLayout>
 
@@ -37,6 +38,8 @@ ObjectTab::ObjectTab() {
     new StringEdit(ATTRIBUTE_USN_CHANGED, "", &edits, this);
 
     edits_set_read_only(edits, true);
+
+    new ProtectDeletionEdit(&edits, this);
 
     edits_connect_to_tab(edits, this);
 

--- a/src/admc/tabs/security_tab.cpp
+++ b/src/admc/tabs/security_tab.cpp
@@ -47,6 +47,8 @@ const QHash<AcePermission, QString> ace_permission_to_name_map = {
     {AcePermission_FullControl, QCoreApplication::translate("Security", "Full control")},
     {AcePermission_Read, QCoreApplication::translate("Security", "Read")},
     {AcePermission_Write, QCoreApplication::translate("Security", "Write")},
+    {AcePermission_Delete, QCoreApplication::translate("Security", "Delete")},
+    {AcePermission_DeleteSubtree, QCoreApplication::translate("Security", "Delete subtree")},
     {AcePermission_CreateChild, QCoreApplication::translate("Security", "Create child")},
     {AcePermission_DeleteChild, QCoreApplication::translate("Security", "Delete child")},
     {AcePermission_AllowedToAuthenticate, QCoreApplication::translate("Security", "Allowed to authenticate")},

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,6 +59,7 @@ set(TEST_TARGETS
     admc_test_string_other_edit
     admc_test_account_option_edit
     admc_test_gpoptions_edit
+    admc_test_protect_deletion_edit
     admc_test_octet_editor
     admc_test_bool_editor
     admc_test_datetime_editor

--- a/tests/admc_test_protect_deletion_edit.cpp
+++ b/tests/admc_test_protect_deletion_edit.cpp
@@ -1,0 +1,91 @@
+/*
+ * ADMC - AD Management Center
+ *
+ * Copyright (C) 2020-2021 BaseALT Ltd.
+ * Copyright (C) 2020-2021 Dmitry Degtyarev
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "admc_test_protect_deletion_edit.h"
+
+#include "edits/protect_deletion_edit.h"
+
+#include <QCheckBox>
+#include <QFormLayout>
+
+// NOTE: this doesn't really "lock" accounts. Accounts can
+// only be locked by the server and lockout time only
+// displays the state. Since unlock edit modifies lockout
+// time, test it like this.
+#define LOCKOUT_LOCKED_VALUE "1"
+
+void ADMCTestProtectDeletionEdit::init() {
+    ADMCTest::init();
+
+    edit = new ProtectDeletionEdit(&edits, parent_widget);
+    add_attribute_edit(edit);
+
+    checkbox = parent_widget->findChild<QCheckBox *>();
+    QVERIFY(checkbox != nullptr);
+
+    dn = test_object_dn(TEST_OU, CLASS_OU);
+    const bool create_success = ad.object_add(dn, CLASS_OU);
+    QVERIFY(create_success);
+}
+
+// edited() signal should be emitted when checkbox is toggled
+void ADMCTestProtectDeletionEdit::emit_edited_signal() {
+    bool edited_signal_emitted = false;
+    connect(
+        edit, &AttributeEdit::edited,
+        [&edited_signal_emitted]() {
+            edited_signal_emitted = true;
+        });
+
+    // Check checkbox
+    checkbox->setChecked(true);
+    QVERIFY(edited_signal_emitted);
+
+    // Unheck checkbox
+    edited_signal_emitted = false;
+    checkbox->setChecked(false);
+    QVERIFY(edited_signal_emitted);
+}
+
+// Edit should unlock locked user if checkbox is checked
+void ADMCTestProtectDeletionEdit::apply() {
+    const AdObject object = ad.search_object(dn);
+    edit->load(ad, object);
+
+    // Enable protection against deletion
+    checkbox->setChecked(true);
+    const bool apply_success = edit->apply(ad, dn);
+    QVERIFY(apply_success);
+
+    // Try to delete, should fail
+    qInfo() << "Error relating to \"Insufficient access\" is part of the test";
+    const bool delete_success = ad.object_delete(dn);
+    QCOMPARE(delete_success, false);
+
+    // Disable protection against deletion
+    checkbox->setChecked(false);
+    const bool apply_2_success = edit->apply(ad, dn);
+    QVERIFY(apply_2_success);
+
+    const bool delete_2_success = ad.object_delete(dn);
+    QCOMPARE(delete_2_success, true);
+}
+
+QTEST_MAIN(ADMCTestProtectDeletionEdit)

--- a/tests/admc_test_protect_deletion_edit.h
+++ b/tests/admc_test_protect_deletion_edit.h
@@ -1,0 +1,44 @@
+/*
+ * ADMC - AD Management Center
+ *
+ * Copyright (C) 2020-2021 BaseALT Ltd.
+ * Copyright (C) 2020-2021 Dmitry Degtyarev
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ADMC_TEST_PROTECT_DELETION_EDIT_H
+#define ADMC_TEST_PROTECT_DELETION_EDIT_H
+
+#include "admc_test.h"
+
+class ProtectDeletionEdit;
+class QCheckBox;
+
+class ADMCTestProtectDeletionEdit : public ADMCTest {
+    Q_OBJECT
+
+private slots:
+    void init() override;
+
+    void emit_edited_signal();
+    void apply();
+
+private:
+    ProtectDeletionEdit *edit;
+    QCheckBox *checkbox;
+    QString dn;
+};
+
+#endif /* ADMC_TEST_PROTECT_DELETION_EDIT_H */


### PR DESCRIPTION
Add edit for "Protect against deletion".
Located in object tab for all objects and in create dialog for OU's.
Went the easy route and added "delete" and "delete subtree" permissions to security tab and my security API for easy implementation. Can later hide those permissions into advanced security dialog, if needed.

closes #283 