### PR TITLE
Crashing after drag and drop attempt in OU results widget is fixed

### DIFF
--- a/src/admc/policy_ou_results_widget.cpp
+++ b/src/admc/policy_ou_results_widget.cpp
@@ -94,6 +94,8 @@ PolicyOUResultsWidget::PolicyOUResultsWidget(ConsoleWidget *console_arg)
     ui->view->detail_view()->header()->resizeSection(3, 100);
     ui->view->detail_view()->header()->resizeSection(4, 500);
 
+    ui->view->set_drag_drop_enabled(false);
+
     const QVariant state = settings_get_variant(SETTING_policy_ou_results_state);
     ui->view->restore_state(state,
         {


### PR DESCRIPTION
When using item's drag and drop in OU results widget on the same area application crashes. It is fixed with drag and drop disabling.