### PR TITLE
Ellipsis for too long names in description bar is added.

### DIFF
--- a/src/admc/console_widget/console_widget.cpp
+++ b/src/admc/console_widget/console_widget.cpp
@@ -119,10 +119,7 @@ ConsoleWidget::ConsoleWidget(QWidget *parent)
 
     d->description_bar = new QWidget();
     d->description_bar_left = new QLabel();
-    d->description_bar_left->setWordWrap(true);
     d->description_bar_right = new QLabel();
-    d->description_bar_right->setWordWrap(true);
-    d->description_bar_left->setStyleSheet("font-weight: bold");
 
     d->results_stacked_widget = new QStackedWidget();
 
@@ -148,7 +145,7 @@ ConsoleWidget::ConsoleWidget(QWidget *parent)
     description_layout->setSpacing(0);
     d->description_bar->setLayout(description_layout);
     description_layout->addWidget(d->description_bar_left);
-    description_layout->addSpacing(10);
+    description_layout->addSpacing(50);
     description_layout->addWidget(d->description_bar_right);
     description_layout->addStretch();
 
@@ -584,6 +581,12 @@ void ConsoleWidget::set_item_sort_index(const QModelIndex &index, const int sort
     d->model->setData(index, sort_index, ConsoleRole_SortIndex);
 }
 
+void ConsoleWidget::resizeEvent(QResizeEvent *event)
+{
+    d->update_description();
+    QWidget::resizeEvent(event);
+}
+
 void ConsoleWidgetPrivate::add_actions(QMenu *menu) {
     // Add custom actions
     const QList<QAction *> custom_action_list = get_custom_action_list();
@@ -896,11 +899,14 @@ void ConsoleWidgetPrivate::update_description() {
     const QModelIndex current_scope = q->get_current_scope_item();
 
     const QString scope_name = current_scope.data().toString();
-
+    const QString elided_name = description_bar_left->fontMetrics().elidedText(scope_name,
+                                                                               Qt::ElideRight,
+                                                                               description_bar->width()/2);
     ConsoleImpl *impl = get_impl(current_scope);
     const QString description = impl->get_description(current_scope);
 
-    description_bar_left->setText(scope_name);
+    description_bar_left->setText(elided_name);
+    description_bar_left->setToolTip(scope_name);
     description_bar_right->setText(description);
 }
 

--- a/src/admc/console_widget/console_widget.h
+++ b/src/admc/console_widget/console_widget.h
@@ -182,6 +182,8 @@ signals:
     // view or change of which view is focused.
     void selection_changed();
 
+protected:
+    void resizeEvent(QResizeEvent *event) override;
 private:
     ConsoleWidgetPrivate *d;
 


### PR DESCRIPTION
Word wrapping for description bar labels is removed. Also tool tip for object name label is added. Tool tip contains full object name.