### PR TITLE
Fix ok button availability creating and renaming GPO

### DIFF
--- a/src/admc/create_policy_dialog.cpp
+++ b/src/admc/create_policy_dialog.cpp
@@ -29,6 +29,8 @@
 #include "status.h"
 #include "utils.h"
 
+#include<QPushButton>
+
 CreatePolicyDialog::CreatePolicyDialog(AdInterface &ad, QWidget *parent)
 : QDialog(parent) {
     ui = new Ui::CreatePolicyDialog();
@@ -55,6 +57,9 @@ CreatePolicyDialog::CreatePolicyDialog(AdInterface &ad, QWidget *parent)
         }();
 
         const QString out = generate_new_name(existing_name_list, tr("New Group Policy Object"));
+
+        connect(ui->name_edit, &QLineEdit::textChanged, this, &CreatePolicyDialog::on_edited);
+        on_edited();
 
         return out;
     }();
@@ -111,5 +116,14 @@ void CreatePolicyDialog::accept() {
 
     if (success) {
         QDialog::accept();
+    }
+}
+
+void CreatePolicyDialog::on_edited()
+{
+    if(ui->name_edit->text().isEmpty()) {
+        ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
+    } else {
+        ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(true);
     }
 }

--- a/src/admc/create_policy_dialog.h
+++ b/src/admc/create_policy_dialog.h
@@ -50,6 +50,9 @@ public slots:
 
 private:
     QString created_dn;
+
+private slots:
+    void on_edited();
 };
 
 #endif /* CREATE_POLICY_DIALOG_H */

--- a/src/admc/rename_policy_dialog.cpp
+++ b/src/admc/rename_policy_dialog.cpp
@@ -46,6 +46,9 @@ RenamePolicyDialog::RenamePolicyDialog(AdInterface &ad, const QString &target_dn
     ui->name_edit->setText(target_name);
     limit_edit(ui->name_edit, ATTRIBUTE_DISPLAY_NAME);
 
+    connect(ui->name_edit, &QLineEdit::textChanged, this, &RenamePolicyDialog::on_edited);
+    on_edited();
+
     settings_setup_dialog_geometry(SETTING_rename_policy_dialog_geometry, this);
 }
 
@@ -72,5 +75,14 @@ void RenamePolicyDialog::accept() {
 
     if (apply_success) {
         QDialog::accept();
+    }
+}
+
+void RenamePolicyDialog::on_edited()
+{
+    if(ui->name_edit->text().isEmpty()) {
+        ui->button_box->button(QDialogButtonBox::Ok)->setEnabled(false);
+    } else {
+        ui->button_box->button(QDialogButtonBox::Ok)->setEnabled(true);
     }
 }

--- a/src/admc/rename_policy_dialog.h
+++ b/src/admc/rename_policy_dialog.h
@@ -50,6 +50,9 @@ public:
 private:
     QString target_dn;
     QString target_name;
+
+private slots:
+    void on_edited();
 };
 
 #endif /* RENAME_DIALOG_POLICY_H */


### PR DESCRIPTION
Fixed availability of the Ok button when a policy name is empty in the dialogs for renaming and creating a group policy object. Bug 90920