### PR TITLE
Gp objects icon displaying

### DIFF
--- a/src/admc/CMakeLists.txt
+++ b/src/admc/CMakeLists.txt
@@ -173,6 +173,7 @@ set(ADMC_SOURCES
     console_widget/results_view.cpp
     console_widget/console_drag_model.cpp
     console_widget/console_impl.cpp
+    console_widget/console_tree_item_icons.cpp
 
     console_impls/object_impl.cpp
     console_impls/policy_impl.cpp

--- a/src/admc/console_impls/object_impl.cpp
+++ b/src/admc/console_impls/object_impl.cpp
@@ -1541,6 +1541,9 @@ QList<QString> console_object_search_attributes() {
     // NOTE: needed to know which icon to use for object
     attributes += ATTRIBUTE_OBJECT_CATEGORY;
 
+    // NOTE: for context menu block inheritance checkbox
+    attributes += ATTRIBUTE_GPOPTIONS;
+
     return attributes;
 }
 

--- a/src/admc/console_impls/policy_impl.cpp
+++ b/src/admc/console_impls/policy_impl.cpp
@@ -214,8 +214,8 @@ void PolicyImpl::update_policy_item_data(const QString &policy_dn, const QString
     QModelIndex gp_objects_index = console->search_item(QModelIndex(), {ItemType_PolicyRoot});
     QModelIndex ou_dn_item_index = console->search_item(gp_objects_index, PolicyOURole_DN,
                                                         ou_dn, {ItemType_PolicyOU});
-    QModelIndex target_policy_index = console->search_item(ou_dn_item_index, PolicyRole_DN,
-                                                           policy_dn, {ItemType_Policy});
+    QModelIndex target_policy_index = get_ou_child_policy_item(console, ou_dn_item_index, policy_dn);
+
     if (!target_policy_index.isValid())
         return;
 

--- a/src/admc/console_impls/policy_impl.h
+++ b/src/admc/console_impls/policy_impl.h
@@ -31,6 +31,7 @@
 #include "console_widget/console_widget.h"
 
 #include <QProcess>
+#include "gplink.h"
 
 class QStandardItem;
 class AdObject;
@@ -69,6 +70,7 @@ public:
 private slots:
     void on_add_link();
     void on_edit();
+    void update_policy_item_data(const QString &policy_dn, const QString &ou_dn, bool is_checked, GplinkOption option);
 
 private:
     PolicyResultsWidget *policy_results;
@@ -76,6 +78,7 @@ private:
     QAction *edit_action;
 
     void on_gpui_error(QProcess::ProcessError error);
+    void set_policy_item_icon(const QModelIndex &policy_index, bool is_checked, GplinkOption option);
 };
 
 void console_policy_load(const QList<QStandardItem *> &row, const AdObject &object);
@@ -86,5 +89,12 @@ void console_policy_rename(const QList<ConsoleWidget *> &console_list, PolicyRes
 void console_policy_add_link(const QList<ConsoleWidget *> &console_list, PolicyResultsWidget *policy_results, const int item_type, const int dn_role);
 void console_policy_delete(const QList<ConsoleWidget *> &console_list, PolicyResultsWidget *policy_results, const int item_type, const int dn_role);
 void console_policy_properties(const QList<ConsoleWidget *> &console_list, PolicyResultsWidget *policy_results, const int item_type, const int dn_role);
+
+bool policy_is_enforced(QStandardItem *policy_item);
+bool policy_is_disabled(QStandardItem *policy_item);
+void set_policy_icon(QStandardItem *policy_item, bool is_enforced, bool is_disabled);
+void set_enforced_policy_icon(QStandardItem *policy_item, bool is_enforced);
+void set_disabled_policy_icon(QStandardItem *policy_item, bool is_disabled);
+void update_ou_item_gpo_lists_data(const QString &policy_dn, QStandardItem *policy_ou_item, bool is_checked, GplinkOption option);
 
 #endif /* POLICY_IMPL_H */

--- a/src/admc/console_impls/policy_ou_impl.cpp
+++ b/src/admc/console_impls/policy_ou_impl.cpp
@@ -112,7 +112,7 @@ void PolicyOUImpl::fetch(const QModelIndex &index) {
         all_policies_item->setIcon(QIcon::fromTheme("folder"));
         // Set sort index for "All policies" to 1 so it's always
         // at the bottom of the policy tree
-        console->set_item_sort_index(all_policies_item->index(), 1);
+        console->set_item_sort_index(all_policies_item->index(), 2);
     }
 
     // Add policies linked to this OU
@@ -358,6 +358,8 @@ void policy_ou_impl_add_objects_to_console(ConsoleWidget *console, const QList<A
             const QList<QStandardItem *> row = console->add_scope_item(ItemType_PolicyOU, parent);
 
             policy_ou_impl_load_row(row, object);
+
+            console->set_item_sort_index(row[0]->index(), 1);
         } else if (is_gpc) {
             const QList<QStandardItem *> row = console->add_scope_item(ItemType_Policy, parent);
 

--- a/src/admc/console_impls/policy_ou_impl.cpp
+++ b/src/admc/console_impls/policy_ou_impl.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * ADMC - AD Management Center
  *
  * Copyright (C) 2020-2022 BaseALT Ltd.
@@ -116,15 +116,13 @@ void PolicyOUImpl::fetch(const QModelIndex &index) {
     }
 
     // Add policies linked to this OU
-    if (!is_domain) {
-        const AdObject parent_object = ad.search_object(dn);
-        const QString gplink_string = parent_object.get_string(ATTRIBUTE_GPLINK);
-        const Gplink gplink = Gplink(gplink_string);
-        const QList<QString> gpo_list = gplink.get_gpo_list();
-        update_ou_enforced_and_disabled_policies(gplink, index);
+    const AdObject parent_object = ad.search_object(dn);
+    const QString gplink_string = parent_object.get_string(ATTRIBUTE_GPLINK);
+    const Gplink gplink = Gplink(gplink_string);
+    const QList<QString> gpo_list = gplink.get_gpo_list();
+    update_ou_enforced_and_disabled_policies(gplink, index);
 
-        policy_ou_impl_add_objects_from_dns(console, ad, gpo_list, index);
-    }
+    policy_ou_impl_add_objects_from_dns(console, ad, gpo_list, index);
 }
 
 bool PolicyOUImpl::can_drop(const QList<QPersistentModelIndex> &dropped_list, const QSet<int> &dropped_type_list, const QPersistentModelIndex &target, const int target_type) {
@@ -512,4 +510,23 @@ void policy_ou_impl_load_item_data(QStandardItem *item, const AdObject &object) 
 
     bool inheritance_is_blocked = object.get_int(ATTRIBUTE_GPOPTIONS);
     item->setData(inheritance_is_blocked, PolicyOURole_Inheritance_Block);
+}
+
+QModelIndex get_ou_child_policy_item(ConsoleWidget *console, const QModelIndex &ou_index, const QString &policy_dn)
+{
+    QList<QModelIndex> found_policy_indexes = console->search_items(ou_index,
+                                                                     PolicyRole_DN,
+                                                                     policy_dn,
+                                                                     {ItemType_Policy});
+    QModelIndex policy_index = QModelIndex();
+    for (QModelIndex index : found_policy_indexes)
+    {
+        if (index.parent().data(ConsoleRole_Type) == ItemType_PolicyOU)
+        {
+            policy_index = index;
+            break;
+        }
+    }
+
+    return policy_index;
 }

--- a/src/admc/console_impls/policy_ou_impl.cpp
+++ b/src/admc/console_impls/policy_ou_impl.cpp
@@ -116,14 +116,11 @@ void PolicyOUImpl::fetch(const QModelIndex &index) {
 
     // Add policies linked to this OU
     if (!is_domain) {
-        const QList<QString> gpo_list = [&]() {
-            const AdObject parent_object = ad.search_object(dn);
-            const QString gplink_string = parent_object.get_string(ATTRIBUTE_GPLINK);
-            const Gplink gplink = Gplink(gplink_string);
-            const QList<QString> out = gplink.get_gpo_list();
-
-            return out;
-        }();
+        const AdObject parent_object = ad.search_object(dn);
+        const QString gplink_string = parent_object.get_string(ATTRIBUTE_GPLINK);
+        const Gplink gplink = Gplink(gplink_string);
+        const QList<QString> gpo_list = gplink.get_gpo_list();
+        update_ou_enforced_and_disabled_policies(gplink, index);
 
         policy_ou_impl_add_objects_from_dns(console, ad, gpo_list, index);
     }
@@ -473,6 +470,21 @@ void PolicyOUImpl::update_gp_options_check_state() const {
     change_gp_options_action->setEnabled(true);
     bool checked = (object.get_string(ATTRIBUTE_GPOPTIONS) == GPOPTIONS_BLOCK_INHERITANCE);
     change_gp_options_action->setChecked(checked);
+}
+
+void PolicyOUImpl::update_ou_enforced_and_disabled_policies(const Gplink &gplink, const QModelIndex &ou_index) {
+    QStandardItem *ou_scope_item = console->get_item(ou_index);
+    QStringList enforced_gpo_dn_list;
+    QStringList disabled_gpo_dn_list;
+    for (QString gpo_dn : gplink.get_gpo_list()) {
+        if (gplink.get_option(gpo_dn, GplinkOption_Enforced))
+            enforced_gpo_dn_list.append(gpo_dn);
+        if (gplink.get_option(gpo_dn, GplinkOption_Disabled))
+            disabled_gpo_dn_list.append(gpo_dn);
+    }
+
+    ou_scope_item->setData(enforced_gpo_dn_list, PolicyOURole_Enforced_GPO_List);
+    ou_scope_item->setData(disabled_gpo_dn_list, PolicyOURole_Disabled_GPO_List);
 }
 
 void policy_ou_impl_load_item_data(QStandardItem *item, const AdObject &object) {

--- a/src/admc/console_impls/policy_ou_impl.h
+++ b/src/admc/console_impls/policy_ou_impl.h
@@ -36,6 +36,9 @@
 
 enum PolicyOURole {
     PolicyOURole_DN = MyConsoleRole_LAST + 1,
+    PolicyOURole_Enforced_GPO_List,
+    PolicyOURole_Disabled_GPO_List,
+    PolicyOURole_Inheritance_Block,
 
     PolicyOURole_LAST,
 };
@@ -43,6 +46,7 @@ enum PolicyOURole {
 class AdInterface;
 class AdObject;
 class PolicyOUResultsWidget;
+class Gplink;
 
 class PolicyOUImpl final : public ConsoleImpl {
     Q_OBJECT
@@ -84,6 +88,7 @@ private:
     void find_gpo();
     void change_gp_options();
     void update_gp_options_check_state() const;
+    void update_ou_enforced_and_disabled_policies(const Gplink &gplink, const QModelIndex &ou_index);
 };
 
 void policy_ou_impl_load_row(const QList<QStandardItem *> row, const AdObject &object);

--- a/src/admc/console_impls/policy_ou_impl.h
+++ b/src/admc/console_impls/policy_ou_impl.h
@@ -96,4 +96,9 @@ void policy_ou_impl_add_objects_from_dns(ConsoleWidget *console, AdInterface &ad
 void policy_ou_impl_add_objects_to_console(ConsoleWidget *console, const QList<AdObject> &object_list, const QModelIndex &parent);
 void policy_ou_impl_load_item_data(QStandardItem *item, const AdObject &object);
 
+//Get policy item that is not in All policies folder.
+//It is applied to exclude policy items from All policies folder
+//those can be found first
+QModelIndex get_ou_child_policy_item(ConsoleWidget *console, const QModelIndex &ou_index, const QString &policy_dn);
+
 #endif /* POLICY_OU_IMPL_H */

--- a/src/admc/console_widget/console_tree_item_icons.cpp
+++ b/src/admc/console_widget/console_tree_item_icons.cpp
@@ -1,0 +1,101 @@
+#include "console_tree_item_icons.h"
+#include "ad_defines.h"
+#include "utils.h"
+
+#include <QPainter>
+#include <QPixmap>
+
+//Enums positions where scope item icon can be overlayed
+//by another icon
+enum IconOverlayPosition {
+    IconOverlayPosition_TopLeft,
+    IconOverlayPosition_BottomLeft,
+    IconOverlayPosition_TopRight,
+    IconOverlayPosition_BottomRight
+};
+
+/**
+ * ConsoleTreeItemIcons struct contains map with icons that
+ * are set to appropriate item when group policy object changes its state
+ */
+struct ConsoleTreeItemIcons final
+{
+    QIcon icons_map[ItemIconType_LAST];
+
+    ConsoleTreeItemIcons();
+};
+
+static QIcon overlay_scope_item_icon(const QIcon &clean_icon, const QIcon &overlay_icon,
+                                     IconOverlayPosition position = IconOverlayPosition_BottomRight);
+static QIcon overlay_scope_item_icon(const QIcon &clean_icon, const QIcon &overlay_icon,
+                                     const QSize &overlay_icon_size, const QPoint &pos);
+
+ConsoleTreeItemIcons::ConsoleTreeItemIcons()
+{
+    icons_map[ItemIconType_Policy_Clean] = get_object_icon("Group-Policy-Container");
+    icons_map[ItemIconType_Policy_Link] = overlay_scope_item_icon(icons_map[ItemIconType_Policy_Clean], QIcon::fromTheme("mail-forward"),
+                                                                  QSize(12, 12), QPoint(-2, 6));
+    icons_map[ItemIconType_Policy_Link_Disabled] = icons_map[ItemIconType_Policy_Link].pixmap(16, 16, QIcon::Disabled);
+    icons_map[ItemIconType_Policy_Enforced] = overlay_scope_item_icon(icons_map[ItemIconType_Policy_Link], QIcon::fromTheme("stop"));
+    icons_map[ItemIconType_Policy_Enforced_Disabled] = icons_map[ItemIconType_Policy_Enforced].pixmap(16, 16, QIcon::Disabled);
+    icons_map[ItemIconType_OU_Clean] = get_object_icon(OBJECT_CATEGORY_OU);
+    icons_map[ItemIconType_OU_InheritanceBlocked] = overlay_scope_item_icon(icons_map[ItemIconType_OU_Clean], QIcon::fromTheme("changes-prevent"),
+                                                                            QSize(10, 10), QPoint(6, 6));
+    icons_map[ItemIconType_Domain_Clean] = get_object_icon("Domain-DNS");
+    icons_map[ItemIconType_Domain_InheritanceBlocked] = overlay_scope_item_icon(icons_map[ItemIconType_Domain_Clean],
+                                                                                QIcon::fromTheme("changes-prevent"),
+                                                                                QSize(10, 10), QPoint(6, 6));
+}
+
+static QIcon overlay_scope_item_icon(const QIcon &clean_icon, const QIcon &overlay_icon, IconOverlayPosition position)
+{
+    QIcon overlapped_icon;
+    //Icon looks not distorted with 16x16 size
+    QPixmap original_pixmap = clean_icon.pixmap(16, 16);
+    QPixmap overlay_pixmap = overlay_icon.pixmap(10, 10);
+
+    QPainter painter(&original_pixmap);
+    switch (position)
+    {
+    case IconOverlayPosition_BottomLeft:
+        painter.drawPixmap(0, original_pixmap.height() - 8, overlay_pixmap);
+        break;
+    case IconOverlayPosition_TopLeft:
+        painter.drawPixmap(0, 0, overlay_pixmap);
+        break;
+    case IconOverlayPosition_TopRight:
+        painter.drawPixmap(original_pixmap.width() - 8, 0, overlay_pixmap);
+        break;
+    case IconOverlayPosition_BottomRight:
+        painter.drawPixmap(original_pixmap.width() - 8, original_pixmap.height() - 8, overlay_pixmap);
+        break;
+    default:
+        break;
+    }
+
+    overlapped_icon.addPixmap(original_pixmap);
+
+    return overlapped_icon;
+}
+
+static QIcon overlay_scope_item_icon(const QIcon &clean_icon, const QIcon &overlay_icon, const QSize &overlay_icon_size, const QPoint &pos)
+{
+    QIcon overlapped_icon;
+    //Icon looks not distorted with 16x16 size
+    QPixmap original_pixmap = clean_icon.pixmap(16, 16);
+    QPixmap overlay_pixmap = overlay_icon.pixmap(overlay_icon_size);
+
+    QPainter painter(&original_pixmap);
+    painter.drawPixmap(pos.x(), pos.y(), overlay_pixmap);
+
+    overlapped_icon.addPixmap(original_pixmap);
+    return overlapped_icon;
+}
+
+const QIcon &get_console_tree_item_icon(ItemIconType icon_type)
+{
+    static const ConsoleTreeItemIcons item_icons;
+
+    const QIcon &icon = item_icons.icons_map[icon_type];
+    return icon;
+}

--- a/src/admc/console_widget/console_tree_item_icons.h
+++ b/src/admc/console_widget/console_tree_item_icons.h
@@ -1,0 +1,22 @@
+#ifndef CONSOLETREEITEMICONS_H
+#define CONSOLETREEITEMICONS_H
+
+#include <QIcon>
+
+enum ItemIconType {
+    ItemIconType_Policy_Clean,
+    ItemIconType_OU_Clean,
+    ItemIconType_OU_InheritanceBlocked,
+    ItemIconType_Policy_Link,
+    ItemIconType_Policy_Link_Disabled,
+    ItemIconType_Policy_Enforced,
+    ItemIconType_Policy_Enforced_Disabled,
+    ItemIconType_Domain_Clean,
+    ItemIconType_Domain_InheritanceBlocked,
+
+    ItemIconType_LAST
+};
+
+const QIcon& get_console_tree_item_icon(ItemIconType icon_type);
+
+#endif // CONSOLETREEITEMICONS_H

--- a/src/admc/policy_ou_results_widget.cpp
+++ b/src/admc/policy_ou_results_widget.cpp
@@ -239,11 +239,9 @@ void PolicyOUResultsWidget::modify_gplink(void (*modify_function)(Gplink &, cons
     hide_busy_indicator();
 }
 
-void PolicyOUResultsWidget::change_policy_icon(const QString &policy_dn, bool is_checked, GplinkOption option) {
-    QModelIndex target_policy_index = console->search_item(console->get_current_scope_item(),
-                                                           PolicyRole_DN,
-                                                           policy_dn,
-                                                           {ItemType_Policy});
+void PolicyOUResultsWidget::change_policy_icon(const QString &policy_dn, bool is_checked, GplinkOption option)
+{
+    QModelIndex target_policy_index = get_ou_child_policy_item(console, console->get_current_scope_item(), policy_dn);
     if (!target_policy_index.isValid())
         return;
 

--- a/src/admc/policy_ou_results_widget.cpp
+++ b/src/admc/policy_ou_results_widget.cpp
@@ -30,10 +30,10 @@
 #include "console_widget/console_widget.h"
 #include "console_widget/results_view.h"
 #include "globals.h"
-#include "gplink.h"
 #include "settings.h"
 #include "status.h"
 #include "utils.h"
+#include "console_widget/console_tree_item_icons.h"
 
 #include <QAction>
 #include <QHeaderView>
@@ -184,7 +184,12 @@ void PolicyOUResultsWidget::on_item_changed(QStandardItem *item) {
 
     const QString gplink_string = gplink.to_string();
 
-    ad.attribute_replace_string(ou_dn, ATTRIBUTE_GPLINK, gplink_string);
+    bool success = ad.attribute_replace_string(ou_dn, ATTRIBUTE_GPLINK, gplink_string);
+
+    if (success) {
+        change_policy_icon(gpo_dn, is_checked, option);
+        update_gpo_lists_data(gpo_dn, is_checked, option);
+    }
 
     g_status->display_ad_messages(ad, this);
 
@@ -232,6 +237,31 @@ void PolicyOUResultsWidget::modify_gplink(void (*modify_function)(Gplink &, cons
     reload_gplink();
 
     hide_busy_indicator();
+}
+
+void PolicyOUResultsWidget::change_policy_icon(const QString &policy_dn, bool is_checked, GplinkOption option) {
+    QModelIndex target_policy_index = console->search_item(console->get_current_scope_item(),
+                                                           PolicyRole_DN,
+                                                           policy_dn,
+                                                           {ItemType_Policy});
+    if (!target_policy_index.isValid())
+        return;
+
+    if (option == GplinkOption_Disabled)
+    {
+        set_disabled_policy_icon(console->get_item(target_policy_index), is_checked);
+    }
+    else if (option == GplinkOption_Enforced)
+    {
+        set_enforced_policy_icon(console->get_item(target_policy_index), is_checked);
+    }
+}
+
+void PolicyOUResultsWidget::update_gpo_lists_data(const QString &policy_dn, bool is_checked, GplinkOption option)
+{
+    QStandardItem *current_ou_item = console->get_item(console->get_current_scope_item());
+
+    update_ou_item_gpo_lists_data(policy_dn, current_ou_item, is_checked, option);
 }
 
 void PolicyOUResultsWidget::remove_link() {
@@ -344,8 +374,7 @@ void PolicyOUResultsWidget::reload_gplink() {
         row[PolicyOUResultsColumn_Name]->setText(name);
         set_data_for_row(row, gpo_dn, PolicyOUResultsRole_DN);
 
-        const QIcon icon = get_object_icon(gpo_object);
-        row[0]->setIcon(icon);
+        row[0]->setIcon(get_console_tree_item_icon(ItemIconType_Policy_Link));
 
         for (const auto column : option_columns) {
             QStandardItem *item = row[column];

--- a/src/admc/policy_ou_results_widget.h
+++ b/src/admc/policy_ou_results_widget.h
@@ -70,6 +70,8 @@ private:
     void move_down();
     void reload_gplink();
     void modify_gplink(void (*modify_function)(Gplink &, const QString &));
+    void change_policy_icon(const QString &policy_dn, bool is_checked, GplinkOption option);
+    void update_gpo_lists_data(const QString &policy_dn, bool is_checked, GplinkOption option);
 
     friend ADMCTestPolicyOUResultsWidget;
 };

--- a/src/admc/policy_results_widget.cpp
+++ b/src/admc/policy_results_widget.cpp
@@ -27,7 +27,6 @@
 #include "console_widget/console_widget.h"
 #include "console_widget/results_view.h"
 #include "globals.h"
-#include "gplink.h"
 #include "settings.h"
 #include "status.h"
 #include "utils.h"
@@ -235,6 +234,8 @@ void PolicyResultsWidget::on_item_changed(QStandardItem *item) {
 
     if (success) {
         model->setData(index, updated_gplink_string, PolicyResultsRole_GplinkString);
+        emit policy_gplink_option_changed(gpo, dn, is_checked, option);
+
     } else {
         const Qt::CheckState undo_check_state = [&]() {
             if (item->checkState() == Qt::Checked) {

--- a/src/admc/policy_results_widget.h
+++ b/src/admc/policy_results_widget.h
@@ -26,6 +26,7 @@
  */
 
 #include <QWidget>
+#include "gplink.h"
 
 class QStandardItemModel;
 class QStandardItem;
@@ -55,6 +56,10 @@ public:
     ResultsView *get_view() const;
 
     QString get_current_gpo() const;
+
+signals:
+    void policy_gplink_option_changed(const QString &policy_dn, const QString &ou_dn,
+                                 bool is_checked, GplinkOption option);
 
 private:
     QStandardItemModel *model;


### PR DESCRIPTION
Following features in group policy objects displaying are added:
-  Block inheritance indicator is added to OU GP objects
-  Policy link indicator icon is added to OU's policies
-  Policy item icon changes appearance (fades) after group policy link disabling
-  Enforced policy indicator is added
-  GPO items in tree is sorted by type. Policies is placed higher than policy organizational units
-  Domain policy items are appeared in the scope view tree. 