### PR TITLE
Minimum cmake version update

### DIFF
--- a/.gear/admc.spec
+++ b/.gear/admc.spec
@@ -11,7 +11,7 @@
 
 Name: admc
 Version: 0.20.0
-Release: alt1
+Release: alt2
 
 Summary: Active Directory Management Center
 License: GPLv3+
@@ -124,6 +124,9 @@ Tests for ADMC
 %_bindir/admc_test_find_policy_dialog
 
 %changelog
+* Mon Apr 7 2025 Vladimir Rubanov <august@altlinux.org> 0.20.0-alt2
+- Update cmake file.
+
 * Mon Mar 17 2025 Semyon Knyazev <samael@altlinux.org> 0.20.0-alt1
 - Native LAPS (Local administrator password solution) 2023 has been implemented.
   The corresponding tab has been added to the properties of computer class

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.14)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
Today, Alt-Linux developers pushed cmake 4.0.0 to sisyphus, causing admc to fail building. This patch resolves the issue.