### PR TITLE
src/adldap/CMakeLists.txt: Improve the libsasl2 check

### DIFF
--- a/src/adldap/CMakeLists.txt
+++ b/src/adldap/CMakeLists.txt
@@ -11,7 +11,7 @@ pkg_check_modules(NdrStandard REQUIRED IMPORTED_TARGET ndr_standard)
 pkg_check_modules(Smbclient REQUIRED IMPORTED_TARGET smbclient)
 pkg_check_modules(Krb5 REQUIRED IMPORTED_TARGET krb5)
 pkg_check_modules(Uuid REQUIRED IMPORTED_TARGET uuid)
-pkg_check_modules(REQUIRED libsasl2)
+pkg_check_modules(Sasl2 REQUIRED libsasl2)
 
 pkg_check_modules(Ndr REQUIRED IMPORTED_TARGET ndr)
 if(Ndr_VERSION VERSION_GREATER "1.0.1")


### PR DESCRIPTION
Without "libsasl2" installed the compilation process always fails with an error due to missing "sasl/sasl.h".  However, in the current situation cmake configuration script does not produce a clear message that "libsasl2" is missing and keeps going, producing a proper Makefile.  This patch fixes such behavior by adding a proper prefix parameter for "pkg_check_modules" in the "libsasl2" check which makes the configuration script to bail out earlier with a clear error.

* src/adldap/CMakeLists.txt: Add prefix parameter for "pkg_check_modules" in the "libsasl2" check.