### PR TITLE
Improve object creation

### DIFF
--- a/src/adldap/ad_config.h
+++ b/src/adldap/ad_config.h
@@ -71,6 +71,10 @@ public:
     QList<ObjectClass> get_filter_containers() const;
 
     QList<ObjectClass> get_possible_superiors(const QList<ObjectClass> &object_classes) const;
+    ObjectClass get_parent_class(const ObjectClass &object_class) const;
+    // Returns all ancestors of given class and the
+    // given class itself
+    QList<ObjectClass> get_inherit_chain(const ObjectClass &object_class) const;
 
     QList<Attribute> get_optional_attributes(const QList<ObjectClass> &object_classes) const;
     QList<Attribute> get_mandatory_attributes(const QList<ObjectClass> &object_classes) const;

--- a/src/adldap/ad_config_p.h
+++ b/src/adldap/ad_config_p.h
@@ -68,6 +68,8 @@ public:
     QHash<QByteArray, QString> guid_to_class_map;
 
     QList<QString> supported_control_list;
+
+    QHash<QString, QString> sub_class_of_map;
 };
 
 #endif /* AD_CONFIG_P_H */

--- a/src/adldap/ad_defines.h
+++ b/src/adldap/ad_defines.h
@@ -195,6 +195,7 @@ enum SystemFlagsBit {
 #define ATTRIBUTE_SCHEMA_ID_GUID "schemaIDGUID"
 #define ATTRIBUTE_APPLIES_TO "appliesTo"
 #define ATTRIBUTE_VALID_ACCESSES "validAccesses"
+#define ATTRIBUTE_UNC_NAME "uNCName"
 
 #define CLASS_GROUP "group"
 #define CLASS_USER "user"

--- a/src/adldap/ad_interface.h
+++ b/src/adldap/ad_interface.h
@@ -143,7 +143,15 @@ public:
     bool attribute_replace_int(const QString &dn, const QString &attribute, const int value, const DoStatusMsg do_msg = DoStatusMsg_Yes);
     bool attribute_replace_datetime(const QString &dn, const QString &attribute, const QDateTime &datetime);
 
+    // NOTE: attrs_map should contain attribute values
+    // that will be added to the newly created object.
+    // Note that it *must* contain a valid value for
+    // objectClass attribute.
+    bool object_add(const QString &dn, const QHash<QString, QList<QString>> &attrs_map);
+    // Simplified version that only only adds one
+    // objectClass value
     bool object_add(const QString &dn, const QString &object_class);
+
     bool object_delete(const QString &dn, const DoStatusMsg do_msg = DoStatusMsg_Yes);
     bool object_move(const QString &dn, const QString &new_container);
     bool object_rename(const QString &dn, const QString &new_name);

--- a/src/admc/CMakeLists.txt
+++ b/src/admc/CMakeLists.txt
@@ -56,6 +56,7 @@ set(ADMC_SOURCES
     create_group_dialog.cpp
     create_computer_dialog.cpp
     create_ou_dialog.cpp
+    create_shared_folder_dialog.cpp
     create_policy_dialog.cpp
     create_query_item_dialog.cpp
     create_query_folder_dialog.cpp

--- a/src/admc/CMakeLists.txt
+++ b/src/admc/CMakeLists.txt
@@ -57,6 +57,7 @@ set(ADMC_SOURCES
     create_computer_dialog.cpp
     create_ou_dialog.cpp
     create_shared_folder_dialog.cpp
+    create_contact_dialog.cpp
     create_policy_dialog.cpp
     create_query_item_dialog.cpp
     create_query_folder_dialog.cpp

--- a/src/admc/console_impls/object_impl.cpp
+++ b/src/admc/console_impls/object_impl.cpp
@@ -904,6 +904,11 @@ void ObjectImpl::new_object(const QString &object_class) {
 
     const QString parent_dn = get_action_target_dn_object(console);
 
+    // NOTE: creating dialogs here instead of directly
+    // in "on_new_x" slots looks backwards but it's
+    // necessary to avoid even more code duplication
+    // due to having to pass "ad" and "parent_dn" args
+    // to dialog ctors
     CreateObjectDialog *dialog = [&]() -> CreateObjectDialog * {
         const bool is_user = (object_class == CLASS_USER);
         const bool is_group = (object_class == CLASS_GROUP);

--- a/src/admc/console_impls/object_impl.cpp
+++ b/src/admc/console_impls/object_impl.cpp
@@ -32,6 +32,7 @@
 #include "create_ou_dialog.h"
 #include "create_user_dialog.h"
 #include "create_shared_folder_dialog.h"
+#include "create_contact_dialog.h"
 #include "attribute_dialogs/list_attribute_dialog.h"
 #include "find_object_dialog.h"
 #include "globals.h"
@@ -88,6 +89,7 @@ ObjectImpl::ObjectImpl(ConsoleWidget *console_arg)
     new_action_map[CLASS_GROUP] = new QAction(tr("Group"), this);
     new_action_map[CLASS_SHARED_FOLDER] = new QAction(tr("Shared Folder"), this);
     new_action_map[CLASS_INET_ORG_PERSON] = new QAction(tr("inetOrgPerson"), this);
+    new_action_map[CLASS_CONTACT] = new QAction(tr("Contact"), this);
     find_action = new QAction(tr("Find..."), this);
     move_action = new QAction(tr("Move..."), this);
     add_to_group_action = new QAction(tr("Add to group..."), this);
@@ -129,6 +131,9 @@ ObjectImpl::ObjectImpl(ConsoleWidget *console_arg)
     connect(
         new_action_map[CLASS_INET_ORG_PERSON], &QAction::triggered,
         this, &ObjectImpl::on_new_inet_org_person);
+    connect(
+        new_action_map[CLASS_CONTACT], &QAction::triggered,
+        this, &ObjectImpl::on_new_contact);
     connect(
         move_action, &QAction::triggered,
         this, &ObjectImpl::on_move);
@@ -708,6 +713,10 @@ void ObjectImpl::on_new_inet_org_person() {
     new_object(CLASS_INET_ORG_PERSON);
 }
 
+void ObjectImpl::on_new_contact() {
+    new_object(CLASS_CONTACT);
+}
+
 void ObjectImpl::on_move() {
     AdInterface ad;
     if (ad_failed(ad, console)) {
@@ -902,6 +911,7 @@ void ObjectImpl::new_object(const QString &object_class) {
         const bool is_ou = (object_class == CLASS_OU);
         const bool is_shared_folder = (object_class == CLASS_SHARED_FOLDER);
         const bool is_inet_org_person = (object_class == CLASS_INET_ORG_PERSON);
+        const bool is_contact = (object_class == CLASS_CONTACT);
 
         if (is_user) {
             return new CreateUserDialog(ad, parent_dn, CLASS_USER, console);
@@ -915,6 +925,8 @@ void ObjectImpl::new_object(const QString &object_class) {
             return new CreateSharedFolderDialog(parent_dn, console);
         } else if (is_inet_org_person) {
             return new CreateUserDialog(ad, parent_dn, CLASS_INET_ORG_PERSON, console);
+        } else if (is_contact) {
+            return new CreateContactDialog(parent_dn, console);
         } else {
             return nullptr;
         }

--- a/src/admc/console_impls/object_impl.cpp
+++ b/src/admc/console_impls/object_impl.cpp
@@ -87,6 +87,7 @@ ObjectImpl::ObjectImpl(ConsoleWidget *console_arg)
     new_action_map[CLASS_OU] = new QAction(tr("OU"), this);
     new_action_map[CLASS_GROUP] = new QAction(tr("Group"), this);
     new_action_map[CLASS_SHARED_FOLDER] = new QAction(tr("Shared Folder"), this);
+    new_action_map[CLASS_INET_ORG_PERSON] = new QAction(tr("inetOrgPerson"), this);
     find_action = new QAction(tr("Find..."), this);
     move_action = new QAction(tr("Move..."), this);
     add_to_group_action = new QAction(tr("Add to group..."), this);
@@ -125,6 +126,9 @@ ObjectImpl::ObjectImpl(ConsoleWidget *console_arg)
     connect(
         new_action_map[CLASS_SHARED_FOLDER], &QAction::triggered,
         this, &ObjectImpl::on_new_shared_folder);
+    connect(
+        new_action_map[CLASS_INET_ORG_PERSON], &QAction::triggered,
+        this, &ObjectImpl::on_new_inet_org_person);
     connect(
         move_action, &QAction::triggered,
         this, &ObjectImpl::on_move);
@@ -700,6 +704,10 @@ void ObjectImpl::on_new_shared_folder() {
     new_object(CLASS_SHARED_FOLDER);
 }
 
+void ObjectImpl::on_new_inet_org_person() {
+    new_object(CLASS_INET_ORG_PERSON);
+}
+
 void ObjectImpl::on_move() {
     AdInterface ad;
     if (ad_failed(ad, console)) {
@@ -893,9 +901,10 @@ void ObjectImpl::new_object(const QString &object_class) {
         const bool is_computer = (object_class == CLASS_COMPUTER);
         const bool is_ou = (object_class == CLASS_OU);
         const bool is_shared_folder = (object_class == CLASS_SHARED_FOLDER);
+        const bool is_inet_org_person = (object_class == CLASS_INET_ORG_PERSON);
 
         if (is_user) {
-            return new CreateUserDialog(ad, parent_dn, console);
+            return new CreateUserDialog(ad, parent_dn, CLASS_USER, console);
         } else if (is_group) {
             return new CreateGroupDialog(parent_dn, console);
         } else if (is_computer) {
@@ -904,6 +913,8 @@ void ObjectImpl::new_object(const QString &object_class) {
             return new CreateOUDialog(parent_dn, console);
         } else if (is_shared_folder) {
             return new CreateSharedFolderDialog(parent_dn, console);
+        } else if (is_inet_org_person) {
+            return new CreateUserDialog(ad, parent_dn, CLASS_INET_ORG_PERSON, console);
         } else {
             return nullptr;
         }

--- a/src/admc/console_impls/object_impl.cpp
+++ b/src/admc/console_impls/object_impl.cpp
@@ -31,6 +31,7 @@
 #include "create_group_dialog.h"
 #include "create_ou_dialog.h"
 #include "create_user_dialog.h"
+#include "create_shared_folder_dialog.h"
 #include "attribute_dialogs/list_attribute_dialog.h"
 #include "find_object_dialog.h"
 #include "globals.h"
@@ -85,6 +86,7 @@ ObjectImpl::ObjectImpl(ConsoleWidget *console_arg)
     new_action_map[CLASS_COMPUTER] = new QAction(tr("Computer"), this);
     new_action_map[CLASS_OU] = new QAction(tr("OU"), this);
     new_action_map[CLASS_GROUP] = new QAction(tr("Group"), this);
+    new_action_map[CLASS_SHARED_FOLDER] = new QAction(tr("Shared Folder"), this);
     find_action = new QAction(tr("Find..."), this);
     move_action = new QAction(tr("Move..."), this);
     add_to_group_action = new QAction(tr("Add to group..."), this);
@@ -120,6 +122,9 @@ ObjectImpl::ObjectImpl(ConsoleWidget *console_arg)
     connect(
         new_action_map[CLASS_GROUP], &QAction::triggered,
         this, &ObjectImpl::on_new_group);
+    connect(
+        new_action_map[CLASS_SHARED_FOLDER], &QAction::triggered,
+        this, &ObjectImpl::on_new_shared_folder);
     connect(
         move_action, &QAction::triggered,
         this, &ObjectImpl::on_move);
@@ -670,6 +675,10 @@ void ObjectImpl::on_new_group() {
     new_object(CLASS_GROUP);
 }
 
+void ObjectImpl::on_new_shared_folder() {
+    new_object(CLASS_SHARED_FOLDER);
+}
+
 void ObjectImpl::on_move() {
     AdInterface ad;
     if (ad_failed(ad, console)) {
@@ -862,6 +871,7 @@ void ObjectImpl::new_object(const QString &object_class) {
         const bool is_group = (object_class == CLASS_GROUP);
         const bool is_computer = (object_class == CLASS_COMPUTER);
         const bool is_ou = (object_class == CLASS_OU);
+        const bool is_shared_folder = (object_class == CLASS_SHARED_FOLDER);
 
         if (is_user) {
             return new CreateUserDialog(ad, parent_dn, console);
@@ -871,6 +881,8 @@ void ObjectImpl::new_object(const QString &object_class) {
             return new CreateComputerDialog(parent_dn, console);
         } else if (is_ou) {
             return new CreateOUDialog(parent_dn, console);
+        } else if (is_shared_folder) {
+            return new CreateSharedFolderDialog(parent_dn, console);
         } else {
             return nullptr;
         }

--- a/src/admc/console_impls/object_impl.cpp
+++ b/src/admc/console_impls/object_impl.cpp
@@ -54,6 +54,8 @@
 #include <QSet>
 #include <QStandardItemModel>
 
+#include <algorithm>
+
 enum DropType {
     DropType_Move,
     DropType_AddToGroup,
@@ -79,10 +81,10 @@ ObjectImpl::ObjectImpl(ConsoleWidget *console_arg)
     object_filter = settings_get_variant(SETTING_object_filter).toString();
     object_filter_enabled = settings_get_variant(SETTING_object_filter_enabled).toBool();
 
-    auto new_user_action = new QAction(tr("User"), this);
-    auto new_computer_action = new QAction(tr("Computer"), this);
-    auto new_ou_action = new QAction(tr("OU"), this);
-    auto new_group_action = new QAction(tr("Group"), this);
+    new_action_map[CLASS_USER] = new QAction(tr("User"), this);
+    new_action_map[CLASS_COMPUTER] = new QAction(tr("Computer"), this);
+    new_action_map[CLASS_OU] = new QAction(tr("OU"), this);
+    new_action_map[CLASS_GROUP] = new QAction(tr("Group"), this);
     find_action = new QAction(tr("Find..."), this);
     move_action = new QAction(tr("Move..."), this);
     add_to_group_action = new QAction(tr("Add to group..."), this);
@@ -95,22 +97,28 @@ ObjectImpl::ObjectImpl(ConsoleWidget *console_arg)
     auto new_menu = new QMenu(tr("New"), console_arg);
     new_action = new_menu->menuAction();
 
-    new_menu->addAction(new_user_action);
-    new_menu->addAction(new_computer_action);
-    new_menu->addAction(new_ou_action);
-    new_menu->addAction(new_group_action);
+    const QList<QString> new_action_keys_sorted = [&]() {
+        QList<QString> out = new_action_map.keys();
+        std::sort(out.begin(), out.end());
+
+        return out;
+    }();
+    for (const QString &key : new_action_keys_sorted) {
+        QAction *action = new_action_map[key];
+        new_menu->addAction(action);
+    }
 
     connect(
-        new_user_action, &QAction::triggered,
+        new_action_map[CLASS_USER], &QAction::triggered,
         this, &ObjectImpl::on_new_user);
     connect(
-        new_computer_action, &QAction::triggered,
+        new_action_map[CLASS_COMPUTER], &QAction::triggered,
         this, &ObjectImpl::on_new_computer);
     connect(
-        new_ou_action, &QAction::triggered,
+        new_action_map[CLASS_OU], &QAction::triggered,
         this, &ObjectImpl::on_new_ou);
     connect(
-        new_group_action, &QAction::triggered,
+        new_action_map[CLASS_GROUP], &QAction::triggered,
         this, &ObjectImpl::on_new_group);
     connect(
         move_action, &QAction::triggered,

--- a/src/admc/console_impls/object_impl.cpp
+++ b/src/admc/console_impls/object_impl.cpp
@@ -347,6 +347,27 @@ QSet<QAction *> ObjectImpl::get_custom_actions(const QModelIndex &index, const b
 
     out.insert(move_action);
 
+    // NOTE: have to manually call setVisible here
+    // because "New" actions are contained inside "New"
+    // sub-menu, so console widget can't manage them
+    for (const QString &action_object_class : new_action_map.keys()) {
+        QAction *action = new_action_map[action_object_class];
+
+        const bool is_visible = [&action_object_class, &object_class]() {
+            // NOTE: to get full list of possible
+            // superiors, need to use the all of the parent
+            // classes too, not just the leaf class
+            const QList<QString> action_object_class_list = g_adconfig->get_inherit_chain(action_object_class);
+            const QList<QString> possible_superiors = g_adconfig->get_possible_superiors(QList<QString>(action_object_class_list));
+            const bool is_visible_out = possible_superiors.contains(object_class);
+
+            return is_visible_out;
+        }();
+
+
+        action->setVisible(is_visible);
+    }
+
     return out;
 }
 

--- a/src/admc/console_impls/object_impl.h
+++ b/src/admc/console_impls/object_impl.h
@@ -103,6 +103,7 @@ private slots:
     void on_new_ou();
     void on_new_group();
     void on_new_shared_folder();
+    void on_new_inet_org_person();
     void on_move();
     void on_enable();
     void on_disable();

--- a/src/admc/console_impls/object_impl.h
+++ b/src/admc/console_impls/object_impl.h
@@ -126,6 +126,7 @@ private:
     QAction *reset_account_action;
     QAction *edit_upn_suffixes_action;
     QAction *new_action;
+    QHash<QString, QAction *> new_action_map;
 
     bool find_action_enabled;
     bool refresh_action_enabled;

--- a/src/admc/console_impls/object_impl.h
+++ b/src/admc/console_impls/object_impl.h
@@ -102,6 +102,7 @@ private slots:
     void on_new_computer();
     void on_new_ou();
     void on_new_group();
+    void on_new_shared_folder();
     void on_move();
     void on_enable();
     void on_disable();

--- a/src/admc/console_impls/object_impl.h
+++ b/src/admc/console_impls/object_impl.h
@@ -104,6 +104,7 @@ private slots:
     void on_new_group();
     void on_new_shared_folder();
     void on_new_inet_org_person();
+    void on_new_contact();
     void on_move();
     void on_enable();
     void on_disable();

--- a/src/admc/create_contact_dialog.cpp
+++ b/src/admc/create_contact_dialog.cpp
@@ -49,7 +49,7 @@ CreateContactDialog::CreateContactDialog(const QString &parent_dn, QWidget *pare
     const QList<QLineEdit *> required_list = {
         ui->first_name_edit,
         ui->last_name_edit,
-        ui->initials_edit,
+        ui->full_name_edit,
         ui->display_name_edit,
     };
 

--- a/src/admc/create_contact_dialog.cpp
+++ b/src/admc/create_contact_dialog.cpp
@@ -1,0 +1,77 @@
+/*
+ * ADMC - AD Management Center
+ *
+ * Copyright (C) 2020-2021 BaseALT Ltd.
+ * Copyright (C) 2020-2021 Dmitry Degtyarev
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "create_contact_dialog.h"
+#include "ui_create_contact_dialog.h"
+
+#include "adldap.h"
+#include "attribute_edits/string_edit.h"
+#include "utils.h"
+#include "settings.h"
+#include "create_object_helper.h"
+
+CreateContactDialog::CreateContactDialog(const QString &parent_dn, QWidget *parent)
+: CreateObjectDialog(parent) {
+    ui = new Ui::CreateContactDialog();
+    ui->setupUi(this);
+
+    setAttribute(Qt::WA_DeleteOnClose);
+
+    auto first_name_edit = new StringEdit(ui->first_name_edit, ATTRIBUTE_FIRST_NAME, this);
+    auto last_name_edit = new StringEdit(ui->last_name_edit, ATTRIBUTE_LAST_NAME, this);
+    auto initials_edit = new StringEdit(ui->initials_edit, ATTRIBUTE_INITIALS, this);
+    auto display_name_edit = new StringEdit(ui->display_name_edit, ATTRIBUTE_DISPLAY_NAME, this);
+
+    const QList<AttributeEdit *> edit_list = {
+        first_name_edit,
+        last_name_edit,
+        initials_edit,
+        display_name_edit,
+    };
+
+    const QList<QLineEdit *> required_list = {
+        ui->first_name_edit,
+        ui->last_name_edit,
+        ui->initials_edit,
+        ui->display_name_edit,
+    };
+
+    setup_full_name_autofill(ui->first_name_edit, ui->last_name_edit, ui->full_name_edit);
+
+    helper = new CreateObjectHelper(ui->full_name_edit, ui->button_box, edit_list, required_list, CLASS_CONTACT, parent_dn, this);
+
+    settings_setup_dialog_geometry(SETTING_create_contact_dialog_geometry, this);
+}
+
+CreateContactDialog::~CreateContactDialog() {
+    delete ui;
+}
+
+void CreateContactDialog::accept() {
+    const bool accepted = helper->accept();
+
+    if (accepted) {
+        QDialog::accept();
+    }
+}
+
+QString CreateContactDialog::get_created_dn() const {
+    return helper->get_created_dn();
+}

--- a/src/admc/create_contact_dialog.h
+++ b/src/admc/create_contact_dialog.h
@@ -1,0 +1,48 @@
+/*
+ * ADMC - AD Management Center
+ *
+ * Copyright (C) 2020-2021 BaseALT Ltd.
+ * Copyright (C) 2020-2021 Dmitry Degtyarev
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CREATE_CONTACT_DIALOG_H
+#define CREATE_CONTACT_DIALOG_H
+
+#include "create_object_dialog.h"
+
+class CreateObjectHelper;
+
+namespace Ui {
+class CreateContactDialog;
+}
+
+class CreateContactDialog final : public CreateObjectDialog {
+    Q_OBJECT
+
+public:
+    Ui::CreateContactDialog *ui;
+
+    CreateContactDialog(const QString &parent_dn, QWidget *parent);
+    ~CreateContactDialog();
+
+    void accept() override;
+    QString get_created_dn() const override;
+
+private:
+    CreateObjectHelper *helper;
+};
+
+#endif /* CREATE_CONTACT_DIALOG_H */

--- a/src/admc/create_contact_dialog.ui
+++ b/src/admc/create_contact_dialog.ui
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CreateContactDialog</class>
+ <widget class="QDialog" name="CreateContactDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>198</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Create Contact</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>First name:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Last name:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Initials:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Full name:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Display name:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="first_name_edit"/>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="last_name_edit"/>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="initials_edit"/>
+     </item>
+     <item row="3" column="1">
+      <widget class="QLineEdit" name="full_name_edit"/>
+     </item>
+     <item row="4" column="1">
+      <widget class="QLineEdit" name="display_name_edit"/>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>button_box</sender>
+   <signal>accepted()</signal>
+   <receiver>CreateContactDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>button_box</sender>
+   <signal>rejected()</signal>
+   <receiver>CreateContactDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/admc/create_object_helper.cpp
+++ b/src/admc/create_object_helper.cpp
@@ -86,7 +86,23 @@ bool CreateObjectHelper::accept() const {
 
     bool final_success = true;
 
-    const bool add_success = ad.object_add(dn, m_object_class);
+    const QHash<QString, QList<QString>> attr_map = [&]() {
+        if (m_object_class == CLASS_SHARED_FOLDER) {
+            // NOTE: for shared folders, UNC name must
+            // be defined on creation because it's a
+            // mandatory attribute
+            return QHash<QString, QList<QString>>({
+                {ATTRIBUTE_OBJECT_CLASS, {m_object_class}},
+                {ATTRIBUTE_UNC_NAME, {"placeholder"}},
+            });
+        } else {
+            return QHash<QString, QList<QString>>({
+                {ATTRIBUTE_OBJECT_CLASS, {m_object_class}},
+            });
+        }
+    }();
+
+    const bool add_success = ad.object_add(dn, attr_map);
 
     final_success = (final_success && add_success);
 

--- a/src/admc/create_object_helper.cpp
+++ b/src/admc/create_object_helper.cpp
@@ -107,10 +107,10 @@ bool CreateObjectHelper::accept() const {
     final_success = (final_success && add_success);
 
     if (add_success) {
-        const bool is_user = (m_object_class == CLASS_USER);
+        const bool is_user_or_person = (m_object_class == CLASS_USER || m_object_class == CLASS_INET_ORG_PERSON);
         const bool is_computer = (m_object_class == CLASS_COMPUTER);
 
-        if (is_user) {
+        if (is_user_or_person) {
             const int uac = [this, dn, &ad]() {
                 const AdObject object = ad.search_object(dn, {ATTRIBUTE_USER_ACCOUNT_CONTROL});
                 const int out = object.get_int(ATTRIBUTE_USER_ACCOUNT_CONTROL);

--- a/src/admc/create_shared_folder_dialog.cpp
+++ b/src/admc/create_shared_folder_dialog.cpp
@@ -1,0 +1,69 @@
+/*
+ * ADMC - AD Management Center
+ *
+ * Copyright (C) 2020-2021 BaseALT Ltd.
+ * Copyright (C) 2020-2021 Dmitry Degtyarev
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "create_shared_folder_dialog.h"
+#include "ui_create_shared_folder_dialog.h"
+
+#include "adldap.h"
+#include "attribute_edits/protect_deletion_edit.h"
+#include "attribute_edits/string_edit.h"
+#include "attribute_edits/upn_edit.h"
+#include "utils.h"
+#include "settings.h"
+#include "create_object_helper.h"
+
+CreateSharedFolderDialog::CreateSharedFolderDialog(const QString &parent_dn, QWidget *parent)
+: CreateObjectDialog(parent) {
+    ui = new Ui::CreateSharedFolderDialog();
+    ui->setupUi(this);
+
+    setAttribute(Qt::WA_DeleteOnClose);
+
+    auto path_edit = new StringEdit(ui->path_edit, ATTRIBUTE_UNC_NAME, this);
+
+    const QList<AttributeEdit *> edit_list = {
+        path_edit,
+    };
+
+    const QList<QLineEdit *> required_list = {
+        ui->name_edit,
+        ui->path_edit,
+    };
+
+    helper = new CreateObjectHelper(ui->name_edit, ui->button_box, edit_list, required_list, CLASS_SHARED_FOLDER, parent_dn, this);
+
+    settings_setup_dialog_geometry(SETTING_create_shared_folder_dialog_geometry, this);
+}
+
+CreateSharedFolderDialog::~CreateSharedFolderDialog() {
+    delete ui;
+}
+
+void CreateSharedFolderDialog::accept() {
+    const bool accepted = helper->accept();
+
+    if (accepted) {
+        QDialog::accept();
+    }
+}
+
+QString CreateSharedFolderDialog::get_created_dn() const {
+    return helper->get_created_dn();
+}

--- a/src/admc/create_shared_folder_dialog.h
+++ b/src/admc/create_shared_folder_dialog.h
@@ -1,0 +1,48 @@
+/*
+ * ADMC - AD Management Center
+ *
+ * Copyright (C) 2020-2021 BaseALT Ltd.
+ * Copyright (C) 2020-2021 Dmitry Degtyarev
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CREATE_SHARED_FOLDER_DIALOG_H
+#define CREATE_SHARED_FOLDER_DIALOG_H
+
+#include "create_object_dialog.h"
+
+class CreateObjectHelper;
+
+namespace Ui {
+class CreateSharedFolderDialog;
+}
+
+class CreateSharedFolderDialog final : public CreateObjectDialog {
+    Q_OBJECT
+
+public:
+    Ui::CreateSharedFolderDialog *ui;
+
+    CreateSharedFolderDialog(const QString &parent_dn, QWidget *parent);
+    ~CreateSharedFolderDialog();
+
+    void accept() override;
+    QString get_created_dn() const override;
+
+private:
+    CreateObjectHelper *helper;
+};
+
+#endif /* CREATE_SHARED_FOLDER_DIALOG_H */

--- a/src/admc/create_shared_folder_dialog.ui
+++ b/src/admc/create_shared_folder_dialog.ui
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CreateSharedFolderDialog</class>
+ <widget class="QDialog" name="CreateSharedFolderDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>127</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Create Shared Folder</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="name_edit"/>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Name:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Network path:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="path_edit"/>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>button_box</sender>
+   <signal>accepted()</signal>
+   <receiver>CreateSharedFolderDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>button_box</sender>
+   <signal>rejected()</signal>
+   <receiver>CreateSharedFolderDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/admc/create_user_dialog.cpp
+++ b/src/admc/create_user_dialog.cpp
@@ -65,13 +65,7 @@ CreateUserDialog::CreateUserDialog(AdInterface &ad, const QString &parent_dn, co
 
     account_option_setup_conflicts(check_map);
 
-    // (first name + last name) -> full name
-    connect(
-        ui->first_name_edit, &QLineEdit::textChanged,
-        this, &CreateUserDialog::autofill_full_name);
-    connect(
-        ui->last_name_edit, &QLineEdit::textChanged,
-        this, &CreateUserDialog::autofill_full_name);
+    setup_full_name_autofill(ui->first_name_edit, ui->last_name_edit, ui->name_edit);
 
     setup_lineedit_autofill(ui->upn_prefix_edit, ui->sam_name_edit);
 
@@ -121,28 +115,4 @@ void CreateUserDialog::accept() {
 
 QString CreateUserDialog::get_created_dn() const {
     return helper->get_created_dn();
-}
-
-void CreateUserDialog::autofill_full_name() {
-    const QString full_name_value = [=]() {
-        const QString first_name = ui->first_name_edit->text();
-        const QString last_name = ui->last_name_edit->text();
-
-        const bool last_name_first = settings_get_variant(SETTING_last_name_before_first_name).toBool();
-        if (!first_name.isEmpty() && !last_name.isEmpty()) {
-            if (last_name_first) {
-                return last_name + " " + first_name;
-            } else {
-                return first_name + " " + last_name;
-            }
-        } else if (!first_name.isEmpty()) {
-            return first_name;
-        } else if (!last_name.isEmpty()) {
-            return last_name;
-        } else {
-            return QString();
-        }
-    }();
-
-    ui->name_edit->setText(full_name_value);
 }

--- a/src/admc/create_user_dialog.cpp
+++ b/src/admc/create_user_dialog.cpp
@@ -31,7 +31,7 @@
 #include "utils.h"
 #include "create_object_helper.h"
 
-CreateUserDialog::CreateUserDialog(AdInterface &ad, const QString &parent_dn, QWidget *parent)
+CreateUserDialog::CreateUserDialog(AdInterface &ad, const QString &parent_dn, const QString &user_class, QWidget *parent)
 : CreateObjectDialog(parent) {
     ui = new Ui::CreateUserDialog();
     ui->setupUi(this);
@@ -98,7 +98,11 @@ CreateUserDialog::CreateUserDialog(AdInterface &ad, const QString &parent_dn, QW
         return out;
     }();
 
-    helper = new CreateObjectHelper(ui->name_edit, ui->button_box, edit_list, required_list, CLASS_USER, parent_dn, this);
+    helper = new CreateObjectHelper(ui->name_edit, ui->button_box, edit_list, required_list, user_class, parent_dn, this);
+
+    if (user_class != CLASS_USER) {
+        setWindowTitle(QString(tr("Create %1")).arg(user_class));
+    }
 
     settings_setup_dialog_geometry(SETTING_create_user_dialog_geometry, this);
 }

--- a/src/admc/create_user_dialog.h
+++ b/src/admc/create_user_dialog.h
@@ -36,7 +36,10 @@ class CreateUserDialog final : public CreateObjectDialog {
 public:
     Ui::CreateUserDialog *ui;
 
-    CreateUserDialog(AdInterface &ad, const QString &parent_dn, QWidget *parent);
+    // NOTE: user_class can be either CLASS_USER or
+    // CLASS_INET_ORG_PERSON. This is so that this
+    // dialog can be reused for both classes.
+    CreateUserDialog(AdInterface &ad, const QString &parent_dn, const QString &user_class, QWidget *parent);
     ~CreateUserDialog();
 
     void accept() override;

--- a/src/admc/settings.h
+++ b/src/admc/settings.h
@@ -91,6 +91,7 @@ DEFINE_SETTING(SETTING_octet_attribute_dialog_geometry);
 DEFINE_SETTING(SETTING_string_attribute_dialog_geometry);
 DEFINE_SETTING(SETTING_fsmo_dialog_geometry);
 DEFINE_SETTING(SETTING_create_shared_folder_dialog_geometry);
+DEFINE_SETTING(SETTING_create_contact_dialog_geometry);
 
 // Header state
 DEFINE_SETTING(SETTING_results_header);

--- a/src/admc/settings.h
+++ b/src/admc/settings.h
@@ -90,6 +90,7 @@ DEFINE_SETTING(SETTING_list_attribute_dialog_geometry);
 DEFINE_SETTING(SETTING_octet_attribute_dialog_geometry);
 DEFINE_SETTING(SETTING_string_attribute_dialog_geometry);
 DEFINE_SETTING(SETTING_fsmo_dialog_geometry);
+DEFINE_SETTING(SETTING_create_shared_folder_dialog_geometry);
 
 // Header state
 DEFINE_SETTING(SETTING_results_header);

--- a/src/admc/utils.cpp
+++ b/src/admc/utils.cpp
@@ -412,3 +412,36 @@ void setup_lineedit_autofill(QLineEdit *src, QLineEdit *dest) {
             dest->setText(src_input);
         });
 }
+
+void setup_full_name_autofill(QLineEdit *first_name_edit, QLineEdit *last_name_edit, QLineEdit *full_name_edit) {
+    auto autofill_full_name = [=]() {
+        const QString full_name_value = [=]() {
+            const QString first_name = first_name_edit->text();
+            const QString last_name = last_name_edit->text();
+
+            const bool last_name_first = settings_get_variant(SETTING_last_name_before_first_name).toBool();
+            if (!first_name.isEmpty() && !last_name.isEmpty()) {
+                if (last_name_first) {
+                    return last_name + " " + first_name;
+                } else {
+                    return first_name + " " + last_name;
+                }
+            } else if (!first_name.isEmpty()) {
+                return first_name;
+            } else if (!last_name.isEmpty()) {
+                return last_name;
+            } else {
+                return QString();
+            }
+        }();
+
+        full_name_edit->setText(full_name_value);
+    };
+
+    QObject::connect(
+        first_name_edit, &QLineEdit::textChanged,
+        first_name_edit, autofill_full_name);
+    QObject::connect(
+        last_name_edit, &QLineEdit::textChanged,
+        last_name_edit, autofill_full_name);
+}

--- a/src/admc/utils.cpp
+++ b/src/admc/utils.cpp
@@ -177,6 +177,7 @@ QIcon get_object_icon(const AdObject &object) {
         {"Person", {"avatar-default", "avatar-default-symbolic"}},
         {"Computer", {"computer"}},
         {"Group-Policy-Container", {"folder-templates"}},
+        {"Volume", {"folder-templates"}},
 
         // Some custom icons for one-off objects
         {"Builtin-Domain", {"emblem-system", "emblem-system-symbolic"}},

--- a/src/admc/utils.h
+++ b/src/admc/utils.h
@@ -126,4 +126,7 @@ bool verify_object_name(const QString &name, QWidget *parent);
 // into dest.
 void setup_lineedit_autofill(QLineEdit *src, QLineEdit *dest);
 
+// (first name + last name) -> full name
+void setup_full_name_autofill(QLineEdit *first_name_edit, QLineEdit *last_name_edit, QLineEdit *full_name_edit);
+
 #endif /* UTILS_H */

--- a/tests/admc_test.h
+++ b/tests/admc_test.h
@@ -45,6 +45,7 @@ class AttributeEdit;
 // NOTE: use shorter length for computer to fit within
 // 16 char length limit for sam account name
 #define TEST_COMPUTER "ADMCTEST-pc"
+#define TEST_OBJECT "ADMCTEST-object"
 
 class ADMCTest : public QObject {
     Q_OBJECT

--- a/tests/admc_test_create_object_dialog.cpp
+++ b/tests/admc_test_create_object_dialog.cpp
@@ -26,12 +26,26 @@
 #include "create_group_dialog.h"
 #include "create_ou_dialog.h"
 #include "create_user_dialog.h"
+#include "create_shared_folder_dialog.h"
+#include "create_contact_dialog.h"
 #include "ui_create_computer_dialog.h"
 #include "ui_create_group_dialog.h"
 #include "ui_create_ou_dialog.h"
 #include "ui_create_user_dialog.h"
+#include "ui_create_shared_folder_dialog.h"
+#include "ui_create_contact_dialog.h"
+
+void ADMCTestCreateObjectDialog::create_user_data() {
+    QTest::addColumn<QString>("user_class");
+    QTest::addColumn<int>("exptected_uac");
+
+    QTest::newRow("user") << CLASS_USER;
+    QTest::newRow("inetOrgPerson") << CLASS_INET_ORG_PERSON;
+}
 
 void ADMCTestCreateObjectDialog::create_user() {
+    QFETCH(QString, user_class);
+
     const QString name = TEST_USER;
     const QString logon_name = TEST_USER_LOGON;
     const QString password = TEST_PASSWORD;
@@ -39,7 +53,7 @@ void ADMCTestCreateObjectDialog::create_user() {
     const QString dn = test_object_dn(name, CLASS_USER);
 
     // Create user
-    auto create_dialog = new CreateUserDialog(ad, parent, parent_widget);
+    auto create_dialog = new CreateUserDialog(ad, parent, user_class, parent_widget);
     create_dialog->open();
     QVERIFY(QTest::qWaitForWindowExposed(create_dialog, 1000));
 
@@ -138,6 +152,48 @@ void ADMCTestCreateObjectDialog::create_group() {
     create_dialog->accept();
 
     QVERIFY2(object_exists(dn), "Created group doesn't exist");
+    QCOMPARE(create_dialog->get_created_dn(), dn);
+}
+
+void ADMCTestCreateObjectDialog::create_shared_folder() {
+    const QString object_class = CLASS_SHARED_FOLDER;
+    const QString name = TEST_OBJECT;
+    const QString parent = test_arena_dn();
+    const QString dn = test_object_dn(name, object_class);
+
+    // Open create dialog
+    auto create_dialog = new CreateSharedFolderDialog(parent, parent_widget);
+    create_dialog->open();
+    QVERIFY(QTest::qWaitForWindowExposed(create_dialog, 1000));
+
+    create_dialog->ui->name_edit->setText(name);
+    create_dialog->ui->path_edit->setText("path");
+
+    create_dialog->accept();
+
+    QVERIFY2(object_exists(dn), "Created shared folder doesn't exist");
+    QCOMPARE(create_dialog->get_created_dn(), dn);
+}
+
+void ADMCTestCreateObjectDialog::create_contact() {
+    const QString object_class = CLASS_CONTACT;
+    const QString name = TEST_OBJECT;
+    const QString parent = test_arena_dn();
+    const QString dn = test_object_dn(name, object_class);
+
+    // Open create dialog
+    auto create_dialog = new CreateContactDialog(parent, parent_widget);
+    create_dialog->open();
+    QVERIFY(QTest::qWaitForWindowExposed(create_dialog, 1000));
+
+    create_dialog->ui->first_name_edit->setText("first");
+    create_dialog->ui->last_name_edit->setText("last");
+    create_dialog->ui->full_name_edit->setText(name);
+    create_dialog->ui->display_name_edit->setText("display");
+
+    create_dialog->accept();
+
+    QVERIFY2(object_exists(dn), "Created contact doesn't exist");
     QCOMPARE(create_dialog->get_created_dn(), dn);
 }
 

--- a/tests/admc_test_create_object_dialog.h
+++ b/tests/admc_test_create_object_dialog.h
@@ -27,10 +27,13 @@ class ADMCTestCreateObjectDialog : public ADMCTest {
     Q_OBJECT
 
 private slots:
+    void create_user_data();
     void create_user();
     void create_ou();
     void create_computer();
     void create_group();
+    void create_shared_folder();
+    void create_contact();
 };
 
 #endif /* ADMC_TEST_CREATE_OBJECT_DIALOG_H */


### PR DESCRIPTION
closes #343 

Add creation of missing object types:
- inetOrgPerson
- contact
- shared folder

Also, make it so that "New" sub-menu of action menu contains only those object types that can be children of targeted parent object.