### PR TITLE
Remove action target variable

### DIFF
--- a/src/admc/console_impls/object_impl.cpp
+++ b/src/admc/console_impls/object_impl.cpp
@@ -66,8 +66,8 @@ enum DropType {
 
 DropType console_object_get_drop_type(const QModelIndex &dropped, const QModelIndex &target);
 QList<QString> index_list_to_dn_list(const QList<QModelIndex> &index_list);
-QList<QString> get_action_target_dn_list_object(ConsoleWidget *console);
-QString get_action_target_dn_object(ConsoleWidget *console);
+QList<QString> get_selected_dn_list_object(ConsoleWidget *console);
+QString get_selected_target_dn_object(ConsoleWidget *console);
 void console_object_delete(ConsoleWidget *console, const QList<QString> &dn_list, const QModelIndex &tree_root);
 
 ObjectImpl::ObjectImpl(ConsoleWidget *console_arg)
@@ -453,7 +453,7 @@ void ObjectImpl::rename(const QList<QModelIndex> &index_list) {
         return;
     }
 
-    const QString old_dn = get_action_target_dn_object(console);
+    const QString old_dn = get_selected_target_dn_object(console);
 
     RenameObjectDialog *dialog = [&]() -> RenameObjectDialog * {
         const QModelIndex index = index_list[0];
@@ -735,7 +735,7 @@ void ObjectImpl::on_move() {
                 return;
             }
 
-            const QList<QString> dn_list = get_action_target_dn_list_object(console);
+            const QList<QString> dn_list = get_selected_dn_list_object(console);
 
             show_busy_indicator();
 
@@ -789,7 +789,7 @@ void ObjectImpl::on_add_to_group() {
 
             show_busy_indicator();
 
-            const QList<QString> target_list = get_action_target_dn_list_object(console);
+            const QList<QString> target_list = get_selected_dn_list_object(console);
 
             const QList<QString> groups = dialog->get_selected();
 
@@ -806,7 +806,7 @@ void ObjectImpl::on_add_to_group() {
 }
 
 void ObjectImpl::on_find() {
-    const QList<QString> dn_list = get_action_target_dn_list_object(console);
+    const QList<QString> dn_list = get_selected_dn_list_object(console);
 
     const QString dn = dn_list[0];
 
@@ -820,7 +820,7 @@ void ObjectImpl::on_reset_password() {
         return;
     }
 
-    const QString dn = get_action_target_dn_object(console);
+    const QString dn = get_selected_target_dn_object(console);
 
     auto dialog = new PasswordDialog(ad, dn, console);
     dialog->open();
@@ -885,7 +885,7 @@ void ObjectImpl::on_reset_account() {
 
     show_busy_indicator();
 
-    const QList<QString> target_list = get_action_target_dn_list_object(console);
+    const QList<QString> target_list = get_selected_dn_list_object(console);
 
     for (const QString &target : target_list) {
         ad.computer_reset_account(target);
@@ -902,7 +902,7 @@ void ObjectImpl::new_object(const QString &object_class) {
         return;
     }
 
-    const QString parent_dn = get_action_target_dn_object(console);
+    const QString parent_dn = get_selected_target_dn_object(console);
 
     // NOTE: creating dialogs here instead of directly
     // in "on_new_x" slots looks backwards but it's
@@ -1008,7 +1008,7 @@ void ObjectImpl::set_disabled(const bool disabled) {
     const QList<QString> changed_objects = [&]() {
         QList<QString> out;
 
-        const QList<QString> dn_list = get_action_target_dn_list_object(console);
+        const QList<QString> dn_list = get_selected_dn_list_object(console);
 
         for (const QString &dn : dn_list) {
             const bool success = ad.user_set_account_option(dn, AccountOption_Disabled, disabled);
@@ -1676,12 +1676,12 @@ QList<QString> index_list_to_dn_list(const QList<QModelIndex> &index_list) {
     return out;
 }
 
-QList<QString> get_action_target_dn_list_object(ConsoleWidget *console) {
-    return get_action_target_dn_list(console, ItemType_Object, ObjectRole_DN);
+QList<QString> get_selected_dn_list_object(ConsoleWidget *console) {
+    return get_selected_dn_list(console, ItemType_Object, ObjectRole_DN);
 }
 
-QString get_action_target_dn_object(ConsoleWidget *console) {
-    return get_action_target_dn(console, ItemType_Object, ObjectRole_DN);
+QString get_selected_target_dn_object(ConsoleWidget *console) {
+    return get_selected_target_dn(console, ItemType_Object, ObjectRole_DN);
 }
 
 void console_object_delete(ConsoleWidget *console, const QList<QString> &dn_list, const QModelIndex &tree_root) {

--- a/src/admc/console_impls/policy_impl.cpp
+++ b/src/admc/console_impls/policy_impl.cpp
@@ -289,7 +289,7 @@ void PolicyImpl::on_add_link() {
         dialog, &SelectObjectDialog::accepted,
         this,
         [this, dialog]() {
-            const QList<QString> gpos = get_action_target_dn_list(console, ItemType_Policy, PolicyRole_DN);
+            const QList<QString> gpos = get_selected_dn_list(console, ItemType_Policy, PolicyRole_DN);
 
             const QList<QString> ou_list = dialog->get_selected();
 
@@ -301,7 +301,7 @@ void PolicyImpl::on_add_link() {
 }
 
 void PolicyImpl::on_edit() {
-    const QString dn = get_action_target_dn(console, ItemType_Policy, PolicyRole_DN);
+    const QString dn = get_selected_target_dn(console, ItemType_Policy, PolicyRole_DN);
 
     const QString path = [&]() {
         AdInterface ad;

--- a/src/admc/console_impls/policy_impl.cpp
+++ b/src/admc/console_impls/policy_impl.cpp
@@ -156,7 +156,7 @@ void PolicyImpl::rename(const QList<QModelIndex> &index_list) {
         return;
     }
 
-    const QModelIndex index = console->get_action_target(ItemType_Policy);
+    const QModelIndex index = console->get_selected_item(ItemType_Policy);
     const QString dn = index.data(PolicyRole_DN).toString();
 
     auto dialog = new RenamePolicyDialog(ad, dn, console);

--- a/src/admc/console_impls/query_folder_impl.cpp
+++ b/src/admc/console_impls/query_folder_impl.cpp
@@ -79,7 +79,7 @@ QueryFolderImpl::QueryFolderImpl(ConsoleWidget *console_arg)
 void QueryFolderImpl::on_create_query_folder() {
     auto dialog = new CreateQueryFolderDialog(console);
 
-    const QModelIndex parent_index = console->get_action_target(ItemType_QueryFolder);
+    const QModelIndex parent_index = console->get_selected_item(ItemType_QueryFolder);
     const QList<QString> sibling_name_list = get_sibling_name_list(parent_index, QModelIndex());
 
     dialog->set_sibling_name_list(sibling_name_list);
@@ -100,7 +100,7 @@ void QueryFolderImpl::on_create_query_folder() {
 }
 
 void QueryFolderImpl::on_create_query_item() {
-    const QModelIndex parent_index = console->get_action_target(ItemType_QueryFolder);
+    const QModelIndex parent_index = console->get_selected_item(ItemType_QueryFolder);
     const QList<QString> sibling_name_list = get_sibling_name_list(parent_index, QModelIndex());
 
     auto dialog = new CreateQueryItemDialog(sibling_name_list, console);
@@ -126,7 +126,7 @@ void QueryFolderImpl::on_create_query_item() {
 void QueryFolderImpl::on_edit_query_folder() {
     auto dialog = new EditQueryFolderDialog(console);
 
-    const QModelIndex index = console->get_action_target(ItemType_QueryFolder);
+    const QModelIndex index = console->get_selected_item(ItemType_QueryFolder);
 
     {
         const QString name = index.data(Qt::DisplayRole).toString();
@@ -295,7 +295,7 @@ void QueryFolderImpl::paste(const QList<QModelIndex> &index_list) {
 }
 
 void QueryFolderImpl::on_import() {
-    const QModelIndex parent_index = console->get_action_target(ItemType_QueryFolder);
+    const QModelIndex parent_index = console->get_selected_item(ItemType_QueryFolder);
 
     const QString file_path = [&]() {
         const QString caption = QCoreApplication::translate("query_item_impl.cpp", "Import Query");

--- a/src/admc/console_impls/query_item_impl.cpp
+++ b/src/admc/console_impls/query_item_impl.cpp
@@ -164,7 +164,7 @@ QList<int> QueryItemImpl::default_columns() const {
 }
 
 void QueryItemImpl::on_export() {
-    const QModelIndex index = console->get_action_target(ItemType_QueryItem);
+    const QModelIndex index = console->get_selected_item(ItemType_QueryItem);
 
     const QString file_path = [&]() {
         const QString query_name = index.data(Qt::DisplayRole).toString();
@@ -250,7 +250,7 @@ void console_query_item_load_hash(ConsoleWidget *console, const QHash<QString, Q
 }
 
 void QueryItemImpl::on_edit_query_item() {
-    const QModelIndex index = console->get_action_target(ItemType_QueryItem);
+    const QModelIndex index = console->get_selected_item(ItemType_QueryItem);
 
     const QModelIndex parent_index = index.parent();
     const QList<QString> sibling_name_list = get_sibling_name_list(parent_index, index);

--- a/src/admc/console_widget/console_widget.cpp
+++ b/src/admc/console_widget/console_widget.cpp
@@ -535,12 +535,12 @@ void ConsoleWidgetPrivate::add_actions(QMenu *menu) {
 
 // Returns whether any action is visible
 bool ConsoleWidgetPrivate::update_actions() {
-    const QList<QModelIndex> action_target_list = get_all_selected_items();
-    if (!action_target_list.isEmpty() && !action_target_list[0].isValid()) {
+    const QList<QModelIndex> selected_list = get_all_selected_items();
+    if (!selected_list.isEmpty() && !selected_list[0].isValid()) {
         return false;
     }
 
-    const bool single_selection = (action_target_list.size() == 1);
+    const bool single_selection = (selected_list.size() == 1);
 
     //
     // Collect information about action state from impl's
@@ -549,8 +549,8 @@ bool ConsoleWidgetPrivate::update_actions() {
     const QSet<QAction *> visible_custom_action_set = [&]() {
         QSet<QAction *> out;
 
-        for (int i = 0; i < action_target_list.size(); i++) {
-            const QModelIndex index = action_target_list[i];
+        for (int i = 0; i < selected_list.size(); i++) {
+            const QModelIndex index = selected_list[i];
 
             ConsoleImpl *impl = get_impl(index);
             QSet<QAction *> for_this_index = impl->get_custom_actions(index, single_selection);
@@ -571,8 +571,8 @@ bool ConsoleWidgetPrivate::update_actions() {
     const QSet<QAction *> disabled_custom_action_set = [&]() {
         QSet<QAction *> out;
 
-        for (int i = 0; i < action_target_list.size(); i++) {
-            const QModelIndex index = action_target_list[i];
+        for (int i = 0; i < selected_list.size(); i++) {
+            const QModelIndex index = selected_list[i];
 
             ConsoleImpl *impl = get_impl(index);
             QSet<QAction *> for_this_index = impl->get_disabled_custom_actions(index, single_selection);
@@ -593,8 +593,8 @@ bool ConsoleWidgetPrivate::update_actions() {
     const QSet<StandardAction> visible_standard_actions = [&]() {
         QSet<StandardAction> out;
 
-        for (int i = 0; i < action_target_list.size(); i++) {
-            const QModelIndex index = action_target_list[i];
+        for (int i = 0; i < selected_list.size(); i++) {
+            const QModelIndex index = selected_list[i];
 
             ConsoleImpl *impl = get_impl(index);
             QSet<StandardAction> for_this_index = impl->get_standard_actions(index, single_selection);
@@ -615,8 +615,8 @@ bool ConsoleWidgetPrivate::update_actions() {
     const QSet<StandardAction> disabled_standard_actions = [&]() {
         QSet<StandardAction> out;
 
-        for (int i = 0; i < action_target_list.size(); i++) {
-            const QModelIndex index = action_target_list[i];
+        for (int i = 0; i < selected_list.size(); i++) {
+            const QModelIndex index = selected_list[i];
 
             ConsoleImpl *impl = get_impl(index);
             QSet<StandardAction> for_this_index = impl->get_disabled_standard_actions(index, single_selection);
@@ -1137,9 +1137,9 @@ void ConsoleWidgetPrivate::on_standard_action(const StandardAction action_enum) 
     const QSet<int> type_set = [&]() {
         QSet<int> out;
 
-        const QList<QModelIndex> action_target_list = get_all_selected_items();
+        const QList<QModelIndex> selected_list = get_all_selected_items();
 
-        for (const QModelIndex &index : action_target_list) {
+        for (const QModelIndex &index : selected_list) {
             const int type = index.data(ConsoleRole_Type).toInt();
             out.insert(type);
         }

--- a/src/admc/console_widget/console_widget.cpp
+++ b/src/admc/console_widget/console_widget.cpp
@@ -313,14 +313,7 @@ QModelIndex ConsoleWidget::get_action_target(const int type) const {
 }
 
 QList<QModelIndex> ConsoleWidget::get_action_target_items(const int type) const {
-    QList<QModelIndex> out;
-
-    for (const QModelIndex &index : d->action_target_list) {
-        const int this_type = console_item_get_type(index);
-        if (this_type == type) {
-            out.append(index);
-        }
-    }
+    const QList<QModelIndex> out = get_selected_items(type);
 
     return out;
 }
@@ -521,7 +514,7 @@ void ConsoleWidget::setup_menubar_action_menu(QMenu *menu) {
 
     connect(
         menu, &QMenu::aboutToShow,
-        d, &ConsoleWidgetPrivate::on_menubar_action_menu_open);
+        d, &ConsoleWidgetPrivate::update_actions);
 }
 
 void ConsoleWidgetPrivate::add_actions(QMenu *menu) {
@@ -546,16 +539,9 @@ void ConsoleWidgetPrivate::add_actions(QMenu *menu) {
     menu->addAction(standard_action_map[StandardAction_Properties]);
 }
 
-void ConsoleWidgetPrivate::on_menubar_action_menu_open() {
-    // Action menu opened from menubar, so use regular
-    // selected items
-    action_target_list = get_all_selected_items();
-
-    update_actions();
-}
-
 // Returns whether any action is visible
 bool ConsoleWidgetPrivate::update_actions() {
+    const QList<QModelIndex> action_target_list = get_all_selected_items();
     if (!action_target_list.isEmpty() && !action_target_list[0].isValid()) {
         return false;
     }
@@ -869,6 +855,9 @@ QList<QModelIndex> ConsoleWidgetPrivate::get_all_selected_items() const {
     } else if (focused_results) {
         const QList<QModelIndex> results_selected = results_view->get_selected_indexes();
 
+        // NOTE: this is necessary for the "context
+        // menu targets current scope if clicked on
+        // empty space in results view" feature.
         if (!results_selected.isEmpty()) {
             return results_selected;
         } else {
@@ -1154,6 +1143,8 @@ void ConsoleWidgetPrivate::on_standard_action(const StandardAction action_enum) 
     const QSet<int> type_set = [&]() {
         QSet<int> out;
 
+        const QList<QModelIndex> action_target_list = get_all_selected_items();
+
         for (const QModelIndex &index : action_target_list) {
             const int type = index.data(ConsoleRole_Type).toInt();
             out.insert(type);
@@ -1213,10 +1204,6 @@ void ConsoleWidgetPrivate::on_standard_action(const StandardAction action_enum) 
     }
 }
 
-// NOTE: when action menu is opened as context menu
-// from results pane, treat clicking on empty space in
-// results pane as clicking on it's parent, which is
-// current scope.
 void ConsoleWidgetPrivate::on_results_context_menu(const QPoint &pos) {
     const QAbstractItemView *results_view = [&]() {
         ConsoleImpl *current_impl = get_current_scope_impl();
@@ -1226,21 +1213,16 @@ void ConsoleWidgetPrivate::on_results_context_menu(const QPoint &pos) {
         return out;
     }();
 
-    action_target_list = [&]() {
-        const QModelIndex index = results_view->indexAt(pos);
-        const bool clicked_empty_space = !index.isValid();
-
-        if (clicked_empty_space) {
-            const QModelIndex current_scope_item = q->get_current_scope_item();
-            const QList<QModelIndex> out = {current_scope_item};
-
-            return out;
-        } else {
-            const QList<QModelIndex> out = get_all_selected_items();
-
-            return out;
-        }
-    }();
+    // NOTE: have to manually clear selection when
+    // clicking on empty space in view because by
+    // default Qt doesn't do it. This is necessary for
+    // the "context menu targets current scope if
+    // clicked on empty space in results view" feature
+    const QModelIndex index = results_view->indexAt(pos);
+    const bool clicked_empty_space = !index.isValid();
+    if (clicked_empty_space) {
+        results_view->selectionModel()->clear();
+    }
 
     const QPoint global_pos = results_view->mapToGlobal(pos);
     open_context_menu(global_pos);
@@ -1252,11 +1234,6 @@ void ConsoleWidgetPrivate::on_scope_context_menu(const QPoint &pos) {
     if (!index.isValid()) {
         return;
     }
-
-    // Scope uses real selection as target of action
-    // menu. If clicked on empty space, action menu
-    // doesn't open.
-    action_target_list = get_all_selected_items();
 
     const QPoint global_pos = focused_view->mapToGlobal(pos);
     open_context_menu(global_pos);

--- a/src/admc/console_widget/console_widget.cpp
+++ b/src/admc/console_widget/console_widget.cpp
@@ -303,19 +303,13 @@ QList<QModelIndex> ConsoleWidget::get_selected_items(const int type) const {
 }
 
 QModelIndex ConsoleWidget::get_action_target(const int type) const {
-    const QList<QModelIndex> index_list = get_action_target_items(type);
+    const QList<QModelIndex> index_list = get_selected_items(type);
 
     if (!index_list.isEmpty()) {
         return index_list[0];
     } else {
         return QModelIndex();
     }
-}
-
-QList<QModelIndex> ConsoleWidget::get_action_target_items(const int type) const {
-    const QList<QModelIndex> out = get_selected_items(type);
-
-    return out;
 }
 
 QList<QModelIndex> ConsoleWidget::search_items(const QModelIndex &parent, int role, const QVariant &value, const int type) const {
@@ -1156,7 +1150,7 @@ void ConsoleWidgetPrivate::on_standard_action(const StandardAction action_enum) 
     // Call impl's action f-n for all present types
     for (const int type : type_set) {
         // Filter selected list so that it only contains indexes of this type
-        const QList<QModelIndex> selected_of_type = q->get_action_target_items(type);
+        const QList<QModelIndex> selected_of_type = q->get_selected_items(type);
 
         ConsoleImpl *impl = impl_map[type];
         switch (action_enum) {

--- a/src/admc/console_widget/console_widget.cpp
+++ b/src/admc/console_widget/console_widget.cpp
@@ -302,7 +302,7 @@ QList<QModelIndex> ConsoleWidget::get_selected_items(const int type) const {
     return out;
 }
 
-QModelIndex ConsoleWidget::get_action_target(const int type) const {
+QModelIndex ConsoleWidget::get_selected_item(const int type) const {
     const QList<QModelIndex> index_list = get_selected_items(type);
 
     if (!index_list.isEmpty()) {

--- a/src/admc/console_widget/console_widget.h
+++ b/src/admc/console_widget/console_widget.h
@@ -126,18 +126,8 @@ public:
     // selected row. There is always at least one
     // selected item. If results is currently focused
     // but has no selection, selected items from scope
-    // are returned instead. Note that this shouldn't
-    // be use for as targets of actions, use
-    // get_action_target_items() instead.
+    // are returned instead.
     QList<QModelIndex> get_selected_items(const int type) const;
-
-    // Get list of action targets. These are the items
-    // that should be the target of console actions,
-    // both default and extra from console impl's.
-    // Targets are equal to currently selected items or
-    // to current scope if context menu was opened by
-    // clicking on empty space in results.
-    QList<QModelIndex> get_action_target_items(const int type) const;
 
     // Get a single action target. Use if you are sure
     // that there's only one (dialog that uses one

--- a/src/admc/console_widget/console_widget.h
+++ b/src/admc/console_widget/console_widget.h
@@ -129,10 +129,10 @@ public:
     // are returned instead.
     QList<QModelIndex> get_selected_items(const int type) const;
 
-    // Get a single action target. Use if you are sure
+    // Get a single selected item. Use if you are sure
     // that there's only one (dialog that uses one
-    // target item for example).
-    QModelIndex get_action_target(const int type) const;
+    // selected item for example).
+    QModelIndex get_selected_item(const int type) const;
 
     // NOTE: Search is inclusive, examining the given parent
     // and all of it's descendants. Pass QModelIndex()

--- a/src/admc/console_widget/console_widget_p.h
+++ b/src/admc/console_widget/console_widget_p.h
@@ -84,8 +84,6 @@ public:
     QList<QPersistentModelIndex> targets_past;
     QList<QPersistentModelIndex> targets_future;
 
-    QList<QModelIndex> action_target_list;
-
     QHash<StandardAction, QAction *> standard_action_map;
 
     ConsoleWidgetPrivate(ConsoleWidget *q_arg);
@@ -105,7 +103,6 @@ public:
     void open_context_menu(const QPoint &global_pos);
     void add_actions(QMenu *menu);
     bool update_actions();
-    void on_menubar_action_menu_open();
 
 public slots:
     void on_current_scope_item_changed(const QModelIndex &current, const QModelIndex &);

--- a/src/admc/utils.cpp
+++ b/src/admc/utils.cpp
@@ -300,15 +300,15 @@ QList<QString> index_list_to_dn_list(const QList<QModelIndex> &index_list, const
     return out;
 }
 
-QList<QString> get_action_target_dn_list(ConsoleWidget *console, const int type, const int dn_role) {
+QList<QString> get_selected_dn_list(ConsoleWidget *console, const int type, const int dn_role) {
     const QList<QModelIndex> indexes = console->get_selected_items(type);
     const QList<QString> out = index_list_to_dn_list(indexes, dn_role);
 
     return out;
 }
 
-QString get_action_target_dn(ConsoleWidget *console, const int type, const int dn_role) {
-    const QList<QString> dn_list = get_action_target_dn_list(console, type, dn_role);
+QString get_selected_target_dn(ConsoleWidget *console, const int type, const int dn_role) {
+    const QList<QString> dn_list = get_selected_dn_list(console, type, dn_role);
 
     if (!dn_list.isEmpty()) {
         return dn_list[0];

--- a/src/admc/utils.cpp
+++ b/src/admc/utils.cpp
@@ -301,7 +301,7 @@ QList<QString> index_list_to_dn_list(const QList<QModelIndex> &index_list, const
 }
 
 QList<QString> get_action_target_dn_list(ConsoleWidget *console, const int type, const int dn_role) {
-    const QList<QModelIndex> indexes = console->get_action_target_items(type);
+    const QList<QModelIndex> indexes = console->get_selected_items(type);
     const QList<QString> out = index_list_to_dn_list(indexes, dn_role);
 
     return out;

--- a/src/admc/utils.h
+++ b/src/admc/utils.h
@@ -104,8 +104,8 @@ QMessageBox *message_box_question(QWidget *parent, const QString &title, const Q
 QMessageBox *message_box_warning(QWidget *parent, const QString &title, const QString &text);
 
 QList<QString> index_list_to_dn_list(const QList<QModelIndex> &index_list, const int dn_role);
-QList<QString> get_action_target_dn_list(ConsoleWidget *console, const int type, const int dn_role);
-QString get_action_target_dn(ConsoleWidget *console, const int type, const int dn_role);
+QList<QString> get_selected_dn_list(ConsoleWidget *console, const int type, const int dn_role);
+QString get_selected_target_dn(ConsoleWidget *console, const int type, const int dn_role);
 
 void center_widget(QWidget *widget);
 


### PR DESCRIPTION
While working on toolbar buttons, discovered that this state is not needed. Originally it was added solely for implementing the "context menu targets current scope if clicked on empty space in results view". There's a way to implement that feature without adding state, by clearing selection of results view and reusing the existing condition in get_selected() that returns scope selection instead of results selection if results selection is empty.

Also renamed all vars and f-ns that have "action target" in them.