### PR TITLE
ad_interface.cpp: replace deprecated smbc_init()

### DIFF
--- a/src/adldap/ad_interface.cpp
+++ b/src/adldap/ad_interface.cpp
@@ -163,8 +163,8 @@ AdInterface::AdInterface() {
     // wouldn't be able to have multiple active
     // AdInterface's instances at the same time
     if (AdInterfacePrivate::smbc == NULL) {
-        smbc_init(get_auth_data_fn, 0);
         AdInterfacePrivate::smbc = smbc_new_context();
+        smbc_setFunctionAuthData(AdInterfacePrivate::smbc, get_auth_data_fn);
         smbc_setOptionUseKerberos(AdInterfacePrivate::smbc, true);
         smbc_setOptionFallbackAfterKerberos(AdInterfacePrivate::smbc, true);
         if (!smbc_init_context(AdInterfacePrivate::smbc)) {
@@ -172,7 +172,6 @@ AdInterface::AdInterface() {
 
             return;
         }
-        smbc_set_context(AdInterfacePrivate::smbc);
     }
 
     d->is_connected = true;


### PR DESCRIPTION
Here I found a sample how to use the new smbc_init_context instead:

https://github.com/samba-team/samba/blob/e61f53b656f074a80ae66dfda776b56b03cc9918/examples/libsmbclient/testctx.c#L24

In fact, we already use it. Please test that the change didn't affected anything.