### PR TITLE
src/admc/main_window: Bugfix: Skip missing themes.

### DIFF
--- a/src/admc/main_window.cpp
+++ b/src/admc/main_window.cpp
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2020-2025 BaseALT Ltd.
  * Copyright (C) 2020-2025 Dmitry Degtyarev
+ * Copyright (C) 2026 Artyom V. Poptsov
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -170,6 +171,9 @@ void MainWindow::setup_themes() {
     auto theme_action_group = new QActionGroup(this);
     for (const QString &theme : theme_list) {
         const QString localized_name = g_icon_manager->localized_theme_name(current_locale, theme);
+        if (localized_name.isEmpty()) {
+            continue;
+        }
         const auto action = new QAction(localized_name, theme_action_group);
 
         action->setCheckable(true);

--- a/src/admc/managers/icon_manager.cpp
+++ b/src/admc/managers/icon_manager.cpp
@@ -338,6 +338,9 @@ QString IconManager::localized_theme_name(const QLocale locale, const QString &t
     const QDir theme_dir = theme_is_system ? QDir(system_icons_dir_path).filePath(theme) :
                                                                  QDir(system_icons_dir_path).filePath(impl->custom_theme);
     QFile index_theme_file(theme_dir.filePath("index.theme"));
+    if (! index_theme_file.exists()) {
+        return QString();
+    }
     index_theme_file.open(QIODevice::ReadOnly);
 
     QString theme_name;


### PR DESCRIPTION
* src/admc/main_window.cpp (MainWindow::setup_themes): Bugfix: Don't add missing themes to the themes list in the "View" menu.
* src/admc/managers/icon_manager.cpp (IconManager::localized_theme_name): Return an empty QString when a theme is not found.