### PR TITLE
Revert "fix: validation in RenameObjectHelper and CreateObjectHelper"

### DIFF
--- a/src/admc/create_object_helper.cpp
+++ b/src/admc/create_object_helper.cpp
@@ -156,15 +156,12 @@ bool CreateObjectHelper::accept() const {
 // Enable/disable create button if all required edits filled
 void CreateObjectHelper::on_edited() {
     const bool all_required_filled = [this]() {
-        QRegExp regName("^([a-zA-Z_0-9]+[*]*)$");
-
-        for (QLineEdit *edit : m_required_list)
-        {
-            if (regName.indexIn((edit->text())) == -1)
-            {
+        for (QLineEdit *edit : m_required_list) {
+            if (edit->text().isEmpty()) {
                 return false;
             }
         }
+
         return true;
     }();
 

--- a/src/admc/rename_object_helper.cpp
+++ b/src/admc/rename_object_helper.cpp
@@ -132,15 +132,12 @@ QString RenameObjectHelper::get_new_dn() const {
 void RenameObjectHelper::on_edited()
 {
     const bool all_required_filled = [this]() {
-        QRegExp regName("^([a-zA-Z_0-9]+[*]*)$");
-
-        for (QLineEdit *edit : required_list)
-        {
-            if (regName.indexIn((edit->text())) == -1)
-            {
+        for (QLineEdit *edit : required_list) {
+            if (edit->text().isEmpty()) {
                 return false;
             }
         }
+
         return true;
     }();
 

--- a/src/admc/rename_policy_dialog.cpp
+++ b/src/admc/rename_policy_dialog.cpp
@@ -80,8 +80,7 @@ void RenamePolicyDialog::accept() {
 
 void RenamePolicyDialog::on_edited()
 {
-    QRegExp regName("^([a-zA-Z_0-9]+[*]*)$");
-    if(regName.indexIn(ui->name_edit->text()) == -1) {
+    if(ui->name_edit->text().isEmpty()) {
         ui->button_box->button(QDialogButtonBox::Ok)->setEnabled(false);
     } else {
         ui->button_box->button(QDialogButtonBox::Ok)->setEnabled(true);


### PR DESCRIPTION
Reverts altlinux/admc#390 - Due to inability to input Russian characters in additional fields of user rename dialog this pull-request is reverted.