### PR TITLE
Attributes display fix and time span edit addition

### DIFF
--- a/src/adldap/ad_config.cpp
+++ b/src/adldap/ad_config.cpp
@@ -566,11 +566,14 @@ LargeIntegerSubtype AdConfig::get_attribute_large_integer_subtype(const QString 
         ATTRIBUTE_PWD_LAST_SET,
         ATTRIBUTE_LOCKOUT_TIME,
         ATTRIBUTE_BAD_PWD_TIME,
+        ATTRIBUTE_CREATION_TIME,
     };
     static const QList<QString> timespans = {
         ATTRIBUTE_MAX_PWD_AGE,
         ATTRIBUTE_MIN_PWD_AGE,
         ATTRIBUTE_LOCKOUT_DURATION,
+        ATTRIBUTE_LOCKOUT_OBSERVATION_WINDOW,
+        ATTRIBUTE_FORCE_LOGOFF,
     };
 
     if (datetimes.contains(attribute)) {

--- a/src/adldap/ad_defines.h
+++ b/src/adldap/ad_defines.h
@@ -85,8 +85,8 @@ enum GroupType {
 };
 
 enum SystemFlagsBit {
-    SystemFlagsBit_CannotMove = 0x04000000,
-    SystemFlagsBit_CannotRename = 0x08000000,
+    SystemFlagsBit_DomainCannotMove = 0x04000000,
+    SystemFlagsBit_DomainCannotRename = 0x08000000,
     SystemFlagsBit_CannotDelete = 0x80000000
 };
 
@@ -199,6 +199,7 @@ enum SystemFlagsBit {
 #define ATTRIBUTE_CREATION_TIME "creationTime"
 #define ATTRIBUTE_LOCKOUT_OBSERVATION_WINDOW "lockOutObservationWindow"
 #define ATTRIBUTE_FORCE_LOGOFF "forceLogoff"
+#define ATTRIBUTE_MS_DS_SUPPORTED_ETYPES "msDS-SupportedEncryptionTypes"
 
 #define CLASS_GROUP "group"
 #define CLASS_USER "user"
@@ -305,6 +306,14 @@ const long long MILLIS_TO_100_NANOS = 10000LL;
 // any better source
 #define SAM_NAME_MAX_LENGTH 20
 #define SAM_NAME_COMPUTER_MAX_LENGTH 16
+
+// NOTE: define supported encryption types bit flags
+// for msDs-SupportedEncryptionTypes attribute
+#define ETYPES_DES_CBC_CRC 0x00000001
+#define ETYPES_DES_CBC_MD5 0x00000002
+#define ETYPES_RC4_HMAC_MD5 0x00000004
+#define ETYPES_AES128_CTS_HMAC_SHA1_96 0x00000008
+#define ETYPES_AES256_CTS_HMAC_SHA1_96 0x00000010
 
 enum SearchScope {
     SearchScope_Object,

--- a/src/adldap/ad_defines.h
+++ b/src/adldap/ad_defines.h
@@ -143,7 +143,6 @@ enum SystemFlagsBit {
 #define ATTRIBUTE_LAST_LOGON "lastLogon"
 #define ATTRIBUTE_LAST_LOGON_TIMESTAMP "lastLogonTimestamp"
 #define ATTRIBUTE_PWD_LAST_SET "pwdLastSet"
-#define ATTRIBUTE_LOCKOUT_TIME "lockoutTime"
 #define ATTRIBUTE_BAD_PWD_TIME "badPasswordTime"
 #define ATTRIBUTE_OBJECT_SID "objectSid"
 #define ATTRIBUTE_SYSTEM_FLAGS "systemFlags"
@@ -197,6 +196,9 @@ enum SystemFlagsBit {
 #define ATTRIBUTE_VALID_ACCESSES "validAccesses"
 #define ATTRIBUTE_UNC_NAME "uNCName"
 #define ATTRIBUTE_KEYWORDS "keywords"
+#define ATTRIBUTE_CREATION_TIME "creationTime"
+#define ATTRIBUTE_LOCKOUT_OBSERVATION_WINDOW "lockOutObservationWindow"
+#define ATTRIBUTE_FORCE_LOGOFF "forceLogoff"
 
 #define CLASS_GROUP "group"
 #define CLASS_USER "user"

--- a/src/adldap/ad_display.cpp
+++ b/src/adldap/ad_display.cpp
@@ -167,6 +167,10 @@ QString timespan_display_value(const QByteArray &bytes) {
         return "(never)";
     }
 
+    if (hundred_nanos_negative == 0) {
+        return "(none)";
+    }
+
     qint64 seconds_total = [hundred_nanos_negative]() {
         const qint64 hundred_nanos = -hundred_nanos_negative;
         const qint64 millis = hundred_nanos / MILLIS_TO_100_NANOS;
@@ -176,13 +180,13 @@ QString timespan_display_value(const QByteArray &bytes) {
     }();
 
     const qint64 days = seconds_total / DAYS_TO_SECONDS;
-    seconds_total = days % DAYS_TO_SECONDS;
+    seconds_total -= days * DAYS_TO_SECONDS;
 
     const qint64 hours = seconds_total / HOURS_TO_SECONDS;
-    seconds_total = hours % HOURS_TO_SECONDS;
+    seconds_total -= hours * HOURS_TO_SECONDS;
 
     const qint64 minutes = seconds_total / MINUTES_TO_SECONDS;
-    seconds_total = minutes % MINUTES_TO_SECONDS;
+    seconds_total -= minutes * MINUTES_TO_SECONDS;
 
     const qint64 seconds = seconds_total;
 
@@ -204,7 +208,7 @@ QString timespan_display_value(const QByteArray &bytes) {
         }
     };
 
-    const QString days_string = time_unit_to_string(days);
+    const QString days_string = QString::number(days);
     const QString hours_string = time_unit_to_string(hours);
     const QString minutes_string = time_unit_to_string(minutes);
     const QString seconds_string = time_unit_to_string(seconds);

--- a/src/adldap/ad_utils.cpp
+++ b/src/adldap/ad_utils.cpp
@@ -465,3 +465,25 @@ QString escape_name_for_dn(const QString &unescaped) {
 
     return out;
 }
+
+QHash<int, QString> attribute_value_bit_string_map(const QString &attribute)
+{
+    QHash<int, QString> bit_string_map;
+    if (attribute == ATTRIBUTE_GROUP_TYPE) {
+        bit_string_map = {
+            {GROUP_TYPE_BIT_SYSTEM, "SYSTEM_GROUP"},
+            {GROUP_TYPE_BIT_SECURITY, "SECURITY_ENABLED"},
+            {group_scope_bit(GroupScope_Global), "ACCOUNT_GROUP"},
+            {group_scope_bit(GroupScope_DomainLocal), "RESOURCE_GROUP"},
+            {group_scope_bit(GroupScope_Universal), "UNIVERSAL_GROUP"},
+        };
+    }
+    else if (attribute == ATTRIBUTE_SYSTEM_FLAGS) {
+        bit_string_map = {
+            {SystemFlagsBit_DomainCannotMove, "DOMAIN_DISALLOW_MOVE"},
+            {SystemFlagsBit_DomainCannotRename, "DOMAIN_DISALLOW_RENAME"},
+            {SystemFlagsBit_CannotDelete, "DISALLOW_DELETE"}
+        };
+    }
+    return bit_string_map;
+}

--- a/src/adldap/ad_utils.h
+++ b/src/adldap/ad_utils.h
@@ -27,6 +27,7 @@
  */
 
 #include "ad_defines.h"
+#include <QHash>
 
 class QString;
 class QDateTime;
@@ -84,5 +85,7 @@ QByteArray sid_string_to_bytes(const QString &sid_string);
 QString attribute_type_display_string(const AttributeType type);
 
 QString int_to_hex_string(const int n);
+
+QHash<int, QString> attribute_value_bit_string_map(const QString &attribute);
 
 #endif /* AD_UTILS_H */

--- a/src/admc/CMakeLists.txt
+++ b/src/admc/CMakeLists.txt
@@ -167,6 +167,7 @@ set(ADMC_SOURCES
     attribute_dialogs/octet_attribute_dialog.cpp
     attribute_dialogs/bool_attribute_dialog.cpp
     attribute_dialogs/datetime_attribute_dialog.cpp
+    attribute_dialogs/time_span_attribute_dialog.cpp
 
     console_widget/console_widget.cpp
     console_widget/scope_proxy_model.cpp

--- a/src/admc/admc_ru.ts
+++ b/src/admc/admc_ru.ts
@@ -3368,6 +3368,19 @@
     </message>
 </context>
 <context>
+    <name>TimeSpanAttributeDialog</name>
+    <message>
+        <location filename="attribute_dialogs/time_span_attribute_dialog.ui" line="14"/>
+        <source>Dialog</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="attribute_dialogs/time_span_attribute_dialog.ui" line="27"/>
+        <source>d:hh:mm:ss or (never) / (none)</source>
+        <translation>д:чч:мм:cc или (never)/(none)</translation>
+    </message>
+</context>
+<context>
     <name>UnlockEdit</name>
     <message>
         <location filename="attribute_edits/unlock_edit.cpp" line="38"/>

--- a/src/admc/attribute_dialogs/time_span_attribute_dialog.cpp
+++ b/src/admc/attribute_dialogs/time_span_attribute_dialog.cpp
@@ -1,0 +1,79 @@
+/*
+ * ADMC - AD Management Center
+ *
+ * Copyright (C) 2023 BaseALT Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "time_span_attribute_dialog.h"
+#include "ui_time_span_attribute_dialog.h"
+
+#include "settings.h"
+#include "utils.h"
+#include "ad_display.cpp"
+#include "ad_defines.h"
+
+#include <QString>
+
+TimeSpanAttributeDialog::TimeSpanAttributeDialog(const QList<QByteArray> &value_list, const QString &attribute, const bool read_only, QWidget *parent) :
+    AttributeDialog(attribute, read_only, parent),
+    ui(new Ui::TimeSpanAttributeDialog)
+{
+    ui->setupUi(this);
+    setAttribute(Qt::WA_DeleteOnClose);
+
+    AttributeDialog::load_attribute_label(ui->attribute_label);
+
+    const QByteArray value = value_list.value(0, QByteArray());
+
+    set_line_edit_to_time_span_format(ui->time_span_edit);
+
+    ui->time_span_edit->setReadOnly(read_only);
+    ui->time_span_edit->setText(timespan_display_value(value));
+
+    settings_setup_dialog_geometry(SETTING_time_span_attribute_dialog_geometry, this);
+}
+
+TimeSpanAttributeDialog::~TimeSpanAttributeDialog()
+{
+    delete ui;
+}
+
+QList<QByteArray> TimeSpanAttributeDialog::get_value_list() const
+{
+    const QString new_value_string = ui->time_span_edit->text();
+    QByteArray value = QByteArray::number(0);
+
+    if (new_value_string == "(none)") {
+        return {value};
+    }
+
+    if (new_value_string == "(never)") {
+        value = QByteArray::number(LLONG_MIN);
+        return {value};
+    }
+
+    QStringList d_hh_mm_ss = new_value_string.split(':');
+    if (d_hh_mm_ss.size() != 4) {
+        return {value};
+    }
+
+    qint64 hundred_nanos = 100 * std::chrono::nanoseconds(-d_hh_mm_ss[0].toLongLong() * DAYS_TO_SECONDS +
+                                                          -d_hh_mm_ss[1].toLongLong() * HOURS_TO_SECONDS +
+                                                          -d_hh_mm_ss[2].toLongLong() * MINUTES_TO_SECONDS
+                                                          -d_hh_mm_ss[3].toLongLong()).count();
+    value = QByteArray::number(hundred_nanos);
+    return {value};
+}

--- a/src/admc/attribute_dialogs/time_span_attribute_dialog.h
+++ b/src/admc/attribute_dialogs/time_span_attribute_dialog.h
@@ -1,0 +1,44 @@
+/*
+ * ADMC - AD Management Center
+ *
+ * Copyright (C) 2023 BaseALT Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TIME_SPAN_ATTRIBUTE_DIALOG_H
+#define TIME_SPAN_ATTRIBUTE_DIALOG_H
+
+#include <QDialog>
+
+#include "attribute_dialogs/attribute_dialog.h"
+
+namespace Ui {
+class TimeSpanAttributeDialog;
+}
+
+class TimeSpanAttributeDialog final : public AttributeDialog {
+    Q_OBJECT
+
+public:
+    explicit TimeSpanAttributeDialog(const QList<QByteArray> &value_list, const QString &attribute, const bool read_only, QWidget *parent);
+    ~TimeSpanAttributeDialog();
+
+    QList<QByteArray> get_value_list() const override;
+
+private:
+    Ui::TimeSpanAttributeDialog *ui;
+};
+
+#endif // TIME_SPAN_ATTRIBUTE_DIALOG_H

--- a/src/admc/attribute_dialogs/time_span_attribute_dialog.ui
+++ b/src/admc/attribute_dialogs/time_span_attribute_dialog.ui
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TimeSpanAttributeDialog</class>
+ <widget class="QDialog" name="TimeSpanAttributeDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>373</width>
+    <height>97</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="attribute_label">
+     <property name="text">
+      <string notr="true">Attribute: name (PLACEHOLDER)</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="time_span_edit">
+     <property name="placeholderText">
+      <string>d:hh:mm:ss or (never) / (none)</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>TimeSpanAttributeDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>TimeSpanAttributeDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/admc/console_impls/object_impl.cpp
+++ b/src/admc/console_impls/object_impl.cpp
@@ -1475,7 +1475,7 @@ void console_object_load(const QList<QStandardItem *> row, const AdObject &objec
 
     console_object_item_data_load(row[0], object);
 
-    const bool cannot_move = object.get_system_flag(SystemFlagsBit_CannotMove);
+    const bool cannot_move = object.get_system_flag(SystemFlagsBit_DomainCannotMove);
 
     for (auto item : row) {
         item->setDragEnabled(!cannot_move);
@@ -1491,10 +1491,10 @@ void console_object_item_data_load(QStandardItem *item, const AdObject &object) 
     const QList<QString> object_classes = object.get_strings(ATTRIBUTE_OBJECT_CLASS);
     item->setData(QVariant(object_classes), ObjectRole_ObjectClasses);
 
-    const bool cannot_move = object.get_system_flag(SystemFlagsBit_CannotMove);
+    const bool cannot_move = object.get_system_flag(SystemFlagsBit_DomainCannotMove);
     item->setData(cannot_move, ObjectRole_CannotMove);
 
-    const bool cannot_rename = object.get_system_flag(SystemFlagsBit_CannotRename);
+    const bool cannot_rename = object.get_system_flag(SystemFlagsBit_DomainCannotRename);
     item->setData(cannot_rename, ObjectRole_CannotRename);
 
     const bool cannot_delete = object.get_system_flag(SystemFlagsBit_CannotDelete);

--- a/src/admc/settings.h
+++ b/src/admc/settings.h
@@ -97,6 +97,7 @@ DEFINE_SETTING(SETTING_fsmo_dialog_geometry);
 DEFINE_SETTING(SETTING_create_shared_folder_dialog_geometry);
 DEFINE_SETTING(SETTING_create_contact_dialog_geometry);
 DEFINE_SETTING(SETTING_find_policy_dialog_geometry);
+DEFINE_SETTING(SETTING_time_span_attribute_dialog_geometry);
 
 // Header state
 DEFINE_SETTING(SETTING_results_header);

--- a/src/admc/utils.cpp
+++ b/src/admc/utils.cpp
@@ -514,3 +514,9 @@ int get_range_upper(const QString &attribute) {
 void set_line_edit_to_hex_numbers_only(QLineEdit *edit) {
     edit->setValidator(new QRegExpValidator(QRegExp("[0-9a-f]*"), edit));
 }
+
+
+void set_line_edit_to_time_span_format(QLineEdit *edit) {
+    QRegExp time_span_reg_exp("([0-9]{1,4}:[0-2][0-3]:[0-5][0-9]:[0-5][0-9])|^\\(never\\)&|^\\(none\\)&");
+    edit->setValidator(new QRegExpValidator(time_span_reg_exp));
+}

--- a/src/admc/utils.h
+++ b/src/admc/utils.h
@@ -66,6 +66,8 @@ void set_line_edit_to_decimal_numbers_only(QLineEdit *edit);
 
 void set_line_edit_to_hex_numbers_only(QLineEdit *edit);
 
+void set_line_edit_to_time_span_format(QLineEdit *edit);
+
 void enable_widget_on_selection(QWidget *widget, QAbstractItemView *view);
 
 void show_busy_indicator();


### PR DESCRIPTION
- Attribute creationTime display/edit fixed.

- Attributes with time span value display fixed. Also time span attribute edit is added.

- Attributes forceLogoff and lockOutObservationWindow are added as time span.

- Attribute userAccountControl, msDs-Supported and systemFlags values are displayed as hexadecimal.